### PR TITLE
fix(llm): handle 2xx error bodies from OpenAI-compatible APIs

### DIFF
--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -165,6 +165,15 @@ fn parse_tool_call_arguments(
     }
 }
 
+/// Extract the error message from a 2xx response body that carries an API-level
+/// error (e.g. OpenRouter rate-limit: `{"error":{"message":"..."}}`).
+fn extract_api_error(body: &serde_json::Value) -> Option<String> {
+    body.get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+        .map(str::to_owned)
+}
+
 // --- Client ---
 
 /// HTTP client for any OpenAI-compatible API (OpenRouter, OpenAI, etc.).
@@ -253,9 +262,14 @@ impl LlmClient for OpenAiClient {
             ));
         }
 
-        let api_response: ApiResponse = response
+        let body: serde_json::Value = response
             .json()
             .await
+            .wrap_err("Failed to parse OpenAI-compatible API response")?;
+        if let Some(msg) = extract_api_error(&body) {
+            return Err(eyre::eyre!("OpenAI-compatible API error: {}", msg));
+        }
+        let api_response: ApiResponse = serde_json::from_value(body)
             .wrap_err("Failed to parse OpenAI-compatible API response")?;
 
         let choice = api_response
@@ -318,9 +332,14 @@ impl LlmClient for OpenAiClient {
             ));
         }
 
-        let api_response: ApiToolResponse = response
+        let body: serde_json::Value = response
             .json()
             .await
+            .wrap_err("Failed to parse OpenAI-compatible API tool response")?;
+        if let Some(msg) = extract_api_error(&body) {
+            return Err(eyre::eyre!("OpenAI-compatible API error: {}", msg));
+        }
+        let api_response: ApiToolResponse = serde_json::from_value(body)
             .wrap_err("Failed to parse OpenAI-compatible API tool response")?;
 
         let choice = api_response
@@ -471,6 +490,21 @@ mod tests {
         let err = err.expect("parse error must be set");
         assert!(!err.error.is_empty());
         assert_eq!(err.raw, raw);
+    }
+
+    #[test]
+    fn extract_api_error_returns_message_for_error_body() {
+        let body = serde_json::json!({"error": {"message": "rate limit exceeded", "type": "rate_limit_error"}});
+        assert_eq!(
+            extract_api_error(&body).as_deref(),
+            Some("rate limit exceeded")
+        );
+    }
+
+    #[test]
+    fn extract_api_error_returns_none_for_choices_body() {
+        let body = serde_json::json!({"choices": [{"message": {"content": "hi"}}]});
+        assert!(extract_api_error(&body).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Some providers (e.g. OpenRouter under rate-limit) return HTTP 200 with `{"error":{"message":"..."}}` instead of `{"choices":[...]}`, causing a confusing `missing field \`choices\`` serde parse failure logged as a non-critical memory extraction warning
- Add `extract_api_error` helper that inspects the `serde_json::Value` body before typed deserialization; propagates the actual provider error message
- Applied symmetrically to both `chat_completion` and `chat_completion_with_tools`

## Test plan

- [ ] `cargo test --lib llm::openai` — 7 tests pass (2 new: `extract_api_error_returns_message_for_error_body`, `extract_api_error_returns_none_for_choices_body`)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Verify memory extraction warnings now show the actual API error message instead of a serde parse failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)