### PR TITLE
Add slowest user to 1337 result message

### DIFF
--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -457,7 +457,6 @@ pub async fn run_1337_handler<T, L>(
                 .iter()
                 .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
                 .max_by_key(|(_, ms)| *ms);
-                // magie_023 as usual
 
             (count, user_vec, fastest, slowest)
         };

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -475,15 +475,12 @@ pub async fn run_1337_handler<T, L>(
                     message.push_str(" - neuer Rekord!");
                 }
             }
-
         }
 
         if let Some((slowest_user, slowest_ms)) = slowest
-            && fastest
-                .as_ref()
-                .is_none_or(|(fastest_user, fastest_ms)| {
-                    slowest_user != *fastest_user || slowest_ms != *fastest_ms
-                })
+            && fastest.as_ref().is_none_or(|(fastest_user, fastest_ms)| {
+                slowest_user != *fastest_user || slowest_ms != *fastest_ms
+            })
         {
             message.push_str(&format!(
                 " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -465,7 +465,7 @@ pub async fn run_1337_handler<T, L>(
             drop(leaderboard_guard);
 
             message.push_str(&format!(
-                " | {fastest_user} war mass schnellste mit {fastest_ms}ms"
+                " | {fastest_user} war am schnellsten mit {fastest_ms}ms"
             ));
             if is_record {
                 message.push_str(" - neuer Rekord!");

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -441,8 +441,8 @@ pub async fn run_1337_handler<T, L>(
         monitor_handle.abort();
         let _ = (&mut monitor_handle).await;
 
-        // Get user list, count, and fastest
-        let (count, user_list, fastest) = {
+        // Get user list, count, fastest, and slowest
+        let (count, user_list, fastest, slowest) = {
             let users = total_users.lock().await;
             let count = users.len();
             let mut user_vec: Vec<String> = users.keys().cloned().collect();
@@ -453,7 +453,12 @@ pub async fn run_1337_handler<T, L>(
                 .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
                 .min_by_key(|(_, ms)| *ms);
 
-            (count, user_vec, fastest)
+            let slowest: Option<(String, u64)> = users
+                .iter()
+                .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
+                .max_by_key(|(_, ms)| *ms);
+
+            (count, user_vec, fastest, slowest)
         };
 
         let mut message = generate_stats_message(count, &user_list);
@@ -469,6 +474,14 @@ pub async fn run_1337_handler<T, L>(
             ));
             if is_record {
                 message.push_str(" - neuer Rekord!");
+            }
+
+            if let Some((slowest_user, slowest_ms)) = slowest {
+                if slowest_user != *fastest_user || slowest_ms != fastest_ms {
+                    message.push_str(&format!(
+                        " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+                    ));
+                }
             }
         }
 

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -457,6 +457,7 @@ pub async fn run_1337_handler<T, L>(
                 .iter()
                 .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
                 .max_by_key(|(_, ms)| *ms);
+                // magie_023 as usual
 
             (count, user_vec, fastest, slowest)
         };

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -448,15 +448,12 @@ pub async fn run_1337_handler<T, L>(
             let mut user_vec: Vec<String> = users.keys().cloned().collect();
             user_vec.sort();
 
-            let fastest: Option<(String, u64)> = users
-                .iter()
-                .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
+            let timed_users = users.iter().map(|(name, ms)| (name.clone(), *ms));
+            let fastest: Option<(String, u64)> = timed_users
+                .clone()
+                .filter(|(_, ms)| *ms < 1000)
                 .min_by_key(|(_, ms)| *ms);
-
-            let slowest: Option<(String, u64)> = users
-                .iter()
-                .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
-                .max_by_key(|(_, ms)| *ms);
+            let slowest: Option<(String, u64)> = timed_users.max_by_key(|(_, ms)| *ms);
 
             (count, user_vec, fastest, slowest)
         };
@@ -464,25 +461,33 @@ pub async fn run_1337_handler<T, L>(
         let mut message = generate_stats_message(count, &user_list);
 
         if let Some((ref fastest_user, fastest_ms)) = fastest {
-            let leaderboard_guard = leaderboard.read().await;
-            let previous_pb = leaderboard_guard.get(fastest_user).map(|pb| pb.ms);
-            let is_record = previous_pb.is_none_or(|best| fastest_ms < best);
-            drop(leaderboard_guard);
-
             message.push_str(&format!(
-                " | {fastest_user} war am schnellsten mit {fastest_ms}ms"
+                " | {fastest_user} war mass schnellste mit {fastest_ms}ms"
             ));
-            if is_record {
-                message.push_str(" - neuer Rekord!");
+
+            if fastest_ms < 1000 {
+                let leaderboard_guard = leaderboard.read().await;
+                let previous_pb = leaderboard_guard.get(fastest_user).map(|pb| pb.ms);
+                let is_record = previous_pb.is_none_or(|best| fastest_ms < best);
+                drop(leaderboard_guard);
+
+                if is_record {
+                    message.push_str(" - neuer Rekord!");
+                }
             }
 
-            if let Some((slowest_user, slowest_ms)) = slowest
-                && (slowest_user != *fastest_user || slowest_ms != fastest_ms)
-            {
-                message.push_str(&format!(
-                    " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
-                ));
-            }
+        }
+
+        if let Some((slowest_user, slowest_ms)) = slowest
+            && fastest
+                .as_ref()
+                .is_none_or(|(fastest_user, fastest_ms)| {
+                    slowest_user != *fastest_user || slowest_ms != *fastest_ms
+                })
+        {
+            message.push_str(&format!(
+                " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+            ));
         }
 
         // Update leaderboard with today's sub-1s times
@@ -493,8 +498,8 @@ pub async fn run_1337_handler<T, L>(
         {
             let users = total_users.lock().await;
             let mut leaderboard_guard = leaderboard.write().await;
-            for (username, timing) in users.iter() {
-                if let Some(ms) = timing {
+            for (username, ms) in users.iter() {
+                if *ms < 1000 {
                     let update = match leaderboard_guard.get(username) {
                         Some(existing) => *ms < existing.ms,
                         None => true,

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -328,7 +328,7 @@ pub(crate) async fn save_leaderboard(
 #[instrument(skip(broadcast_rx, total_users))]
 pub(crate) async fn monitor_1337_messages(
     mut broadcast_rx: broadcast::Receiver<ServerMessage>,
-    total_users: Arc<Mutex<HashMap<String, Option<u64>>>>,
+    total_users: Arc<Mutex<HashMap<String, u64>>>,
 ) {
     loop {
         match broadcast_rx.recv().await {
@@ -354,11 +354,10 @@ pub(crate) async fn monitor_1337_messages(
                             + u64::from(local.timestamp_subsec_millis());
                         if ms_since_minute < 1000 {
                             debug!(user = %username, ms = ms_since_minute, "User said 1337 at 13:37 (sub-second)");
-                            users.insert(username, Some(ms_since_minute));
                         } else {
-                            debug!(user = %username, "User said 1337 at 13:37");
-                            users.insert(username, None);
+                            debug!(user = %username, ms = ms_since_minute, "User said 1337 at 13:37");
                         }
+                        users.insert(username, ms_since_minute);
                     }
                 }
             }

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -476,12 +476,12 @@ pub async fn run_1337_handler<T, L>(
                 message.push_str(" - neuer Rekord!");
             }
 
-            if let Some((slowest_user, slowest_ms)) = slowest {
-                if slowest_user != *fastest_user || slowest_ms != fastest_ms {
-                    message.push_str(&format!(
-                        " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
-                    ));
-                }
+            if let Some((slowest_user, slowest_ms)) = slowest
+                && (slowest_user != *fastest_user || slowest_ms != fastest_ms)
+            {
+                message.push_str(&format!(
+                    " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+                ));
             }
         }
 


### PR DESCRIPTION
This pull request enhances the statistics reporting in the `run_1337_handler` by including information about the slowest user in addition to the fastest. The update ensures that both ends of the performance spectrum are highlighted in the generated stats message.

**Enhancements to user stats reporting:**

* The handler now calculates and retrieves the slowest user and their response time, in addition to the fastest user. [[1]](diffhunk://#diff-633023963531befe20205509b8dbca7e5f69864e4f905be3e1f5f4bf3c6bedfcL444-R445) [[2]](diffhunk://#diff-633023963531befe20205509b8dbca7e5f69864e4f905be3e1f5f4bf3c6bedfcL456-R461)
* The stats message is updated to display the slowest user's name and time, provided they are not the same as the fastest user, giving a fuller picture of user performance.

**Minor improvements:**

* The message for the fastest user is reworded for clarity and correctness.