### PR TITLE
feat(ai): include current time in prompt and timestamps in chat history

### DIFF
--- a/src/commands/ai.rs
+++ b/src/commands/ai.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use eyre::Result;
 use tracing::{debug, error, instrument};
 use twitch_irc::{login::LoginCredentials, transport::Transport};
@@ -130,29 +131,36 @@ where
 
         self.cooldown.record(user).await;
 
-        let system_prompt = if let Some(ref mem) = self.memory {
+        let now = Utc::now();
+        let facts = if let Some(ref mem) = self.memory {
             let mut store_guard = mem.config.store.write().await;
-            match store_guard.format_for_prompt(chrono::Utc::now()) {
-                Some(facts) => format!("{}{}", self.prompts.system, facts),
-                None => self.prompts.system.clone(),
-            }
+            store_guard.format_for_prompt(now).unwrap_or_default()
         } else {
-            self.prompts.system.clone()
+            String::new()
         };
+        let system_prompt = format!(
+            "{}{}\n\nCurrent time: {}",
+            self.prompts.system,
+            facts,
+            now.with_timezone(&chrono_tz::Europe::Berlin)
+                .format("%Y-%m-%d %H:%M %Z")
+        );
 
         let user_message = self
             .prompts
             .instruction_template
             .replace("{message}", &instruction);
 
-        // Build chat history string
         let chat_history_text = if let Some(ref chat) = self.chat_ctx {
             let buf = chat.history.lock().await;
             if buf.is_empty() {
                 String::new()
             } else {
                 buf.iter()
-                    .map(|(user, msg)| format!("{user}: {msg}"))
+                    .map(|(user, msg, ts)| {
+                        let ts_berlin = ts.with_timezone(&chrono_tz::Europe::Berlin);
+                        format!("[{}] {user}: {msg}", ts_berlin.format("%H:%M"))
+                    })
                     .collect::<Vec<_>>()
                     .join("\n")
             }
@@ -189,7 +197,7 @@ where
                     if buf.len() >= chat.history_length {
                         buf.pop_front();
                     }
-                    buf.push_back((chat.bot_username.clone(), truncated.clone()));
+                    buf.push_back((chat.bot_username.clone(), truncated.clone(), Utc::now()));
                 }
                 (truncated, true)
             }

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use chrono::Utc;
 use tokio::{sync::broadcast, time::Duration};
 use tracing::{debug, error, info, instrument};
 use twitch_irc::{
@@ -226,7 +227,11 @@ pub(crate) async fn run_command_dispatcher<T, L>(
                         if buf.len() >= history_length {
                             buf.pop_front();
                         }
-                        buf.push_back((privmsg.sender.login.clone(), privmsg.message_text.clone()));
+                        buf.push_back((
+                            privmsg.sender.login.clone(),
+                            privmsg.message_text.clone(),
+                            Utc::now(),
+                        ));
                     }
                 }
 

--- a/src/prefill.rs
+++ b/src/prefill.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use chrono::Datelike;
+use chrono::{DateTime, Datelike, Utc};
 use chrono_tz::Europe::Berlin;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
@@ -43,7 +43,7 @@ async fn fetch_messages_for_date(
     channel: &str,
     date: chrono::NaiveDate,
     limit: usize,
-) -> Vec<(String, String)> {
+) -> Vec<(String, String, DateTime<Utc>)> {
     let url = format!(
         "{}/channel/{}/{}/{}/{}?jsonBasic=1&limit={}&reverse=1",
         base_url.trim_end_matches('/'),
@@ -81,12 +81,14 @@ async fn fetch_messages_for_date(
         }
     };
 
-    // API returns newest-first with reverse=1, so reverse to get chronological order
+    // API returns newest-first with reverse=1, so reverse to get chronological order.
+    // Prefilled messages lack exact timestamps; use the fetch time as a proxy.
+    let fetched_at = Utc::now();
     log_response
         .messages
         .into_iter()
         .rev()
-        .map(|msg| (msg.display_name, msg.text))
+        .map(|msg| (msg.display_name, msg.text, fetched_at))
         .collect()
 }
 
@@ -103,7 +105,7 @@ pub async fn prefill_chat_history(
     channel: &str,
     history_length: usize,
     config: &HistoryPrefillConfig,
-) -> VecDeque<(String, String)> {
+) -> VecDeque<(String, String, DateTime<Utc>)> {
     let http = match reqwest::Client::builder().timeout(PREFILL_TIMEOUT).build() {
         Ok(client) => client,
         Err(e) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,8 +9,9 @@ pub static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CAR
 /// Maximum response length for Twitch chat (to stay within limits).
 pub const MAX_RESPONSE_LENGTH: usize = 500;
 
-/// Type alias for the shared chat history buffer (username, message text).
-pub type ChatHistory = Arc<tokio::sync::Mutex<VecDeque<(String, String)>>>;
+/// Type alias for the shared chat history buffer (username, message text, timestamp).
+pub type ChatHistory =
+    Arc<tokio::sync::Mutex<VecDeque<(String, String, chrono::DateTime<chrono::Utc>)>>>;
 
 /// Returns the data directory path, resolved from `$DATA_DIR` env var.
 ///


### PR DESCRIPTION
## Summary

- Appends current Berlin time (`YYYY-MM-DD HH:MM CET/CEST`) to every AI system prompt so the model always knows what time it is (closes #71)
- Extends `ChatHistory` tuple with `DateTime<Utc>`; live messages are stamped on arrival, prefilled messages use fetch time as a proxy
- Chat history entries are now formatted as `[HH:MM] user: msg` (Berlin timezone) in the prompt

## Test plan

- [ ] Verify `!ai` response references correct time when asked ("what time is it?")
- [ ] Check chat history context shows `[HH:MM]` prefixes in logs (RUST_LOG=debug)
- [ ] CI: fmt + clippy + test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)