### PR TITLE
refactor(config): move memory_enabled into [ai.memory], rename timeout_secs to timeout

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -59,7 +59,6 @@ client_secret = "your_client_secret"
 # instruction_template = "{chat_history}\n{message}" # Use {message} and {chat_history} as placeholders
 # timeout = 30                                        # Optional, AI request timeout in seconds (default: 30)
 # history_length = 10                                # Optional, number of chat messages to keep as context (0 = disabled, max 100)
-# memory_enabled = false                             # Enable persistent AI memory (default: false)
 # max_memories = 50                                  # DEPRECATED: use [ai.memory] max_user instead (kept for back-compat)
 #
 # Optional: Prefill chat history from a log API at startup
@@ -78,7 +77,6 @@ client_secret = "your_client_secret"
 # instruction_template = "{chat_history}\n{message}" # Use {message} and {chat_history} as placeholders
 # timeout = 30                                        # Optional, AI request timeout in seconds (default: 30)
 # history_length = 10                                # Optional, number of chat messages to keep as context (0 = disabled, max 100)
-# memory_enabled = false                             # Enable persistent AI memory (default: false)
 # max_memories = 50                                  # DEPRECATED: use [ai.memory] max_user instead (kept for back-compat)
 #
 # Optional: Prefill chat history from a log API at startup
@@ -106,28 +104,29 @@ client_secret = "your_client_secret"
 # When a scope is full, the lowest-scoring entry (across all users in that
 # scope) is evicted. Score combines confidence × exp-decay × hit-boost.
 # [ai.memory]
-# max_user = 50          # total User-scope entries (all users combined)
+# enabled        = false         # Enable persistent AI memory (default: false)
+# max_user = 50                  # total User-scope entries (all users combined)
 # max_lore = 50
-# max_pref = 50          # total Pref-scope entries (all users combined)
-# half_life_days = 30    # exponential decay; feeds the eviction score
+# max_pref = 50                  # total Pref-scope entries (all users combined)
+# half_life_days = 30            # exponential decay; feeds the eviction score
 
 # Extractor: runs after every !ai turn to propose new memories. Tool-call
 # reliability matters here — a small model that mangles JSON will silently
 # under-perform. Recommend a mid-sized tool-capable model.
 # [ai.extraction]
-# enabled      = true
-# model        = "qwen2.5:14b"   # fallback → [ai].model
-# timeout_secs = 30
-# max_rounds   = 3
+# enabled    = true
+# model      = "qwen2.5:14b"   # fallback → [ai].model
+# timeout    = 30
+# max_rounds = 3
 
 # Consolidator: runs once per day, curates the whole store (merge duplicates,
 # drop contradictions, adjust confidence). Quality matters more than speed,
 # so use the strongest model you can afford here.
 # [ai.consolidation]
