### PR TITLE
fix: use data directory for pings.ron storage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1074,7 +1074,7 @@ pub async fn main() -> Result<()> {
     });
 
     let ping_manager = Arc::new(tokio::sync::RwLock::new(
-        ping::PingManager::load().wrap_err("Failed to load ping manager")?
+        ping::PingManager::load(&get_data_dir()).wrap_err("Failed to load ping manager")?
     ));
 
     let handler_generic_commands = tokio::spawn({

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use eyre::{Result, WrapErr, bail};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
-const PINGS_PATH: &str = "./pings.ron";
+const PINGS_FILENAME: &str = "pings.ron";
 
 /// A single ping definition. The ping's name is the HashMap key in PingStore.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,8 +32,8 @@ pub struct PingManager {
 
 impl PingManager {
     /// Load pings from disk. Creates empty store if file doesn't exist.
-    pub fn load() -> Result<Self> {
-        let path = PathBuf::from(PINGS_PATH);
+    pub fn load(data_dir: &Path) -> Result<Self> {
+        let path = data_dir.join(PINGS_FILENAME);
         let store = if path.exists() {
             let data = std::fs::read_to_string(&path)
                 .wrap_err("Failed to read pings.ron")?;


### PR DESCRIPTION
## Summary
- `pings.ron` was the only persistent file using a hardcoded relative path (`./pings.ron`) instead of the centralized `get_data_dir()` pattern
- Changed `PingManager::load()` to accept a `&Path` data dir parameter, consistent with how `token.ron`, `leaderboard.ron`, `flights.ron`, and `feedback.txt` are stored

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Confirm pings.ron is created in the data directory on fresh start
- [ ] Confirm existing pings still load if moved to the data directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)