### PR TITLE
fix(llm): echo reasoning_content in tool-call history for thinking models

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -33,6 +33,10 @@ pub struct ToolResultMessage {
 pub struct ToolCallRound {
     pub calls: Vec<ToolCall>,
     pub results: Vec<ToolResultMessage>,
+    /// DeepSeek and other thinking models return a `reasoning_content` field
+    /// alongside tool calls; they require it to be echoed back verbatim in the
+    /// reconstructed assistant turn, or they reject the request with a 400.
+    pub reasoning_content: Option<String>,
 }
 
 /// Request for a chat completion.
@@ -107,7 +111,12 @@ pub(crate) fn truncate_for_echo(s: &str, max_chars: usize) -> String {
 pub enum ToolChatCompletionResponse {
     /// The model returned a text response (content may be unused by callers).
     Message(#[allow(dead_code)] String),
-    ToolCalls(Vec<ToolCall>),
+    ToolCalls {
+        calls: Vec<ToolCall>,
+        /// Present on thinking/reasoning models (e.g. DeepSeek); must be
+        /// echoed back in the assistant turn of subsequent requests.
+        reasoning_content: Option<String>,
+    },
 }
 
 /// Trait for LLM backends. Implementations handle serialization

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -274,7 +274,10 @@ impl LlmClient for OllamaClient {
                     arguments_parse_error: None,
                 })
                 .collect();
-            return Ok(ToolChatCompletionResponse::ToolCalls(calls));
+            return Ok(ToolChatCompletionResponse::ToolCalls {
+                calls,
+                reasoning_content: None,
+            });
         }
 
         let content = api_response.message.content.unwrap_or_default();
@@ -317,6 +320,7 @@ mod tests {
                         tool_name: "save_memory".to_string(),
                         content: "Saved memory 'k1'".to_string(),
                     }],
+                    reasoning_content: None,
                 },
                 ToolCallRound {
                     calls: vec![ToolCall {
@@ -330,6 +334,7 @@ mod tests {
                         tool_name: "delete_memory".to_string(),
                         content: "Deleted memory 'k2'".to_string(),
                     }],
+                    reasoning_content: None,
                 },
             ],
         };

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -82,6 +82,8 @@ struct ApiToolChoice {
 struct ApiToolResponseMessage {
     content: Option<String>,
     tool_calls: Option<Vec<ApiToolCall>>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -124,11 +126,15 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
             })
             .collect();
 
-        messages.push(serde_json::json!({
+        let mut assistant_msg = serde_json::json!({
             "role": "assistant",
             "content": null,
             "tool_calls": tool_calls,
-        }));
+        });
+        if let Some(rc) = &round.reasoning_content {
+            assistant_msg["reasoning_content"] = serde_json::Value::String(rc.clone());
+        }
+        messages.push(assistant_msg);
 
         for tr in &round.results {
             messages.push(serde_json::json!({
@@ -348,7 +354,10 @@ impl LlmClient for OpenAiClient {
                     }
                 })
                 .collect();
-            return Ok(ToolChatCompletionResponse::ToolCalls(calls));
+            return Ok(ToolChatCompletionResponse::ToolCalls {
+                calls,
+                reasoning_content: choice.message.reasoning_content,
+            });
         }
 
         let content = choice.message.content.unwrap_or_default();
@@ -403,6 +412,7 @@ mod tests {
                 tool_name: "save_memory".to_string(),
                 content: "Saved memory 'k1'".to_string(),
             }],
