### PR TITLE
feat(commands): add !suspend/!unsuspend admin commands

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -38,6 +38,12 @@ client_secret = "your_client_secret"
 # up = 30        # !up command (default: 30)
 # feedback = 300 # !fb command (default: 300)
 
+# Optional: Suspend configuration
+# Controls the default suspend duration applied when no explicit duration is given.
+# Must be between 1 second and 604800 seconds (7 days).
+# [suspend]
+# default_duration_secs = 600  # Default suspend duration in seconds (default: 600 = 10 min)
+
 # Optional: AI configuration for the !ai command
 # If not configured, the !ai command will be disabled.
 #

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,8 +14,32 @@ pub mod leaderboard;
 pub mod ping_admin;
 pub mod ping_trigger;
 pub mod random_flight;
+pub mod suspend;
 pub mod track;
 pub mod untrack;
+
+/// German rejection reply used by admin-gated commands when the sender
+/// lacks the required badge or id.
+pub const ADMIN_DENIED_MSG: &str = "Das darfst du nicht FDM";
+
+/// Returns true if the author of `privmsg` is allowed to run admin commands:
+/// carries a broadcaster or moderator badge, or their user id is in
+/// `hidden_admin_ids`.
+pub fn is_admin(privmsg: &PrivmsgMessage, hidden_admin_ids: &[String]) -> bool {
+    for badge in &privmsg.badges {
+        if badge.name == "broadcaster" || badge.name == "moderator" {
+            return true;
+        }
+    }
+    hidden_admin_ids.contains(&privmsg.sender.id)
+}
+
+/// Normalize a command name from user input: strip leading `!`s and
+/// ASCII-lowercase. Used both by admin suspend commands and by the
+/// dispatcher's suspension lookup — they MUST agree.
+pub fn normalize_command_name(raw: &str) -> String {
+    raw.trim_start_matches('!').to_ascii_lowercase()
+}
 
 /// Context passed to every command execution.
 pub struct CommandContext<'a, T: Transport, L: LoginCredentials> {
@@ -52,4 +76,17 @@ where
 
     /// Execute the command with the given context.
     async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_command_name_strips_bangs_and_lowercases() {
+        assert_eq!(normalize_command_name("AI"), "ai");
+        assert_eq!(normalize_command_name("!AI"), "ai");
+        assert_eq!(normalize_command_name("!!foo"), "foo");
+        assert_eq!(normalize_command_name("track"), "track");
+    }
 }

--- a/src/commands/ping_admin.rs
+++ b/src/commands/ping_admin.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use eyre::Result;
 use tokio::sync::RwLock;
-use twitch_irc::{login::LoginCredentials, message::PrivmsgMessage, transport::Transport};
+use twitch_irc::{login::LoginCredentials, transport::Transport};
 
 use crate::ping::PingManager;
 
-use super::{Command, CommandContext};
+use super::{ADMIN_DENIED_MSG, Command, CommandContext, is_admin};
 
 /// Normalize a ping name from user input to the canonical lowercase form.
 fn normalize_ping_name(name: &str) -> String {
@@ -26,15 +26,6 @@ impl PingAdminCommand {
             hidden_admin_ids,
         }
     }
-
-    fn is_admin(&self, privmsg: &PrivmsgMessage) -> bool {
-        for badge in &privmsg.badges {
-            if badge.name == "broadcaster" || badge.name == "moderator" {
-                return true;
-            }
-        }
-        self.hidden_admin_ids.contains(&privmsg.sender.id)
-    }
 }
 
 #[async_trait]
