### PR TITLE
fix(1337): correct "Erwarungen" typo

### DIFF
--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -187,7 +187,7 @@ pub(crate) fn generate_stats_message(count: usize, user_list: &[String]) -> Stri
                 "verbesserungswürdig Waiting",
                 "unterdurchschnittlich Waiting",
                 "ausbaufähig Waiting",
-                "entspricht nicht ganz den Erwarungen Waiting",
+                "entspricht nicht ganz den Erwartungen Waiting",
                 "bemüht",
                 "anpassungsfähig YEP"
             ])


### PR DESCRIPTION
## Summary
- Fix German typo in 1337 stats message: `Erwarungen` → `Erwartungen` (missing `t`).
- Appears in `src/handlers/tracker_1337.rs:190`, one of the 2–3 user random stats lines.

Swept rest of codebase (German + English string literals, comments, config) — no other typos found.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)