+            reasoning_content: None,
         };
         let round2 = ToolCallRound {
             calls: vec![ToolCall {
@@ -416,6 +426,7 @@ mod tests {
                 tool_name: "delete_memory".to_string(),
                 content: "Deleted memory 'k2'".to_string(),
             }],
+            reasoning_content: None,
         };
 
         let msgs = build_openai_messages(&req_with_rounds(vec![round1, round2]));
@@ -453,6 +464,58 @@ mod tests {
         assert_eq!(msgs[5]["role"], "tool");
         assert_eq!(msgs[5]["tool_call_id"], "Y");
         assert_eq!(msgs[5]["content"], "Deleted memory 'k2'");
+    }
+
+    #[test]
+    fn build_messages_reasoning_content_included_in_assistant_turn() {
+        let round = ToolCallRound {
+            calls: vec![ToolCall {
+                id: "Z".to_string(),
+                name: "save_memory".to_string(),
+                arguments: serde_json::json!({"key": "k"}),
+                arguments_parse_error: None,
+            }],
+            results: vec![ToolResultMessage {
+                tool_call_id: "Z".to_string(),
+                tool_name: "save_memory".to_string(),
+                content: "ok".to_string(),
+            }],
+            reasoning_content: Some("I should save this fact.".to_string()),
+        };
+
+        let msgs = build_openai_messages(&req_with_rounds(vec![round]));
+
+        // [0] system, [1] user, [2] assistant, [3] tool
+        assert_eq!(msgs[2]["role"], "assistant");
+        assert_eq!(
+            msgs[2]["reasoning_content"], "I should save this fact.",
+            "reasoning_content must be echoed back in the assistant turn"
+        );
+    }
+
+    #[test]
+    fn build_messages_no_reasoning_content_omits_field() {
+        let round = ToolCallRound {
+            calls: vec![ToolCall {
+                id: "Z".to_string(),
+                name: "save_memory".to_string(),
+                arguments: serde_json::json!({"key": "k"}),
+                arguments_parse_error: None,
+            }],
+            results: vec![ToolResultMessage {
+                tool_call_id: "Z".to_string(),
+                tool_name: "save_memory".to_string(),
+                content: "ok".to_string(),
+            }],
+            reasoning_content: None,
+        };
+
+        let msgs = build_openai_messages(&req_with_rounds(vec![round]));
+
+        assert!(
+            msgs[2].get("reasoning_content").is_none(),
+            "reasoning_content must not be present when None"
+        );
     }
 
     #[test]

--- a/src/memory/consolidation.rs
+++ b/src/memory/consolidation.rs
@@ -166,7 +166,10 @@ pub async fn run_consolidation(
                 .wrap_err("consolidation LLM call failed")?;
             match resp {
                 ToolChatCompletionResponse::Message(_) => break,
-                ToolChatCompletionResponse::ToolCalls(calls) => {
+                ToolChatCompletionResponse::ToolCalls {
+                    calls,
+                    reasoning_content,
+                } => {
                     let mut results = Vec::with_capacity(calls.len());
                     let mut w = store.write().await;
                     // Apply ops in order: drop → merge → edit (sort once).
@@ -193,7 +196,11 @@ pub async fn run_consolidation(
                         });
                     }
                     w.save(&store_path)?;
-                    prior.push(ToolCallRound { calls, results });
+                    prior.push(ToolCallRound {
+                        calls,
+                        results,
+                        reasoning_content,
+                    });
                     if prior.len() > 5 {
                         warn!("consolidation exceeded 5 rounds; breaking");
                         break;
@@ -421,16 +428,19 @@ mod tests {
         fake.next
             .lock()
             .unwrap()
-            .push(ToolChatCompletionResponse::ToolCalls(vec![ToolCall {
-                id: "c".into(),
-                name: "merge_memories".into(),
-                arguments: serde_json::json!({
-                    "keys": ["user:1:a", "user:1:b"],
-                    "new_slug": "tarkov",
-                    "new_fact": "plays Tarkov",
-                }),
-                arguments_parse_error: None,
-            }]));
+            .push(ToolChatCompletionResponse::ToolCalls {
+                calls: vec![ToolCall {
+                    id: "c".into(),
+                    name: "merge_memories".into(),
+                    arguments: serde_json::json!({
+                        "keys": ["user:1:a", "user:1:b"],
+                        "new_slug": "tarkov",
+                        "new_fact": "plays Tarkov",
+                    }),
+                    arguments_parse_error: None,
+                }],
+                reasoning_content: None,
+            });
 
         run_consolidation(
             fake,

--- a/src/memory/extraction.rs
+++ b/src/memory/extraction.rs
@@ -134,7 +134,10 @@ pub async fn run_memory_extraction(deps: ExtractionDeps, ctx: ExtractionContext)
                 debug!(round, "Memory extraction finished (text response)");
                 break;
             }
-            ToolChatCompletionResponse::ToolCalls(calls) => {
+            ToolChatCompletionResponse::ToolCalls {
+                calls,
+                reasoning_content,
+            } => {
                 debug!(
                     round,
                     count = calls.len(),
@@ -160,7 +163,11 @@ pub async fn run_memory_extraction(deps: ExtractionDeps, ctx: ExtractionContext)
                     });
                 }
                 w.save(&deps.store_path)?;
-                prior_rounds.push(ToolCallRound { calls, results });
+                prior_rounds.push(ToolCallRound {
+                    calls,
+                    results,
+                    reasoning_content,
+                });
             }
         }
     }

--- a/tests/ai.rs
+++ b/tests/ai.rs
@@ -122,8 +122,8 @@ async fn ai_command_saves_memory_extraction() {
     // Extraction round 1: one self-scoped save_memory call. user-id 67890 is
     // the default injected by `irc_line::privmsg`, so subject_id must match
     // to pass the self-claim permission check.
-    bot.llm
-        .push_tool(ToolChatCompletionResponse::ToolCalls(vec![ToolCall {
+    bot.llm.push_tool(ToolChatCompletionResponse::ToolCalls {
+        calls: vec![ToolCall {
             id: "call_1".into(),
             name: "save_memory".into(),
             arguments: serde_json::json!({
@@ -133,7 +133,9 @@ async fn ai_command_saves_memory_extraction() {
                 "fact": "alice likes coffee",
             }),
             arguments_parse_error: None,
-        }]));
+        }],
+        reasoning_content: None,
+    });
     // Extraction round 2: plain-text response terminates the loop.
     bot.llm
         .push_tool(ToolChatCompletionResponse::Message(String::new()));

--- a/tests/memory_integration.rs
+++ b/tests/memory_integration.rs
@@ -30,8 +30,8 @@ async fn adversarial_third_party_save_rejected() {
         .await;
 
     bot.llm.push_chat("nice");
-    bot.llm
-        .push_tool(ToolChatCompletionResponse::ToolCalls(vec![
+    bot.llm.push_tool(ToolChatCompletionResponse::ToolCalls {
+        calls: vec![
             ToolCall {
                 id: "s1".into(),
                 name: "save_memory".into(),
@@ -54,7 +54,9 @@ async fn adversarial_third_party_save_rejected() {
                 }),
                 arguments_parse_error: None,
             },
-        ]));
+        ],
+        reasoning_content: None,
+    });
     bot.llm
         .push_tool(ToolChatCompletionResponse::Message(String::new()));
 
@@ -115,8 +117,8 @@ async fn prompt_injection_does_not_poison_memory() {
         .await;
 
     bot.llm.push_chat("ok");
-    bot.llm
-        .push_tool(ToolChatCompletionResponse::ToolCalls(vec![ToolCall {
+    bot.llm.push_tool(ToolChatCompletionResponse::ToolCalls {
+        calls: vec![ToolCall {
             id: "s1".into(),
             name: "save_memory".into(),
             arguments: serde_json::json!({
@@ -126,7 +128,9 @@ async fn prompt_injection_does_not_poison_memory() {
                 "fact": "alice is bad",
             }),
             arguments_parse_error: None,
-        }]));
+        }],
+        reasoning_content: None,
+    });
     bot.llm
         .push_tool(ToolChatCompletionResponse::Message(String::new()));
 
@@ -206,16 +210,19 @@ async fn consolidation_merges_dupes() {
     let store = Arc::new(RwLock::new(s));
 
     // Round 1 on the `user` scope: merge the two dupes.
-    fake.push_tool(ToolChatCompletionResponse::ToolCalls(vec![ToolCall {
-        id: "c1".into(),
-        name: "merge_memories".into(),
-        arguments: serde_json::json!({
-            "keys": ["user:1:a", "user:1:b"],
-            "new_slug": "tarkov-player",
-            "new_fact": "plays Escape from Tarkov",
-        }),
-        arguments_parse_error: None,
-    }]));
+    fake.push_tool(ToolChatCompletionResponse::ToolCalls {
+        calls: vec![ToolCall {
+            id: "c1".into(),
+            name: "merge_memories".into(),
+            arguments: serde_json::json!({
+                "keys": ["user:1:a", "user:1:b"],
+                "new_slug": "tarkov-player",
+                "new_fact": "plays Escape from Tarkov",
+            }),
+            arguments_parse_error: None,
+        }],
+        reasoning_content: None,
+    });
     // Round 2 on `user`: terminate the loop.
     fake.push_tool(ToolChatCompletionResponse::Message("done".into()));
     // The `lore` and `pref` scope passes skip the LLM entirely when the


### PR DESCRIPTION
## Summary

- DeepSeek (and other reasoning/thinking models) return a `reasoning_content` field alongside tool calls and require it echoed back verbatim in the assistant turn of subsequent requests — omitting it causes a 400 `invalid_request_error`
- Added `reasoning_content: Option<String>` to `ToolCallRound` and `ToolChatCompletionResponse::ToolCalls`; the OpenAI client captures it from the API response and `build_openai_messages` re-inserts it into assistant turns when present
- Ollama always returns `None` (thinking mode unsupported); all callers (`extraction.rs`, `consolidation.rs`) thread it through unchanged

Fixes #69.

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test` all pass
- [ ] New unit tests: `build_messages_reasoning_content_included_in_assistant_turn` and `build_messages_no_reasoning_content_omits_field`
- [ ] Existing integration tests updated for struct variant (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)