### PR TITLE
feat: add !p edit command to change ping templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ toml = "0.9.11"
 notify-debouncer-mini = "0.5"
 random-flight = { git = "https://github.com/Chronophylos/random-flight.git" }
 csv = "1.4.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/commands/ping_admin.rs
+++ b/src/commands/ping_admin.rs
@@ -42,7 +42,7 @@ impl Command for PingAdminCommand {
         let subcommand = ctx.args.first().copied().unwrap_or("");
 
         match subcommand {
-            "create" | "delete" | "add" | "remove" => {
+            "create" | "delete" | "edit" | "add" | "remove" => {
                 if !self.is_admin(ctx.privmsg) {
                     ctx.client
                         .say_in_reply_to(ctx.privmsg, "Das darfst du nicht FDM".to_string())
@@ -52,6 +52,7 @@ impl Command for PingAdminCommand {
                 match subcommand {
                     "create" => self.handle_create(&ctx).await,
                     "delete" => self.handle_delete(&ctx).await,
+                    "edit" => self.handle_edit(&ctx).await,
                     "add" => self.handle_member_op(&ctx, "add").await,
                     "remove" => self.handle_member_op(&ctx, "remove").await,
                     _ => unreachable!(),
@@ -64,7 +65,7 @@ impl Command for PingAdminCommand {
                 ctx.client
                     .say_in_reply_to(
                         ctx.privmsg,
-                        "Nutze: join, leave, list (oder create, delete, add, remove als Mod)"
+                        "Nutze: join, leave, list (oder create, delete, edit, add, remove als Mod)"
                             .to_string(),
                     )
                     .await?;
@@ -125,6 +126,34 @@ impl PingAdminCommand {
             Ok(()) => {
                 ctx.client
                     .say_in_reply_to(ctx.privmsg, format!("Ping \"{name}\" gelöscht Okayge"))
+                    .await?;
+            }
+            Err(e) => {
+                ctx.client
+                    .say_in_reply_to(ctx.privmsg, format!("{e} FDM"))
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// !p edit <name> <new template...>
+    async fn handle_edit(&self, ctx: &CommandContext<'_>) -> Result<()> {
+        if ctx.args.len() < 3 {
+            ctx.client
+                .say_in_reply_to(ctx.privmsg, "Nutze: !p edit <name> <template>".to_string())
+                .await?;
+            return Ok(());
+        }
+
+        let name = ctx.args[1].to_lowercase();
+        let template = ctx.args[2..].join(" ");
+
+        let mut manager = self.ping_manager.write().await;
+        match manager.edit_template(&name, template) {
+            Ok(()) => {
+                ctx.client
+                    .say_in_reply_to(ctx.privmsg, format!("Ping \"{name}\" updated SeemsGood"))
                     .await?;
             }
             Err(e) => {

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -106,6 +106,14 @@ impl PingManager {
         self.save()
     }
 
+    /// Edit a ping's template. Errors if ping doesn't exist.
+    pub fn edit_template(&mut self, name: &str, template: String) -> Result<()> {
+        let ping = self.store.pings.get_mut(name)
+            .ok_or_else(|| eyre::eyre!("Ping \"{}\" gibt es nicht", name))?;
+        ping.template = template;
+        self.save()
+    }
+
     /// Add a member to a ping. Errors if ping doesn't exist or user already a member.
     pub fn add_member(&mut self, ping_name: &str, username: &str) -> Result<()> {
         let ping = self.store.pings.get_mut(ping_name)
@@ -184,5 +192,72 @@ impl PingManager {
             .replace("{sender}", sender);
         Some(rendered)
     }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_manager(dir: &Path) -> PingManager {
+        PingManager {
+            store: PingStore { pings: HashMap::new() },
+            last_triggered: HashMap::new(),
+            path: dir.join(PINGS_FILENAME),
+        }
+    }
+
+    fn test_manager(dir: &Path) -> PingManager {
+        let mut mgr = empty_manager(dir);
+        mgr.create_ping("test".into(), "Hey {mentions}!".into(), "admin".into(), None)
+            .unwrap();
+        mgr
+    }
+
+    #[test]
+    fn edit_template_updates_template() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = test_manager(dir.path());
+
+        mgr.edit_template("test", "New template {mentions}".into()).unwrap();
+
+        let ping = mgr.store.pings.get("test").unwrap();
+        assert_eq!(ping.template, "New template {mentions}");
+    }
+
+    #[test]
+    fn edit_template_preserves_members() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = test_manager(dir.path());
+        mgr.add_member("test", "alice").unwrap();
+        mgr.add_member("test", "bob").unwrap();
+
+        mgr.edit_template("test", "Updated {mentions}".into()).unwrap();
+
+        let ping = mgr.store.pings.get("test").unwrap();
+        assert!(ping.members.contains("alice"));
+        assert!(ping.members.contains("bob"));
+        assert_eq!(ping.members.len(), 2);
+    }
+
+    #[test]
+    fn edit_template_nonexistent_ping_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = test_manager(dir.path());
+
+        let result = mgr.edit_template("nope", "whatever".into());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("gibt es nicht"));
+    }
+
+    #[test]
+    fn edit_template_persists_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = test_manager(dir.path());
+        mgr.edit_template("test", "Persisted {mentions}".into()).unwrap();
+
+        // Reload from disk
+        let mgr2 = PingManager::load(dir.path()).unwrap();
+        let ping = mgr2.store.pings.get("test").unwrap();
+        assert_eq!(ping.template, "Persisted {mentions}");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `!p edit <name> <template>` admin command to update an existing ping's template message without losing members
- Adds `edit_template` method to `PingManager` with persistence
- Adds 4 unit tests covering template update, member preservation, error handling, and disk persistence

Closes #6

## Test plan
- [x] `cargo test ping::tests` — 4/4 pass
- [x] `cargo clippy` — clean
- [ ] Manual test: `!p create testping Hello {mentions}` then `!p edit testping Goodbye {mentions}` confirms template changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)