-# enabled      = true
-# model        = "gpt-5"         # fallback → [ai.extraction].model → [ai].model
-# run_at       = "04:00"         # HH:MM in Europe/Berlin
-# timeout_secs = 120
+# enabled  = true
+# model    = "gpt-5"           # fallback → [ai.extraction].model → [ai].model
+# run_at   = "04:00"           # HH:MM in Europe/Berlin
+# timeout  = 120
 
 # Optional: Scheduled messages configuration
 # Add [[schedules]] sections to define scheduled messages.

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,9 @@ fn default_consolidation_timeout() -> u64 {
 /// `[ai.memory]` in `config.toml.example`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MemoryConfigSection {
+    /// Enable persistent AI memory (default: false)
+    #[serde(default)]
+    pub enabled: bool,
     #[serde(default = "default_max_user")]
     pub max_user: usize,
     #[serde(default = "default_max_lore")]
@@ -98,6 +101,7 @@ pub struct MemoryConfigSection {
 impl Default for MemoryConfigSection {
     fn default() -> Self {
         Self {
+            enabled: false,
             max_user: default_max_user(),
             max_lore: default_max_lore(),
             max_pref: default_max_pref(),
@@ -106,7 +110,7 @@ impl Default for MemoryConfigSection {
     }
 }
 
-/// Knobs for the per-turn memory extractor. `model` / `timeout_secs` fall back
+/// Knobs for the per-turn memory extractor. `model` / `timeout` fall back
 /// to the main `[ai]` values when omitted. See `[ai.extraction]`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExtractionConfigSection {
@@ -115,7 +119,7 @@ pub struct ExtractionConfigSection {
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
-    pub timeout_secs: Option<u64>,
+    pub timeout: Option<u64>,
     #[serde(default = "default_max_rounds")]
     pub max_rounds: usize,
 }
@@ -125,7 +129,7 @@ impl Default for ExtractionConfigSection {
         Self {
             enabled: true,
             model: None,
-            timeout_secs: None,
+            timeout: None,
             max_rounds: default_max_rounds(),
         }
     }
@@ -141,7 +145,7 @@ pub struct ConsolidationConfigSection {
     #[serde(default = "default_run_at")]
     pub run_at: String,
     #[serde(default = "default_consolidation_timeout")]
-    pub timeout_secs: u64,
+    pub timeout: u64,
 }
 
 impl Default for ConsolidationConfigSection {
@@ -150,7 +154,7 @@ impl Default for ConsolidationConfigSection {
             enabled: true,
             model: None,
             run_at: default_run_at(),
-            timeout_secs: default_consolidation_timeout(),
+            timeout: default_consolidation_timeout(),
         }
     }
 }
@@ -182,9 +186,6 @@ pub struct AiConfig {
     /// Optional: Prefill chat history from a rustlog-compatible API at startup
     #[serde(default)]
     pub history_prefill: Option<prefill::HistoryPrefillConfig>,
-    /// Enable persistent AI memory (default: false)
-    #[serde(default)]
-    pub memory_enabled: bool,
     /// Per-scope caps + decay for the memory store.
     #[serde(default)]
     pub memory: MemoryConfigSection,
@@ -438,7 +439,7 @@ pub fn validate_config(config: &Configuration) -> Result<()> {
     }
 
     if let Some(ref ai) = config.ai
-        && ai.memory_enabled
+        && ai.memory.enabled
         && let Some(n) = ai.max_memories
         && !(1..=200).contains(&n)
     {
@@ -498,7 +499,6 @@ mod tests {
             timeout: default_ai_timeout(),
             history_length: 0,
             history_prefill: None,
-            memory_enabled: false,
             memory: MemoryConfigSection::default(),
             extraction: ExtractionConfigSection::default(),
             consolidation: ConsolidationConfigSection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ where
     // model; consolidation falls back to extraction and then to chat.
     let (ai_memory, consolidation_model): (Option<crate::commands::ai::AiMemory>, Option<String>) =
         match (&config.ai, &llm) {
-            (Some(ai), Some(llm_arc)) if ai.memory_enabled => {
+            (Some(ai), Some(llm_arc)) if ai.memory.enabled => {
                 let extraction_model = ai
                     .extraction
                     .model
@@ -237,7 +237,7 @@ where
                                 llm: llm_arc.clone(),
                                 model: extraction_model,
                                 timeout: Duration::from_secs(
-                                    ai.extraction.timeout_secs.unwrap_or(ai.timeout),
+                                    ai.extraction.timeout.unwrap_or(ai.timeout),
                                 ),
                                 max_rounds: ai.extraction.max_rounds,
                             },
@@ -340,7 +340,7 @@ where
             store,
             path,
             run_at,
-            Duration::from_secs(ai.timeout_secs),
+            Duration::from_secs(ai.timeout),
             shutdown_notify.clone(),
         );
         info!(

--- a/tests/ai.rs
+++ b/tests/ai.rs
@@ -111,7 +111,7 @@ async fn ai_command_saves_memory_extraction() {
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
-                ai.memory_enabled = true;
+                ai.memory.enabled = true;
             }
         })
         .spawn()

--- a/tests/common/test_bot.rs
+++ b/tests/common/test_bot.rs
@@ -68,7 +68,6 @@ impl TestBotBuilder {
                 timeout: 30,
                 history_length: 0,
                 history_prefill: None,
-                memory_enabled: false,
                 memory: twitch_1337::config::MemoryConfigSection::default(),
                 extraction: twitch_1337::config::ExtractionConfigSection::default(),
                 consolidation: twitch_1337::config::ConsolidationConfigSection::default(),

--- a/tests/memory_integration.rs
+++ b/tests/memory_integration.rs
@@ -23,7 +23,7 @@ async fn adversarial_third_party_save_rejected() {
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
-                ai.memory_enabled = true;
+                ai.memory.enabled = true;
             }
         })
         .spawn()
@@ -108,7 +108,7 @@ async fn prompt_injection_does_not_poison_memory() {
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
-                ai.memory_enabled = true;
+                ai.memory.enabled = true;
             }
         })
         .spawn()


### PR DESCRIPTION
## Summary

- `[ai].memory_enabled` → `[ai.memory].enabled` — co-located with the other memory caps instead of split across two sections
- `[ai.extraction].timeout_secs` → `[ai.extraction].timeout`
- `[ai.consolidation].timeout_secs` → `[ai.consolidation].timeout` — `_secs` suffix is redundant; unit is obvious from context

## Migration

Update any existing `config.toml`:

```toml
# Before
[ai]
memory_enabled = true

[ai.extraction]
timeout_secs = 30

[ai.consolidation]
timeout_secs = 120

# After
[ai.memory]
enabled = true

[ai.extraction]
timeout = 30

[ai.consolidation]
timeout = 120
```

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (all existing tests updated to new field names)
- [x] `config.toml.example` updated to reflect new schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)