### PR TITLE
fix(llm): surface malformed tool-call args to model

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -61,14 +61,18 @@ pub struct ToolDefinition {
 }
 
 /// A single tool call returned by the LLM.
+///
+/// Executors MUST check `arguments_parse_error` before inspecting `arguments`:
+/// when set, the provider returned an unparseable payload and `arguments` is
+/// `Value::Null`. Acting on the empty `arguments` would make a malformed call
+/// indistinguishable from a genuinely empty one.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ToolCall {
     pub id: String,
     pub name: String,
     pub arguments: serde_json::Value,
     /// Set when the provider delivered `arguments` as an unparseable string
-    /// (OpenAI-compatible APIs only). Executors should surface this back to the
-    /// model instead of acting on the empty `arguments`.
+    /// (OpenAI-compatible APIs only).
     #[serde(default)]
     pub arguments_parse_error: Option<ToolCallArgsError>,
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -66,6 +66,36 @@ pub struct ToolCall {
     pub id: String,
     pub name: String,
     pub arguments: serde_json::Value,
+    /// Set when the provider delivered `arguments` as an unparseable string
+    /// (OpenAI-compatible APIs only). Executors should surface this back to the
+    /// model instead of acting on the empty `arguments`.
+    #[serde(default)]
+    pub arguments_parse_error: Option<ToolCallArgsError>,
+}
+
+/// Details of a malformed `arguments` payload returned from the LLM.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToolCallArgsError {
+    pub error: String,
+    /// The raw string the provider sent. Already truncated to a bounded length
+    /// to avoid blowing up context budget when echoed back.
+    pub raw: String,
+}
+
+/// Truncate `s` at a char boundary to at most `max_chars` characters, appending
+/// a suffix describing how much was dropped. Used before echoing provider
+/// payloads back into the model context.
+pub(crate) fn truncate_for_echo(s: &str, max_chars: usize) -> String {
+    let total = s.chars().count();
+    if total <= max_chars {
+        return s.to_string();
+    }
+    let cutoff = s
+        .char_indices()
+        .nth(max_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    format!("{}… ({} more chars)", &s[..cutoff], total - max_chars)
 }
 
 /// Response from a tool-calling chat completion.
@@ -133,5 +163,28 @@ pub fn build_llm_client(
             error!(error = ?e, "Failed to initialize LLM client");
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_for_echo;
+
+    #[test]
+    fn truncate_for_echo_short_input_passes_through() {
+        assert_eq!(truncate_for_echo("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_for_echo_long_input_trims_at_char_boundary() {
+        let out = truncate_for_echo("abcdefghij", 4);
+        assert_eq!(out, "abcd… (6 more chars)");
+    }
+
+    #[test]
+    fn truncate_for_echo_respects_multibyte_chars() {
+        // 6 emoji × 4 bytes each; byte slicing would panic mid-codepoint.
+        let out = truncate_for_echo("🙂🙂🙂🙂🙂🙂", 3);
+        assert_eq!(out, "🙂🙂🙂… (3 more chars)");
     }
 }

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -271,6 +271,7 @@ impl LlmClient for OllamaClient {
                     id: format!("call_{}", i),
                     name: tc.function.name,
                     arguments: tc.function.arguments,
+                    arguments_parse_error: None,
                 })
                 .collect();
             return Ok(ToolChatCompletionResponse::ToolCalls(calls));
@@ -309,6 +310,7 @@ mod tests {
                         id: "call_0".to_string(),
                         name: "save_memory".to_string(),
                         arguments: serde_json::json!({"key": "k1", "fact": "f1"}),
+                        arguments_parse_error: None,
                     }],
                     results: vec![ToolResultMessage {
                         tool_call_id: "call_0".to_string(),
@@ -321,6 +323,7 @@ mod tests {
                         id: "call_0".to_string(),
                         name: "delete_memory".to_string(),
                         arguments: serde_json::json!({"key": "k2"}),
+                        arguments_parse_error: None,
                     }],
                     results: vec![ToolResultMessage {
                         tool_call_id: "call_0".to_string(),

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -6,6 +6,7 @@ use tracing::{debug, instrument, warn};
 
 use super::{
     ChatCompletionRequest, LlmClient, ToolChatCompletionRequest, ToolChatCompletionResponse,
+    truncate_for_echo,
 };
 use crate::APP_USER_AGENT;
 
@@ -311,28 +312,29 @@ impl LlmClient for OpenAiClient {
             let calls = tool_calls
                 .into_iter()
                 .map(|tc| {
-                    let arguments = match serde_json::from_str::<serde_json::Value>(
-                        &tc.function.arguments,
-                    ) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            warn!(
-                                tool = %tc.function.name,
-                                id = %tc.id,
-                                error = %e,
-                                raw = %tc.function.arguments,
-                                "Tool call arguments were not valid JSON; surfacing parse error to model",
-                            );
-                            serde_json::json!({
-                                "__parse_error": e.to_string(),
-                                "__raw": tc.function.arguments,
-                            })
-                        }
-                    };
+                    let (arguments, arguments_parse_error) =
+                        match serde_json::from_str::<serde_json::Value>(&tc.function.arguments) {
+                            Ok(v) => (v, None),
+                            Err(e) => {
+                                warn!(
+                                    tool = %tc.function.name,
+                                    id = %tc.id,
+                                    error = %e,
+                                    raw = %tc.function.arguments,
+                                    "invalid tool-call JSON arguments",
+                                );
+                                let err = super::ToolCallArgsError {
+                                    error: e.to_string(),
+                                    raw: truncate_for_echo(&tc.function.arguments, 512),
+                                };
+                                (serde_json::Value::Null, Some(err))
+                            }
+                        };
                     super::ToolCall {
                         id: tc.id,
                         name: tc.function.name,
                         arguments,
+                        arguments_parse_error,
                     }
                 })
                 .collect();
@@ -384,6 +386,7 @@ mod tests {
                 id: "X".to_string(),
                 name: "save_memory".to_string(),
                 arguments: serde_json::json!({"key": "k1", "fact": "f1"}),
+                arguments_parse_error: None,
             }],
             results: vec![ToolResultMessage {
                 tool_call_id: "X".to_string(),
@@ -396,6 +399,7 @@ mod tests {
                 id: "Y".to_string(),
                 name: "delete_memory".to_string(),
                 arguments: serde_json::json!({"key": "k2"}),
+                arguments_parse_error: None,
             }],
             results: vec![ToolResultMessage {
                 tool_call_id: "Y".to_string(),

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -142,6 +142,29 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
     messages
 }
 
+/// Parse the `arguments` string from an OpenAI-compatible tool call. Returns
+/// the parsed `Value` on success; on failure, returns `Value::Null` plus a
+/// `ToolCallArgsError` with the parse error and a truncated copy of the raw
+/// payload, and emits a `warn!` tracing event. Executors use the error to
+/// surface a useful tool-result to the model instead of silently dropping.
+fn parse_tool_call_arguments(
+    tool: &str,
+    id: &str,
+    raw: &str,
+) -> (serde_json::Value, Option<super::ToolCallArgsError>) {
+    match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(v) => (v, None),
+        Err(e) => {
+            warn!(tool, id, error = %e, raw, "invalid tool-call JSON arguments");
+            let err = super::ToolCallArgsError {
+                error: e.to_string(),
+                raw: truncate_for_echo(raw, 512),
+            };
+            (serde_json::Value::Null, Some(err))
+        }
+    }
+}
+
 // --- Client ---
 
 /// HTTP client for any OpenAI-compatible API (OpenRouter, OpenAI, etc.).
@@ -312,24 +335,11 @@ impl LlmClient for OpenAiClient {
             let calls = tool_calls
                 .into_iter()
                 .map(|tc| {
-                    let (arguments, arguments_parse_error) =
-                        match serde_json::from_str::<serde_json::Value>(&tc.function.arguments) {
-                            Ok(v) => (v, None),
-                            Err(e) => {
-                                warn!(
-                                    tool = %tc.function.name,
-                                    id = %tc.id,
-                                    error = %e,
-                                    raw = %tc.function.arguments,
-                                    "invalid tool-call JSON arguments",
-                                );
-                                let err = super::ToolCallArgsError {
-                                    error: e.to_string(),
-                                    raw: truncate_for_echo(&tc.function.arguments, 512),
-                                };
-                                (serde_json::Value::Null, Some(err))
-                            }
-                        };
+                    let (arguments, arguments_parse_error) = parse_tool_call_arguments(
+                        &tc.function.name,
+                        &tc.id,
+                        &tc.function.arguments,
+                    );
                     super::ToolCall {
                         id: tc.id,
                         name: tc.function.name,
@@ -443,5 +453,33 @@ mod tests {
         assert_eq!(msgs[5]["role"], "tool");
         assert_eq!(msgs[5]["tool_call_id"], "Y");
         assert_eq!(msgs[5]["content"], "Deleted memory 'k2'");
+    }
+
+    #[test]
+    fn parse_tool_call_arguments_valid_json_returns_value() {
+        let (args, err) =
+            parse_tool_call_arguments("save_memory", "X", r#"{"key":"k","fact":"f"}"#);
+        assert!(err.is_none());
+        assert_eq!(args, serde_json::json!({"key": "k", "fact": "f"}));
+    }
+
+    #[test]
+    fn parse_tool_call_arguments_malformed_json_returns_error() {
+        let raw = r#"{"key":"k" "fact":"f"}"#; // missing comma
+        let (args, err) = parse_tool_call_arguments("save_memory", "X", raw);
+        assert_eq!(args, serde_json::Value::Null);
+        let err = err.expect("parse error must be set");
+        assert!(!err.error.is_empty());
+        assert_eq!(err.raw, raw);
+    }
+
+    #[test]
+    fn parse_tool_call_arguments_truncates_oversized_raw() {
+        let raw = "x".repeat(1024);
+        let (_, err) = parse_tool_call_arguments("save_memory", "X", &raw);
+        let err = err.expect("parse error must be set");
+        assert!(err.raw.starts_with(&"x".repeat(512)));
+        assert!(err.raw.contains("more chars"));
+        assert!(err.raw.chars().count() < raw.chars().count());
     }
 }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr as _};
 use reqwest::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use super::{
     ChatCompletionRequest, LlmClient, ToolChatCompletionRequest, ToolChatCompletionResponse,
@@ -311,8 +311,24 @@ impl LlmClient for OpenAiClient {
             let calls = tool_calls
                 .into_iter()
                 .map(|tc| {
-                    let arguments: serde_json::Value =
-                        serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+                    let arguments = match serde_json::from_str::<serde_json::Value>(
+                        &tc.function.arguments,
+                    ) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            warn!(
+                                tool = %tc.function.name,
+                                id = %tc.id,
+                                error = %e,
+                                raw = %tc.function.arguments,
+                                "Tool call arguments were not valid JSON; surfacing parse error to model",
+                            );
+                            serde_json::json!({
+                                "__parse_error": e.to_string(),
+                                "__raw": tc.function.arguments,
+                            })
+                        }
+                    };
                     super::ToolCall {
                         id: tc.id,
                         name: tc.function.name,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -105,16 +105,13 @@ impl MemoryStore {
 
     /// Execute a single tool call against the store. Returns a result message.
     pub fn execute_tool_call(&mut self, call: &ToolCall, max_memories: usize) -> String {
-        if let Some(err) = call.arguments.get("__parse_error").and_then(|v| v.as_str()) {
-            let raw = call
-                .arguments
-                .get("__raw")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
+        if let Some(err) = &call.arguments_parse_error {
             return format!(
-                "Error: tool '{}' arguments were not valid JSON ({err}). Raw text: {raw}. \
-                 Resend with a valid JSON object.",
-                call.name
+                "Error: tool '{name}' arguments were not valid JSON ({error}). \
+                 Raw text: {raw}. Resend with a valid JSON object.",
+                name = call.name,
+                error = err.error,
+                raw = err.raw,
             );
         }
         match call.name.as_str() {
@@ -329,14 +326,15 @@ mod tests {
     }
 
     #[test]
-    fn execute_tool_call_surfaces_parse_error_sentinel() {
+    fn execute_tool_call_surfaces_parse_error() {
         let mut store = empty_store();
         let call = ToolCall {
             id: "c1".to_string(),
             name: "save_memory".to_string(),
-            arguments: serde_json::json!({
-                "__parse_error": "expected `,` or `}` at line 1 column 17",
-                "__raw": "{\"key\":\"k\" \"fact\":\"f\"}",
+            arguments: serde_json::Value::Null,
+            arguments_parse_error: Some(llm::ToolCallArgsError {
+                error: "expected `,` or `}` at line 1 column 17".to_string(),
+                raw: "{\"key\":\"k\" \"fact\":\"f\"}".to_string(),
             }),
         };
         let result = store.execute_tool_call(&call, 50);
@@ -353,6 +351,7 @@ mod tests {
             id: "c2".to_string(),
             name: "save_memory".to_string(),
             arguments: serde_json::Value::Null,
+            arguments_parse_error: None,
         };
         let result = store.execute_tool_call(&call, 50);
         assert!(

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -105,6 +105,18 @@ impl MemoryStore {
 
     /// Execute a single tool call against the store. Returns a result message.
     pub fn execute_tool_call(&mut self, call: &ToolCall, max_memories: usize) -> String {
+        if let Some(err) = call.arguments.get("__parse_error").and_then(|v| v.as_str()) {
+            let raw = call
+                .arguments
+                .get("__raw")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            return format!(
+                "Error: tool '{}' arguments were not valid JSON ({err}). Raw text: {raw}. \
+                 Resend with a valid JSON object.",
+                call.name
+            );
+        }
         match call.name.as_str() {
             "save_memory" => {
                 let key = call.arguments.get("key").and_then(|v| v.as_str());
@@ -304,4 +316,49 @@ async fn run_memory_extraction(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_store() -> MemoryStore {
+        MemoryStore {
+            memories: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn execute_tool_call_surfaces_parse_error_sentinel() {
+        let mut store = empty_store();
+        let call = ToolCall {
+            id: "c1".to_string(),
+            name: "save_memory".to_string(),
+            arguments: serde_json::json!({
+                "__parse_error": "expected `,` or `}` at line 1 column 17",
+                "__raw": "{\"key\":\"k\" \"fact\":\"f\"}",
+            }),
+        };
+        let result = store.execute_tool_call(&call, 50);
+        assert!(result.contains("not valid JSON"), "got: {result}");
+        assert!(result.contains("save_memory"), "got: {result}");
+        assert!(result.contains("{\"key\":\"k\""), "got: {result}");
+        assert!(store.memories.is_empty());
+    }
+
+    #[test]
+    fn execute_tool_call_missing_args_is_distinct_from_parse_error() {
+        let mut store = empty_store();
+        let call = ToolCall {
+            id: "c2".to_string(),
+            name: "save_memory".to_string(),
+            arguments: serde_json::Value::Null,
+        };
+        let result = store.execute_tool_call(&call, 50);
+        assert!(
+            result.contains("requires 'key' and 'fact'"),
+            "got: {result}"
+        );
+        assert!(!result.contains("not valid JSON"), "got: {result}");
+    }
 }

--- a/tests/ai.rs
+++ b/tests/ai.rs
@@ -123,6 +123,7 @@ async fn ai_command_saves_memory_extraction() {
                 "key": "alice_name",
                 "fact": "alice likes coffee"
             }),
+            arguments_parse_error: None,
         }]));
     // Memory extraction loop continues until the LLM stops returning tool calls.
     // Second round: return a plain message to terminate the loop.


### PR DESCRIPTION
Closes #19.

## Summary
- OpenAI tool-call arg parsing silently swallowed bad JSON via `unwrap_or_default()`, leaving `arguments = Value::Null`. `MemoryStore::execute_tool_call` then returned a generic "requires 'key' and 'fact'" message — same as a truly missing field — so the extraction round counted as successful and the malformed call was effectively dropped.
- Add a typed `arguments_parse_error: Option<ToolCallArgsError>` field on `ToolCall` (`src/llm/mod.rs`). On parse failure the OpenAI client populates it with the serde error and a truncated copy of the raw payload (and emits a `warn!` tracing event). `arguments` itself becomes `Value::Null`.
- `execute_tool_call` checks the typed field first and returns `"Error: tool '<name>' arguments were not valid JSON (<err>). Raw text: <raw>. Resend with a valid JSON object."` — giving the model specific feedback so it can retry.
- Ollama path untouched: native API returns `arguments` as a `Value`, so the field is always `None` there.
- Shared `truncate_for_echo(s, max_chars)` helper in `src/llm/mod.rs` caps the raw payload at 512 chars (char-boundary safe) before echoing back to the model, so a pathological blob can't inflate the next request's context.
- Parse logic extracted into a free `parse_tool_call_arguments` fn for direct unit testing.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all green. New coverage:
  - `memory::tests`: parse-error path produces informative result + leaves store untouched; null-args path remains distinct from parse-error path.
  - `llm::tests`: `truncate_for_echo` short pass-through, long trim, multibyte emoji (guards against mid-codepoint panic).
  - `openai::tests`: `parse_tool_call_arguments` valid JSON, malformed JSON, oversized raw truncation.