@@ -52,9 +43,9 @@ where
 
         match subcommand {
             "create" | "delete" | "edit" | "add" | "remove" => {
-                if !self.is_admin(ctx.privmsg) {
+                if !is_admin(ctx.privmsg, &self.hidden_admin_ids) {
                     ctx.client
-                        .say_in_reply_to(ctx.privmsg, "Das darfst du nicht FDM".to_string())
+                        .say_in_reply_to(ctx.privmsg, ADMIN_DENIED_MSG.to_string())
                         .await?;
                     return Ok(());
                 }

--- a/src/commands/suspend.rs
+++ b/src/commands/suspend.rs
@@ -1,0 +1,241 @@
+//! Admin commands for transiently suspending other bot commands.
+//!
+//! `!suspend <command> [duration]` silences another command for the given
+//! duration (defaults to [`SuspendConfig::default_duration_secs`]).
+//! `!unsuspend <command>` lifts an active suspension.
+//!
+//! Both commands are gated to broadcaster/moderator badges or user ids listed
+//! in `twitch.hidden_admins`. The commands `suspend`, `unsuspend`, and `p`
+//! cannot be suspended (enforced in [`SuspendCommand`]).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use eyre::Result;
+use tracing::error;
+use twitch_irc::{login::LoginCredentials, transport::Transport};
+
+use super::{ADMIN_DENIED_MSG, Command, CommandContext, is_admin, normalize_command_name};
+use crate::cooldown::format_cooldown_remaining;
+use crate::suspend::{ParseDurationError, SuspensionManager, parse_duration};
+
+/// Command names that must never be suspendable. Kept lowercase; the key
+/// passed from user input is normalized the same way before comparison.
+const EXEMPT_COMMANDS: &[&str] = &["suspend", "unsuspend", "p"];
+
+/// Map a [`ParseDurationError`] to a user-facing German message.
+fn duration_error_message(err: &ParseDurationError) -> String {
+    match err {
+        ParseDurationError::Empty => "Dauer fehlt. Nutze z.B. 30s, 10m, 2h, 1d FDM".to_string(),
+        ParseDurationError::InvalidNumber => {
+            "Ungültige Zahl. Nutze z.B. 30s, 10m, 2h, 1d FDM".to_string()
+        }
+        ParseDurationError::UnknownUnit => {
+            "Unbekannte Einheit. Erlaubt: s, m, h, d FDM".to_string()
+        }
+        ParseDurationError::Zero => "Dauer muss größer als 0 sein FDM".to_string(),
+        ParseDurationError::TooLong => "Dauer zu lang (max 7 Tage) FDM".to_string(),
+    }
+}
+
+pub struct SuspendCommand {
+    manager: Arc<SuspensionManager>,
+    hidden_admin_ids: Vec<String>,
+    default_duration: Duration,
+}
+
+impl SuspendCommand {
+    pub fn new(
+        manager: Arc<SuspensionManager>,
+        hidden_admin_ids: Vec<String>,
+        default_duration: Duration,
+    ) -> Self {
+        Self {
+            manager,
+            hidden_admin_ids,
+            default_duration,
+        }
+    }
+}
+
+#[async_trait]
+impl<T, L> Command<T, L> for SuspendCommand
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    fn name(&self) -> &str {
+        "!suspend"
+    }
+
+    async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()> {
+        if !is_admin(ctx.privmsg, &self.hidden_admin_ids) {
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(ctx.privmsg, ADMIN_DENIED_MSG.to_string())
+                .await
+            {
+                error!(error = ?e, "Failed to send admin-gate reply");
+            }
+            return Ok(());
+        }
+
+        let raw_cmd = match ctx.args.first() {
+            Some(c) => *c,
+            None => {
+                if let Err(e) = ctx
+                    .client
+                    .say_in_reply_to(ctx.privmsg, "Nutze: !suspend <command> [dauer]".to_string())
+                    .await
+                {
+                    error!(error = ?e, "Failed to send usage reply");
+                }
+                return Ok(());
+            }
+        };
+
+        let cmd = normalize_command_name(raw_cmd);
+
+        if EXEMPT_COMMANDS.contains(&cmd.as_str()) {
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(
+                    ctx.privmsg,
+                    "Das kann nicht gesperrt werden FDM".to_string(),
+                )
+                .await
+            {
+                error!(error = ?e, "Failed to send exempt reply");
+            }
+            return Ok(());
+        }
+
+        let duration = match ctx.args.get(1) {
+            None => self.default_duration,
+            Some(s) => match parse_duration(s) {
+                Ok(d) => d,
+                Err(err) => {
+                    if let Err(e) = ctx
+                        .client
+                        .say_in_reply_to(ctx.privmsg, duration_error_message(&err))
+                        .await
+                    {
+                        error!(error = ?e, "Failed to send duration-error reply");
+                    }
+                    return Ok(());
+                }
+            },
+        };
+
+        self.manager.suspend(&cmd, duration).await;
+
+        if let Err(e) = ctx
+            .client
+            .say_in_reply_to(
+                ctx.privmsg,
+                format!(
+                    "!{cmd} gesperrt für {}",
+                    format_cooldown_remaining(duration)
+                ),
+            )
+            .await
+        {
+            error!(error = ?e, "Failed to send suspend confirmation");
+        }
+
+        Ok(())
+    }
+}
+
+pub struct UnsuspendCommand {
+    manager: Arc<SuspensionManager>,
+    hidden_admin_ids: Vec<String>,
+}
+
+impl UnsuspendCommand {
+    pub fn new(manager: Arc<SuspensionManager>, hidden_admin_ids: Vec<String>) -> Self {
+        Self {
+            manager,
+            hidden_admin_ids,
+        }
+    }
+}
+
+#[async_trait]
+impl<T, L> Command<T, L> for UnsuspendCommand
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    fn name(&self) -> &str {
+        "!unsuspend"
+    }
+
+    async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()> {
+        if !is_admin(ctx.privmsg, &self.hidden_admin_ids) {
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(ctx.privmsg, ADMIN_DENIED_MSG.to_string())
+                .await
+            {
+                error!(error = ?e, "Failed to send admin-gate reply");
+            }
+            return Ok(());
+        }
+
+        let raw_cmd = match ctx.args.first() {
+            Some(c) => *c,
+            None => {
+                if let Err(e) = ctx
+                    .client
+                    .say_in_reply_to(ctx.privmsg, "Nutze: !unsuspend <command>".to_string())
+                    .await
+                {
+                    error!(error = ?e, "Failed to send usage reply");
+                }
+                return Ok(());
+            }
+        };
+
+        let cmd = normalize_command_name(raw_cmd);
+
+        let reply = if self.manager.unsuspend(&cmd).await {
+            format!("!{cmd} entsperrt Okayge")
+        } else {
+            format!("!{cmd} war nicht gesperrt FDM")
+        };
+
+        if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, reply).await {
+            error!(error = ?e, "Failed to send unsuspend reply");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exempt_list_covers_required_commands() {
+        assert!(EXEMPT_COMMANDS.contains(&"suspend"));
+        assert!(EXEMPT_COMMANDS.contains(&"unsuspend"));
+        assert!(EXEMPT_COMMANDS.contains(&"p"));
+    }
+
+    #[test]
+    fn duration_error_messages_end_in_fdm() {
+        for err in [
+            ParseDurationError::Empty,
+            ParseDurationError::InvalidNumber,
+            ParseDurationError::UnknownUnit,
+            ParseDurationError::Zero,
+            ParseDurationError::TooLong,
+        ] {
+            let msg = duration_error_message(&err);
+            assert!(msg.ends_with("FDM"), "expected FDM suffix, got: {msg}");
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,24 @@ impl Default for PingsConfig {
     }
 }
 
+fn default_suspend_duration() -> u64 {
+    600
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SuspendConfig {
+    #[serde(default = "default_suspend_duration")]
+    pub default_duration_secs: u64,
+}
+
+impl Default for SuspendConfig {
+    fn default() -> Self {
+        Self {
+            default_duration_secs: default_suspend_duration(),
+        }
+    }
+}
+
 fn default_enabled() -> bool {
     true
 }
@@ -177,6 +195,8 @@ pub struct Configuration {
     #[serde(default)]
     pub cooldowns: CooldownsConfig,
     #[serde(default)]
+    pub suspend: SuspendConfig,
+    #[serde(default)]
     pub ai: Option<AiConfig>,
     #[serde(default)]
     pub schedules: Vec<ScheduleConfig>,
@@ -201,6 +221,7 @@ impl Configuration {
             },
             pings: PingsConfig::default(),
             cooldowns: CooldownsConfig::default(),
+            suspend: SuspendConfig::default(),
             ai: None,
             schedules: Vec::new(),
         }
@@ -259,6 +280,13 @@ pub fn validate_config(config: &Configuration) -> Result<()> {
         if admin_ch == &config.twitch.channel {
             bail!("twitch.admin_channel must be different from twitch.channel");
         }
+    }
+
+    if !(1..=7 * 86400).contains(&config.suspend.default_duration_secs) {
+        bail!(
+            "suspend.default_duration_secs must be between 1 and 604800 (7 days) (got {})",
+            config.suspend.default_duration_secs
+        );
     }
 
     if let Some(ref ai) = config.ai

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -15,8 +15,9 @@ use twitch_irc::{
 
 use crate::{
     ChatHistory, PersonalBest, aviation, commands,
-    config::{AiConfig, CooldownsConfig},
+    config::{AiConfig, CooldownsConfig, SuspendConfig},
     flight_tracker, llm, memory, ping, prefill,
+    suspend::SuspensionManager,
 };
 
 /// Configuration for the generic command handler.
@@ -40,6 +41,8 @@ pub struct CommandHandlerConfig<T: Transport, L: LoginCredentials> {
     pub bot_username: String,
     pub channel: String,
     pub data_dir: std::path::PathBuf,
+    pub suspension_manager: Arc<SuspensionManager>,
+    pub suspend: SuspendConfig,
 }
 
 /// Handler for generic text commands that start with `!`.
@@ -68,7 +71,11 @@ where
         bot_username,
         channel,
         data_dir,
+        suspension_manager,
+        suspend,
     } = cfg;
+
+    let default_suspend_duration = Duration::from_secs(suspend.default_duration_secs);
 
     let broadcast_rx = broadcast_tx.subscribe();
 
@@ -103,6 +110,15 @@ where
     let mut cmd_list: Vec<Box<dyn commands::Command<T, L>>> = vec![
         Box::new(commands::ping_admin::PingAdminCommand::new(
             ping_manager.clone(),
+            hidden_admin_ids.clone(),
+        )),
+        Box::new(commands::suspend::SuspendCommand::new(
+            suspension_manager.clone(),
+            hidden_admin_ids.clone(),
+            default_suspend_duration,
+        )),
+        Box::new(commands::suspend::UnsuspendCommand::new(
+            suspension_manager.clone(),
             hidden_admin_ids,
         )),
         Box::new(commands::random_flight::RandomFlightCommand),
@@ -179,6 +195,7 @@ where
         admin_channel,
         chat_history,
         history_length,
+        suspension_manager,
     )
     .await;
 }
@@ -191,6 +208,7 @@ pub(crate) async fn run_command_dispatcher<T, L>(
     admin_channel: Option<String>,
     chat_history: Option<ChatHistory>,
     history_length: usize,
+    suspension_manager: Arc<SuspensionManager>,
 ) where
     T: Transport,
     L: LoginCredentials,
@@ -235,6 +253,18 @@ pub(crate) async fn run_command_dispatcher<T, L>(
                 else {
                     continue;
                 };
+
+                // Must match SuspendCommand's normalization, else admin
+                // suspensions silently miss the dispatcher hook.
+                let suspend_key = crate::commands::normalize_command_name(first_word);
+                if suspension_manager
+                    .is_suspended(&suspend_key)
+                    .await
+                    .is_some()
+                {
+                    debug!(command = %first_word, "Skipping suspended command");
+                    continue;
+                }
 
                 let ctx = crate::commands::CommandContext {
                     privmsg: &privmsg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod llm;
 pub mod memory;
 pub mod ping;
 pub mod prefill;
+pub mod suspend;
 pub mod telemetry;
 pub mod token_storage;
 pub mod twitch_setup;
@@ -175,6 +176,8 @@ where
         (None, None)
     };
 
+    let suspension_manager = Arc::new(suspend::SuspensionManager::new());
+
     let latency = Arc::new(AtomicU32::new(config.twitch.expected_latency));
 
     let handler_latency = tokio::spawn({
@@ -220,6 +223,8 @@ where
                 bot_username: config.twitch.username.clone(),
                 channel: config.twitch.channel.clone(),
                 data_dir: data_dir.clone(),
+                suspension_manager: suspension_manager.clone(),
+                suspend: config.suspend.clone(),
             })
             .await;
         }

--- a/src/suspend.rs
+++ b/src/suspend.rs
@@ -1,0 +1,275 @@
+//! Transient command-suspension manager.
+//!
+//! Tracks per-command suspension expiry timestamps in memory. State is not
+//! persisted across restarts. A suspended command is one whose key (the
+//! command name without the leading `!`, lowercased) maps to a future
+//! `Instant`.
+//!
+//! Also provides [`parse_duration`] for parsing short human-friendly duration
+//! strings used by the admin suspend command (`30s`, `10m`, `2h`, `1d`, or a
+//! bare integer meaning seconds).
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::RwLock;
+use tracing::debug;
+
+/// Upper bound on a single suspension: 7 days.
+pub const MAX_SUSPEND_DURATION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+/// Transient per-command suspension tracker.
+///
+/// Cheap to clone: the inner map is shared via `Arc<RwLock<_>>`. Keys are
+/// normalized to lowercase on all operations.
+#[derive(Clone, Default)]
+pub struct SuspensionManager {
+    inner: Arc<RwLock<HashMap<String, Instant>>>,
+}
+
+impl SuspensionManager {
+    /// Create an empty manager.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Suspend `key` for `duration`, overwriting any existing entry.
+    pub async fn suspend(&self, key: &str, duration: Duration) {
+        let key = key.to_ascii_lowercase();
+        let expiry = Instant::now() + duration;
+        debug!(key = %key, ?duration, "Command suspended");
+        self.inner.write().await.insert(key, expiry);
+    }
+
+    /// Remove any suspension for `key`.
+    ///
+    /// Returns `true` only if an entry existed AND had not yet expired (i.e.
+    /// it was actively suspending the command). Stale entries are removed
+    /// silently and reported as `false`.
+    pub async fn unsuspend(&self, key: &str) -> bool {
+        let key = key.to_ascii_lowercase();
+        let mut guard = self.inner.write().await;
+        match guard.remove(&key) {
+            Some(expiry) if expiry > Instant::now() => {
+                debug!(key = %key, "Command unsuspended");
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Return `Some(remaining)` if `key` is currently suspended, else `None`.
+    ///
+    /// Does not remove expired entries. The map is bounded by the number of
+    /// registered commands so it cannot grow without bound in practice.
+    pub async fn is_suspended(&self, key: &str) -> Option<Duration> {
+        let key = key.to_ascii_lowercase();
+        let guard = self.inner.read().await;
+        let expiry = guard.get(&key)?;
+        expiry.checked_duration_since(Instant::now())
+    }
+}
+
+/// Error returned by [`parse_duration`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseDurationError {
+    /// Input was empty or whitespace-only.
+    Empty,
+    /// Numeric portion was missing, non-ASCII-digit, or overflowed `u64`.
+    InvalidNumber,
+    /// Unit suffix was not one of `s`, `m`, `h`, `d`.
+    UnknownUnit,
+    /// Parsed duration was zero.
+    Zero,
+    /// Parsed duration exceeded [`MAX_SUSPEND_DURATION`].
+    TooLong,
+}
+
+impl fmt::Display for ParseDurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "duration is empty"),
+            Self::InvalidNumber => write!(f, "invalid number"),
+            Self::UnknownUnit => write!(f, "unknown unit (use s, m, h, or d)"),
+            Self::Zero => write!(f, "duration must be greater than zero"),
+            Self::TooLong => write!(f, "duration exceeds maximum of 7 days"),
+        }
+    }
+}
+
+impl std::error::Error for ParseDurationError {}
+
+/// Parse a short duration string.
+///
+/// Accepted forms: `30s`, `10m`, `2h`, `1d`, or a bare integer (seconds).
+/// Duration must be > 0 and <= [`MAX_SUSPEND_DURATION`] (7 days). Rejects
+/// negative values implicitly via `u64`.
+pub fn parse_duration(input: &str) -> Result<Duration, ParseDurationError> {
+    let s = input.trim();
+    if s.is_empty() {
+        return Err(ParseDurationError::Empty);
+    }
+
+    let (num_part, multiplier) = match s.as_bytes().last() {
+        Some(&b) if b.is_ascii_digit() => (s, 1u64),
+        Some(&b's') => (&s[..s.len() - 1], 1u64),
+        Some(&b'm') => (&s[..s.len() - 1], 60u64),
+        Some(&b'h') => (&s[..s.len() - 1], 3600u64),
+        Some(&b'd') => (&s[..s.len() - 1], 86_400u64),
+        Some(_) => return Err(ParseDurationError::UnknownUnit),
+        None => return Err(ParseDurationError::Empty),
+    };
+
+    if num_part.is_empty() || !num_part.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(ParseDurationError::InvalidNumber);
+    }
+
+    let n: u64 = num_part
+        .parse()
+        .map_err(|_| ParseDurationError::InvalidNumber)?;
+    let secs = n
+        .checked_mul(multiplier)
+        .ok_or(ParseDurationError::InvalidNumber)?;
+
+    if secs == 0 {
+        return Err(ParseDurationError::Zero);
+    }
+
+    let duration = Duration::from_secs(secs);
+    if duration > MAX_SUSPEND_DURATION {
+        return Err(ParseDurationError::TooLong);
+    }
+
+    Ok(duration)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_accepts_valid_forms() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("10m").unwrap(), Duration::from_secs(600));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7200));
+        assert_eq!(parse_duration("1d").unwrap(), Duration::from_secs(86_400));
+        assert_eq!(parse_duration("90").unwrap(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn parse_duration_trims_whitespace() {
+        assert_eq!(parse_duration("  30s  ").unwrap(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn parse_duration_rejects_empty() {
+        assert_eq!(parse_duration(""), Err(ParseDurationError::Empty));
+        assert_eq!(parse_duration("   "), Err(ParseDurationError::Empty));
+    }
+
+    #[test]
+    fn parse_duration_rejects_non_numeric() {
+        assert_eq!(parse_duration("abc"), Err(ParseDurationError::UnknownUnit));
+        // "-1" ends in a digit so the first-arm fast path treats the whole
+        // string as seconds; the leading '-' then fails the digit-only check.
+        assert_eq!(parse_duration("-1"), Err(ParseDurationError::InvalidNumber));
+    }
+
+    #[test]
+    fn parse_duration_rejects_zero() {
+        assert_eq!(parse_duration("0"), Err(ParseDurationError::Zero));
+        assert_eq!(parse_duration("0s"), Err(ParseDurationError::Zero));
+        assert_eq!(parse_duration("0m"), Err(ParseDurationError::Zero));
+    }
+
+    #[test]
+    fn parse_duration_rejects_above_cap() {
+        assert_eq!(parse_duration("8d"), Err(ParseDurationError::TooLong));
+        assert_eq!(parse_duration("604801"), Err(ParseDurationError::TooLong));
+    }
+
+    #[test]
+    fn parse_duration_accepts_exact_cap() {
+        assert_eq!(parse_duration("7d").unwrap(), MAX_SUSPEND_DURATION);
+    }
+
+    #[test]
+    fn parse_duration_rejects_unknown_unit() {
+        assert_eq!(parse_duration("1w"), Err(ParseDurationError::UnknownUnit));
+        assert_eq!(parse_duration("5y"), Err(ParseDurationError::UnknownUnit));
+    }
+
+    #[test]
+    fn parse_duration_rejects_missing_number() {
+        assert_eq!(parse_duration("s"), Err(ParseDurationError::InvalidNumber));
+        assert_eq!(parse_duration("m"), Err(ParseDurationError::InvalidNumber));
+    }
+
+    #[tokio::test]
+    async fn suspend_and_is_suspended() {
+        let mgr = SuspensionManager::new();
+        mgr.suspend("ai", Duration::from_secs(60)).await;
+        let remaining = mgr.is_suspended("ai").await;
+        assert!(remaining.is_some());
+        assert!(remaining.unwrap() <= Duration::from_secs(60));
+    }
+
+    #[tokio::test]
+    async fn is_suspended_returns_none_after_expiry() {
+        let mgr = SuspensionManager::new();
+        mgr.suspend("ai", Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(mgr.is_suspended("ai").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unsuspend_removes_active_entry() {
+        let mgr = SuspensionManager::new();
+        mgr.suspend("ai", Duration::from_secs(60)).await;
+        assert!(mgr.unsuspend("ai").await);
+        assert!(mgr.is_suspended("ai").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unsuspend_unknown_key_returns_false() {
+        let mgr = SuspensionManager::new();
+        assert!(!mgr.unsuspend("nope").await);
+    }
+
+    #[tokio::test]
+    async fn unsuspend_expired_entry_returns_false() {
+        let mgr = SuspensionManager::new();
+        mgr.suspend("ai", Duration::from_millis(20)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!mgr.unsuspend("ai").await);
+    }
+
+    #[tokio::test]
+    async fn suspend_overwrites_existing_entry() {
+        let mgr = SuspensionManager::new();
+        mgr.suspend("ai", Duration::from_secs(3600)).await;
+        mgr.suspend("ai", Duration::from_millis(30)).await;
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Second call shortened the suspension; it should now be expired.
+        assert!(mgr.is_suspended("ai").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn keys_are_lowercased() {
+        let mgr = SuspensionManager::new();
+        mgr.suspend("AI", Duration::from_secs(60)).await;
+        assert!(mgr.is_suspended("ai").await.is_some());
+        assert!(mgr.is_suspended("Ai").await.is_some());
+        assert!(mgr.unsuspend("aI").await);
+    }
+
+    #[tokio::test]
+    async fn clone_shares_state() {
+        let mgr = SuspensionManager::new();
+        let clone = mgr.clone();
+        mgr.suspend("ai", Duration::from_secs(60)).await;
+        assert!(clone.is_suspended("ai").await.is_some());
+    }
+}

--- a/src/suspend.rs
+++ b/src/suspend.rs
@@ -61,9 +61,7 @@ impl SuspensionManager {
     }
 
     /// Return `Some(remaining)` if `key` is currently suspended, else `None`.
-    ///
-    /// Does not remove expired entries. The map is bounded by the number of
-    /// registered commands so it cannot grow without bound in practice.
+    /// Expired entries are not removed; callers read and ignore them.
     pub async fn is_suspended(&self, key: &str) -> Option<Duration> {
         let key = key.to_ascii_lowercase();
         let guard = self.inner.read().await;
@@ -104,8 +102,7 @@ impl std::error::Error for ParseDurationError {}
 /// Parse a short duration string.
 ///
 /// Accepted forms: `30s`, `10m`, `2h`, `1d`, or a bare integer (seconds).
-/// Duration must be > 0 and <= [`MAX_SUSPEND_DURATION`] (7 days). Rejects
-/// negative values implicitly via `u64`.
+/// Duration must be > 0 and <= [`MAX_SUSPEND_DURATION`] (7 days).
 pub fn parse_duration(input: &str) -> Result<Duration, ParseDurationError> {
     let s = input.trim();
     if s.is_empty() {
@@ -252,7 +249,6 @@ mod tests {
         mgr.suspend("ai", Duration::from_secs(3600)).await;
         mgr.suspend("ai", Duration::from_millis(30)).await;
         tokio::time::sleep(Duration::from_millis(60)).await;
-        // Second call shortened the suspension; it should now be expired.
         assert!(mgr.is_suspended("ai").await.is_none());
     }
 

--- a/tests/common/irc_line.rs
+++ b/tests/common/irc_line.rs
@@ -52,7 +52,15 @@ pub fn privmsg_as_broadcaster(channel: &str, user: &str, text: &str) -> String {
 }
 
 pub fn privmsg_as_mod(channel: &str, user: &str, text: &str) -> String {
-    privmsg_with(channel, user, text, &[("mod", "1")])
+    // Real Twitch sends both the `mod` tag and a `moderator/1` entry in
+    // `badges`. Handlers (e.g. `!suspend`, `!p create`) gate on the badge
+    // list, so set both for realism.
+    privmsg_with(
+        channel,
+        user,
+        text,
+        &[("badges", "moderator/1"), ("mod", "1")],
+    )
 }
 
 /// Build a PRIVMSG with a specific `tmi-sent-ts` (Unix milliseconds).

--- a/tests/suspend.rs
+++ b/tests/suspend.rs
@@ -8,6 +8,13 @@ use common::{TestBot, TestBotBuilder};
 use serial_test::serial;
 use twitch_1337::PersonalBest;
 
+/// twitch-irc's default rate limiter allows 5 msgs / 150 ms per connection.
+/// When a test crosses that threshold the client opens a second connection,
+/// but FakeTransport's `install()` slot has already been drained — the
+/// second connect hangs. Tests that cross the boundary pause long enough
+/// for the earlier sends to age out of the rate window.
+const RATE_LIMIT_DRAIN_DELAY: Duration = Duration::from_millis(800);
+
 /// Insert a single seeded PB so that `!lb` produces a deterministic reply
 /// (instead of the empty-state message).
 fn seeded_lb_with_alice() -> HashMap<String, PersonalBest> {
@@ -263,12 +270,7 @@ async fn ping_can_be_suspended() {
         "expected ping trigger to mention bob, got: {before}"
     );
 
-    // twitch-irc's default rate limiter (5 msgs / 150ms per connection) kicks
-    // in around the 5th outgoing message and makes the client try to open a
-    // second connection — which fails in tests because FakeTransport's
-    // install()-backed slot has already been drained. A short pause lets the
-    // already-sent messages age out of the rate window.
-    tokio::time::sleep(Duration::from_millis(800)).await;
+    tokio::time::sleep(RATE_LIMIT_DRAIN_DELAY).await;
 
     // Suspend the ping by name. Broadcaster-gated admin command.
     bot.send_as_broadcaster("broadcaster", "!suspend hi 1m")
@@ -283,8 +285,7 @@ async fn ping_can_be_suspended() {
     bot.send("bob", "!hi").await;
     bot.expect_silent(Duration::from_millis(500)).await;
 
-    // Another pause before the 7th outgoing to avoid the rate-limit corner.
-    tokio::time::sleep(Duration::from_millis(800)).await;
+    tokio::time::sleep(RATE_LIMIT_DRAIN_DELAY).await;
 
     // Unsuspend.
     bot.send_as_broadcaster("broadcaster", "!unsuspend hi")
@@ -300,7 +301,7 @@ async fn ping_can_be_suspended() {
     // trigger through the handler (replying with cooldown message) instead
     // of silently dropping it, which proves the ping is no longer
     // suspended.
-    tokio::time::sleep(Duration::from_millis(800)).await;
+    tokio::time::sleep(RATE_LIMIT_DRAIN_DELAY).await;
     bot.send("bob", "!hi").await;
     let after = bot.expect_say(Duration::from_secs(2)).await;
     assert!(

--- a/tests/suspend.rs
+++ b/tests/suspend.rs
@@ -1,0 +1,312 @@
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::NaiveDate;
+use common::{TestBot, TestBotBuilder};
+use serial_test::serial;
+use twitch_1337::PersonalBest;
+
+/// Insert a single seeded PB so that `!lb` produces a deterministic reply
+/// (instead of the empty-state message).
+fn seeded_lb_with_alice() -> HashMap<String, PersonalBest> {
+    let mut seeded: HashMap<String, PersonalBest> = HashMap::new();
+    seeded.insert(
+        "alice".into(),
+        PersonalBest {
+            ms: 234,
+            date: NaiveDate::from_ymd_opt(2026, 4, 17).unwrap(),
+        },
+    );
+    seeded
+}
+
+/// Sanity check: `!lb` yields a non-empty leaderboard reply mentioning alice.
+/// Used after tests that should NOT actually have suspended the command.
+async fn assert_lb_works(bot: &mut TestBot) {
+    bot.send("alice", "!lb").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(out.contains("alice"), "expected !lb to reply, got: {out}");
+}
+
+#[tokio::test]
+#[serial]
+async fn broadcaster_can_suspend_lb_then_unsuspend() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .spawn()
+        .await;
+
+    // Broadcaster suspends !lb for 1m.
+    bot.send_as_broadcaster("broadcaster", "!suspend lb 1m")
+        .await;
+    let confirm = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        confirm.contains("!lb") && confirm.contains("gesperrt"),
+        "expected suspend confirmation, got: {confirm}"
+    );
+    assert!(
+        confirm.contains("1m"),
+        "expected duration 1m in confirmation, got: {confirm}"
+    );
+
+    // Regular user triggers !lb -> silently skipped.
+    bot.send("alice", "!lb").await;
+    bot.expect_silent(Duration::from_millis(500)).await;
+
+    // Broadcaster unsuspends.
+    bot.send_as_broadcaster("broadcaster", "!unsuspend lb")
+        .await;
+    let unsusp = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        unsusp.contains("!lb") && unsusp.contains("entsperrt"),
+        "expected unsuspend confirmation, got: {unsusp}"
+    );
+
+    // Now !lb works again.
+    assert_lb_works(&mut bot).await;
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn mod_can_suspend_lb() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .spawn()
+        .await;
+
+    bot.send_as_mod("modguy", "!suspend lb 1m").await;
+    let confirm = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        confirm.contains("!lb") && confirm.contains("gesperrt"),
+        "expected suspend confirmation from mod, got: {confirm}"
+    );
+
+    bot.send("alice", "!lb").await;
+    bot.expect_silent(Duration::from_millis(500)).await;
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn hidden_admin_can_suspend_lb() {
+    // irc_line::privmsg sets user-id=67890; add it as a hidden admin.
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .with_config(|c| {
+            c.twitch.hidden_admins = vec!["67890".into()];
+        })
+        .spawn()
+        .await;
+
+    // Plain send() -> no badges, but user-id matches hidden_admins.
+    bot.send("sneaky", "!suspend lb 1m").await;
+    let confirm = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        confirm.contains("!lb") && confirm.contains("gesperrt"),
+        "expected hidden-admin suspend confirmation, got: {confirm}"
+    );
+
+    bot.send("alice", "!lb").await;
+    bot.expect_silent(Duration::from_millis(500)).await;
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn non_admin_cannot_suspend() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .spawn()
+        .await;
+
+    bot.send("random_user", "!suspend lb").await;
+    let rejection = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        rejection.contains("darfst du nicht") || rejection.contains("FDM"),
+        "expected rejection, got: {rejection}"
+    );
+
+    // !lb must still work since the suspend never took effect.
+    assert_lb_works(&mut bot).await;
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn exempt_commands_rejected() {
+    let mut bot = TestBotBuilder::new().spawn().await;
+
+    for exempt in ["suspend", "unsuspend", "p"] {
+        bot.send_as_broadcaster("broadcaster", &format!("!suspend {exempt}"))
+            .await;
+        let reply = bot.expect_say(Duration::from_secs(2)).await;
+        assert!(
+            reply.contains("kann nicht gesperrt werden"),
+            "expected exempt rejection for '{exempt}', got: {reply}"
+        );
+    }
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn default_duration_used_when_omitted() {
+    // Uses the built-in default of 600s = 10m.
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .spawn()
+        .await;
+
+    bot.send_as_broadcaster("broadcaster", "!suspend lb").await;
+    let confirm = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        confirm.contains("10m"),
+        "expected default duration rendered as '10m', got: {confirm}"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn custom_default_from_config() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .with_config(|c| {
+            c.suspend.default_duration_secs = 90;
+        })
+        .spawn()
+        .await;
+
+    bot.send_as_broadcaster("broadcaster", "!suspend lb").await;
+    let confirm = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        confirm.contains("1m 30s"),
+        "expected custom default rendered as '1m 30s', got: {confirm}"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn bad_duration_format_rejected() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_lb_with_alice())
+        .spawn()
+        .await;
+
+    bot.send_as_broadcaster("broadcaster", "!suspend lb wat")
+        .await;
+    let reply = bot.expect_say(Duration::from_secs(2)).await;
+    // Actual reply for UnknownUnit: "Unbekannte Einheit. Erlaubt: s, m, h, d FDM".
+    // Check for the unit-list substring so minor wording changes don't break
+    // the test.
+    assert!(
+        reply.contains("s, m, h, d"),
+        "expected accepted-units list in rejection, got: {reply}"
+    );
+
+    // Suspend did not take effect.
+    assert_lb_works(&mut bot).await;
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn unsuspend_unknown_command_replies_not_suspended() {
+    let mut bot = TestBotBuilder::new().spawn().await;
+
+    bot.send_as_broadcaster("broadcaster", "!unsuspend lb")
+        .await;
+    let reply = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        reply.contains("war nicht gesperrt"),
+        "expected 'war nicht gesperrt', got: {reply}"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn ping_can_be_suspended() {
+    let mut bot = TestBotBuilder::new().spawn().await;
+
+    // Create ping as broadcaster.
+    bot.send_as_broadcaster("broadcaster", "!p create hi yo {mentions}")
+        .await;
+    let _ = bot.expect_say(Duration::from_secs(2)).await;
+
+    // Both users join so !hi can fire (default `pings.public = false`
+    // requires the triggering user to be a member) and has someone to
+    // mention.
+    bot.send("alice", "!p join hi").await;
+    let _ = bot.expect_say(Duration::from_secs(2)).await;
+    bot.send("bob", "!p join hi").await;
+    let _ = bot.expect_say(Duration::from_secs(2)).await;
+
+    // alice triggers !hi -> reply mentioning bob (not sender).
+    bot.send("alice", "!hi").await;
+    let before = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        before.contains("@bob"),
+        "expected ping trigger to mention bob, got: {before}"
+    );
+
+    // twitch-irc's default rate limiter (5 msgs / 150ms per connection) kicks
+    // in around the 5th outgoing message and makes the client try to open a
+    // second connection — which fails in tests because FakeTransport's
+    // install()-backed slot has already been drained. A short pause lets the
+    // already-sent messages age out of the rate window.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    // Suspend the ping by name. Broadcaster-gated admin command.
+    bot.send_as_broadcaster("broadcaster", "!suspend hi 1m")
+        .await;
+    let confirm = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        confirm.contains("!hi") && confirm.contains("gesperrt"),
+        "expected suspend confirmation for !hi, got: {confirm}"
+    );
+
+    // Trigger by bob (sender) now silent (suspended).
+    bot.send("bob", "!hi").await;
+    bot.expect_silent(Duration::from_millis(500)).await;
+
+    // Another pause before the 7th outgoing to avoid the rate-limit corner.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    // Unsuspend.
+    bot.send_as_broadcaster("broadcaster", "!unsuspend hi")
+        .await;
+    let unsusp = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        unsusp.contains("!hi") && unsusp.contains("entsperrt"),
+        "expected unsuspend confirmation for !hi, got: {unsusp}"
+    );
+
+    // Bob triggers — the pre-suspend trigger came from alice, so the 300s
+    // per-ping cooldown still applies. Assert that the bot routes the
+    // trigger through the handler (replying with cooldown message) instead
+    // of silently dropping it, which proves the ping is no longer
+    // suspended.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+    bot.send("bob", "!hi").await;
+    let after = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        after.contains("warte") || after.contains("@alice"),
+        "expected ping trigger to route after unsuspend (cooldown msg or mention), got: {after}"
+    );
+
+    bot.shutdown().await;
+}


### PR DESCRIPTION
## Summary

- Adds `!suspend <cmd> [duration]` and `!unsuspend <cmd>` admin commands that transiently silence any bot command (including specific pings). Dispatcher silently drops messages whose normalized trigger matches an active suspension. Closes #35.
- Duration accepts `30s` / `10m` / `2h` / `1d` or bare integer seconds; cap 7 days. Default from `[suspend] default_duration_secs` (defaults to 600 = 10 min when absent).
- Suspension state is in-memory only (not persisted across restart, by design). Exempt commands `suspend`, `unsuspend`, `p` cannot be suspended to avoid self-lockout.
- Admin gate: broadcaster/moderator badge OR user id in `twitch.hidden_admins`. `is_admin` + `ADMIN_DENIED_MSG` + `normalize_command_name` lifted into `commands::mod` and reused by `ping_admin`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 84 pass (55 lib + 29 integration incl. 10 new in `tests/suspend.rs`)
- [x] Integration coverage: broadcaster suspend+unsuspend !lb, mod badge, hidden_admin id, non-admin rejection, exempt commands, default vs explicit duration, custom config default, bad duration format, unsuspend-unknown, ping suspension
- [ ] Manual smoke in prod channel after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
