### PR TITLE
ci: limit push trigger to main to avoid duplicate PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
+    branches: [main]
 
 concurrency:
   group: sast-${{ github.ref }}


### PR DESCRIPTION
Branch pushes in a same-repo PR were firing both the push event (on the feature branch) and the pull_request event, so every job ran twice. Restricting the push trigger to main keeps CI on post-merge commits intact while letting pull_request carry the pre-merge validation. Same fix applied to ci.yml and sast.yml.