### PR TITLE
fix(tls): install rustls ring CryptoProvider at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "random-flight",
  "reqwest 0.12.28",
  "ron",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls-webpki-roots",
 ] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 eyre = "0.6.12"
 tracing-error = "0.2.1"
 toml = "1.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod ping;
 pub mod prefill;
 pub mod suspend;
 pub mod telemetry;
+pub mod tls;
 pub mod token_storage;
 pub mod twitch_setup;
 pub mod util;
@@ -61,7 +62,8 @@ pub type AuthenticatedTwitchClient<
 
 pub use config::{load_configuration, validate_config};
 pub use handlers::tracker_1337::PersonalBest;
-pub use telemetry::{install_crypto_provider, install_tracing};
+pub use telemetry::install_tracing;
+pub use tls::install_crypto_provider;
 pub use token_storage::FileBasedTokenStorage;
 pub use twitch_setup::{setup_and_verify_twitch_client, setup_twitch_client};
 pub use util::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub type AuthenticatedTwitchClient<
 
 pub use config::{load_configuration, validate_config};
 pub use handlers::tracker_1337::PersonalBest;
-pub use telemetry::install_tracing;
+pub use telemetry::{install_crypto_provider, install_tracing};
 pub use token_storage::FileBasedTokenStorage;
 pub use twitch_setup::{setup_and_verify_twitch_client, setup_twitch_client};
 pub use util::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,15 @@ use color_eyre::eyre::Result;
 use tokio::sync::oneshot;
 use tracing::info;
 use twitch_1337::{
-    Services, aviation, clock::SystemClock, ensure_data_dir, get_data_dir, install_tracing, llm,
-    load_configuration, run_bot, setup_and_verify_twitch_client,
+    Services, aviation, clock::SystemClock, ensure_data_dir, get_data_dir, install_crypto_provider,
+    install_tracing, llm, load_configuration, run_bot, setup_and_verify_twitch_client,
 };
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
     color_eyre::install()?;
     install_tracing();
+    install_crypto_provider();
 
     let config = load_configuration().await?;
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -4,6 +4,19 @@ use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt};
 
+/// Install the `ring` rustls [`CryptoProvider`] as the process-wide default.
+///
+/// rustls 0.23 requires an explicit provider when its Cargo features pull in
+/// more than one (our dependency tree transitively enables both `ring` and
+/// `aws-lc-rs`), otherwise the first TLS handshake panics. Call once at
+/// program startup before any TLS client is built. Safe to call again — a
+/// second install is reported via the returned `Err` which we ignore.
+///
+/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+pub fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 /// Install the global tracing subscriber (format + env-filter + error layer).
 ///
 /// Call once at program startup before any spans are created.

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -4,19 +4,6 @@ use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt};
 
-/// Install the `ring` rustls [`CryptoProvider`] as the process-wide default.
-///
-/// rustls 0.23 requires an explicit provider when its Cargo features pull in
-/// more than one (our dependency tree transitively enables both `ring` and
-/// `aws-lc-rs`), otherwise the first TLS handshake panics. Call once at
-/// program startup before any TLS client is built. Safe to call again — a
-/// second install is reported via the returned `Err` which we ignore.
-///
-/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
-pub fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
-
 /// Install the global tracing subscriber (format + env-filter + error layer).
 ///
 /// Call once at program startup before any spans are created.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,13 @@
+//! Process-wide rustls configuration.
+
+/// Install the `ring` rustls [`CryptoProvider`] as the process-wide default.
+///
+/// Our dependency tree enables both `ring` (via this crate) and `aws-lc-rs`
+/// (transitively, through rustls' default features on other deps), so rustls
+/// 0.23 refuses to auto-pick and panics on the first TLS handshake. Pick one
+/// explicitly. Must run before any TLS client is built. Idempotent.
+///
+/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+pub fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}


### PR DESCRIPTION
## Summary
- Fixes #60: container panic on first TLS handshake (`Could not automatically determine the process-level CryptoProvider from Rustls crate features`).
- Root cause: `rustls 0.23` requires an explicit provider when more than one of its `ring` / `aws-lc-rs` features is enabled. Our tree pulls in both transitively (reqwest enables `ring`, `rustls-platform-verifier` enables `aws-lc-rs`), so rustls refuses to guess.
- Fix: add `rustls` as a direct dep with the `ring` feature and call `rustls::crypto::ring::default_provider().install_default()` from `main` before any TLS client is built. `ring` keeps the `FROM scratch` musl image pure-Rust (no C toolchain).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (all suites pass locally)
- [x] `cargo audit` (no advisories)
- [ ] Verify container boots past `setup_twitch_client` and joins channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)