### PR TITLE
feat(news): implement !news command for summarizing Twitch chat history

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -35,6 +35,7 @@ client_secret = "your_client_secret"
 # Optional: Command cooldowns in seconds
 # [cooldowns]
 # ai = 30        # !ai command (default: 30)
+# news = 60      # !news command (default: 60)
 # up = 30        # !up command (default: 30)
 # feedback = 300 # !fb command (default: 300)
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod feedback;
 pub mod flights;
 pub mod flights_above;
 pub mod leaderboard;
+pub mod news;
 pub mod ping_admin;
 pub mod ping_trigger;
 pub mod random_flight;

--- a/src/commands/news.rs
+++ b/src/commands/news.rs
@@ -16,7 +16,7 @@ use super::{Command, CommandContext};
 
 const NEWS_SYSTEM_PROMPT: &str = "Du fasst Twitch-Chat-Verlaeufe knapp und hilfreich zusammen. Antworte auf Deutsch, erfinde keine Details und konzentriere dich auf Themen, Highlights und wichtige Antworten. Halte die Antwort kurz genug fuer eine einzelne Twitch-Chatnachricht.";
 const EMPTY_HISTORY_MESSAGE: &str =
-    "Ich habe noch keine Chat-Historie fuer eine Zusammenfassung FDM";
+    "Ich habe noch keine Chat-Historie für eine Zusammenfassung FDM";
 const NO_NEW_MESSAGES_MESSAGE: &str =
     "Seit deiner letzten Nachricht ist noch nichts Neues passiert FDM";
 

--- a/src/commands/news.rs
+++ b/src/commands/news.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use eyre::Result;
 use tracing::{debug, error, instrument};
 use twitch_irc::{login::LoginCredentials, transport::Transport};
@@ -51,7 +52,7 @@ impl NewsCommand {
             buf.iter().cloned().collect::<Vec<_>>()
         };
 
-        if snapshot.last().is_some_and(|(sender, msg)| {
+        if snapshot.last().is_some_and(|(sender, msg, _)| {
             sender.eq_ignore_ascii_case(user) && msg == current_message
         }) {
             snapshot.pop();
@@ -63,12 +64,12 @@ impl NewsCommand {
 
         let start = snapshot
             .iter()
-            .rposition(|(sender, _)| sender.eq_ignore_ascii_case(user))
+            .rposition(|(sender, _, _)| sender.eq_ignore_ascii_case(user))
             .map_or(0, |idx| idx + 1);
 
         let messages = snapshot[start..]
             .iter()
-            .map(|(sender, msg)| format!("{sender}: {msg}"))
+            .map(|(sender, msg, _)| format!("{sender}: {msg}"))
             .collect::<Vec<_>>();
 
         Some(messages)
@@ -171,7 +172,7 @@ where
             if buf.len() >= chat.history_length {
                 buf.pop_front();
             }
-            buf.push_back((chat.bot_username.clone(), response.clone()));
+            buf.push_back((chat.bot_username.clone(), response.clone(), Utc::now()));
         }
 
         if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, response).await {

--- a/src/commands/news.rs
+++ b/src/commands/news.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use eyre::Result;
+use tracing::{debug, error, instrument};
+use twitch_irc::{login::LoginCredentials, transport::Transport};
+
+use crate::commands::ai::ChatContext;
+use crate::cooldown::{PerUserCooldown, format_cooldown_remaining};
+use crate::llm::{ChatCompletionRequest, LlmClient, Message};
+use crate::util::{MAX_RESPONSE_LENGTH, truncate_response};
+
+use super::{Command, CommandContext};
+
+const NEWS_SYSTEM_PROMPT: &str = "Du fasst Twitch-Chat-Verlaeufe knapp und hilfreich zusammen. Antworte auf Deutsch, erfinde keine Details und konzentriere dich auf Themen, Highlights und wichtige Antworten. Halte die Antwort kurz genug fuer eine einzelne Twitch-Chatnachricht.";
+const EMPTY_HISTORY_MESSAGE: &str =
+    "Ich habe noch keine Chat-Historie fuer eine Zusammenfassung FDM";
+const NO_NEW_MESSAGES_MESSAGE: &str =
+    "Seit deiner letzten Nachricht ist noch nichts Neues passiert FDM";
+
+pub struct NewsCommand {
+    llm_client: Arc<dyn LlmClient>,
+    model: String,
+    cooldown: PerUserCooldown,
+    timeout: Duration,
+    chat_ctx: Option<ChatContext>,
+}
+
+impl NewsCommand {
+    pub fn new(
+        llm_client: Arc<dyn LlmClient>,
+        model: String,
+        timeout: Duration,
+        cooldown: Duration,
+        chat_ctx: Option<ChatContext>,
+    ) -> Self {
+        Self {
+            llm_client,
+            model,
+            cooldown: PerUserCooldown::new(cooldown),
+            timeout,
+            chat_ctx,
+        }
+    }
+
+    async fn relevant_history(&self, user: &str, current_message: &str) -> Option<Vec<String>> {
+        let chat = self.chat_ctx.as_ref()?;
+        let mut snapshot = {
+            let buf = chat.history.lock().await;
+            buf.iter().cloned().collect::<Vec<_>>()
+        };
+
+        if snapshot.last().is_some_and(|(sender, msg)| {
+            sender.eq_ignore_ascii_case(user) && msg == current_message
+        }) {
+            snapshot.pop();
+        }
+
+        if snapshot.is_empty() {
+            return None;
+        }
+
+        let start = snapshot
+            .iter()
+            .rposition(|(sender, _)| sender.eq_ignore_ascii_case(user))
+            .map_or(0, |idx| idx + 1);
+
+        let messages = snapshot[start..]
+            .iter()
+            .map(|(sender, msg)| format!("{sender}: {msg}"))
+            .collect::<Vec<_>>();
+
+        Some(messages)
+    }
+}
+
+#[async_trait]
+impl<T, L> Command<T, L> for NewsCommand
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    fn name(&self) -> &str {
+        "!news"
+    }
+
+    #[instrument(skip(self, ctx))]
+    async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()> {
+        let user = &ctx.privmsg.sender.login;
+
+        if let Some(remaining) = self.cooldown.check(user).await {
+            debug!(user = %user, remaining_secs = remaining.as_secs(), "News command on cooldown");
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(
+                    ctx.privmsg,
+                    format!(
+                        "Bitte warte noch {} Waiting",
+                        format_cooldown_remaining(remaining)
+                    ),
+                )
+                .await
+            {
+                error!(error = ?e, "Failed to send cooldown message");
+            }
+            return Ok(());
+        }
+
+        let Some(history_lines) = self.relevant_history(user, &ctx.privmsg.message_text).await
+        else {
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(ctx.privmsg, EMPTY_HISTORY_MESSAGE.to_string())
+                .await
+            {
+                error!(error = ?e, "Failed to send empty-history message");
+            }
+            return Ok(());
+        };
+
+        if history_lines.is_empty() {
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(ctx.privmsg, NO_NEW_MESSAGES_MESSAGE.to_string())
+                .await
+            {
+                error!(error = ?e, "Failed to send no-new-messages message");
+            }
+            return Ok(());
+        }
+
+        self.cooldown.record(user).await;
+
+        let user_message = format!(
+            "Fasse diesen Twitch-Chat seit der letzten Nachricht von {user} zusammen:\n{}",
+            history_lines.join("\n")
+        );
+
+        let request = ChatCompletionRequest {
+            model: self.model.clone(),
+            messages: vec![
+                Message {
+                    role: "system".to_string(),
+                    content: NEWS_SYSTEM_PROMPT.to_string(),
+                },
+                Message {
+                    role: "user".to_string(),
+                    content: user_message,
+                },
+            ],
+        };
+
+        let result =
+            tokio::time::timeout(self.timeout, self.llm_client.chat_completion(request)).await;
+
+        let (response, success) = match result {
+            Ok(Ok(text)) => (truncate_response(&text, MAX_RESPONSE_LENGTH), true),
+            Ok(Err(e)) => {
+                error!(error = ?e, "News AI execution failed");
+                ("Da ist was schiefgelaufen FDM".to_string(), false)
+            }
+            Err(_) => {
+                error!("News AI execution timed out");
+                ("Das hat zu lange gedauert Waiting".to_string(), false)
+            }
+        };
+
+        if let (true, Some(chat)) = (success, &self.chat_ctx) {
+            let mut buf = chat.history.lock().await;
+            if buf.len() >= chat.history_length {
+                buf.pop_front();
+            }
+            buf.push_back((chat.bot_username.clone(), response.clone()));
+        }
+
+        if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, response).await {
+            error!(error = ?e, "Failed to send news response");
+        }
+
+        Ok(())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,10 @@ fn default_ai_cooldown() -> u64 {
     30
 }
 
+fn default_news_cooldown() -> u64 {
+    60
+}
+
 fn default_up_cooldown() -> u64 {
     30
 }
@@ -220,6 +224,8 @@ fn default_feedback_cooldown() -> u64 {
 pub struct CooldownsConfig {
     #[serde(default = "default_ai_cooldown")]
     pub ai: u64,
+    #[serde(default = "default_news_cooldown")]
+    pub news: u64,
     #[serde(default = "default_up_cooldown")]
     pub up: u64,
     #[serde(default = "default_feedback_cooldown")]
@@ -230,6 +236,7 @@ impl Default for CooldownsConfig {
     fn default() -> Self {
         Self {
             ai: default_ai_cooldown(),
+            news: default_news_cooldown(),
             up: default_up_cooldown(),
             feedback: default_feedback_cooldown(),
         }

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -179,15 +179,15 @@ where
 
         cmd_list.push(Box::new(commands::ai::AiCommand::new(
             commands::ai::AiCommandDeps {
-                llm_client: llm,
-                model: cfg.model,
+                llm_client: llm.clone(),
+                model: cfg.model.clone(),
                 prompts: commands::ai::AiPrompts {
                     system: cfg.system_prompt,
                     instruction_template: cfg.instruction_template,
                 },
                 timeout: Duration::from_secs(cfg.timeout),
                 cooldown: Duration::from_secs(cooldowns.ai),
-                chat_ctx,
+                chat_ctx: ai_chat_ctx,
                 memory: ai_memory,
                 emotes: emote_provider,
             },

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -147,7 +147,14 @@ where
     }
 
     if let Some((llm, cfg)) = llm_client {
-        let chat_ctx = chat_history
+        let ai_chat_ctx = chat_history
+            .clone()
+            .map(|history| commands::ai::ChatContext {
+                history,
+                history_length,
+                bot_username: bot_username.clone(),
+            });
+        let news_chat_ctx = chat_history
             .clone()
             .map(|history| commands::ai::ChatContext {
                 history,
@@ -156,16 +163,23 @@ where
             });
 
         cmd_list.push(Box::new(commands::ai::AiCommand::new(
-            llm,
-            cfg.model,
+            llm.clone(),
+            cfg.model.clone(),
             commands::ai::AiPrompts {
                 system: cfg.system_prompt,
                 instruction_template: cfg.instruction_template,
             },
             Duration::from_secs(cfg.timeout),
             Duration::from_secs(cooldowns.ai),
-            chat_ctx,
+            ai_chat_ctx,
             ai_memory,
+        )));
+        cmd_list.push(Box::new(commands::news::NewsCommand::new(
+            llm,
+            cfg.model,
+            Duration::from_secs(cfg.timeout),
+            Duration::from_secs(cooldowns.news),
+            news_chat_ctx,
         )));
     }
 

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -457,7 +457,6 @@ pub async fn run_1337_handler<T, L>(
                 .iter()
                 .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
                 .max_by_key(|(_, ms)| *ms);
-                // magie_023 as usual
 
             (count, user_vec, fastest, slowest)
         };

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -475,15 +475,12 @@ pub async fn run_1337_handler<T, L>(
                     message.push_str(" - neuer Rekord!");
                 }
             }
-
         }
 
         if let Some((slowest_user, slowest_ms)) = slowest
-            && fastest
-                .as_ref()
-                .is_none_or(|(fastest_user, fastest_ms)| {
-                    slowest_user != *fastest_user || slowest_ms != *fastest_ms
-                })
+            && fastest.as_ref().is_none_or(|(fastest_user, fastest_ms)| {
+                slowest_user != *fastest_user || slowest_ms != *fastest_ms
+            })
         {
             message.push_str(&format!(
                 " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -465,7 +465,7 @@ pub async fn run_1337_handler<T, L>(
             drop(leaderboard_guard);
 
             message.push_str(&format!(
-                " | {fastest_user} war mass schnellste mit {fastest_ms}ms"
+                " | {fastest_user} war am schnellsten mit {fastest_ms}ms"
             ));
             if is_record {
                 message.push_str(" - neuer Rekord!");

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -441,8 +441,8 @@ pub async fn run_1337_handler<T, L>(
         monitor_handle.abort();
         let _ = (&mut monitor_handle).await;
 
-        // Get user list, count, and fastest
-        let (count, user_list, fastest) = {
+        // Get user list, count, fastest, and slowest
+        let (count, user_list, fastest, slowest) = {
             let users = total_users.lock().await;
             let count = users.len();
             let mut user_vec: Vec<String> = users.keys().cloned().collect();
@@ -453,7 +453,12 @@ pub async fn run_1337_handler<T, L>(
                 .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
                 .min_by_key(|(_, ms)| *ms);
 
-            (count, user_vec, fastest)
+            let slowest: Option<(String, u64)> = users
+                .iter()
+                .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
+                .max_by_key(|(_, ms)| *ms);
+
+            (count, user_vec, fastest, slowest)
         };
 
         let mut message = generate_stats_message(count, &user_list);
@@ -469,6 +474,14 @@ pub async fn run_1337_handler<T, L>(
             ));
             if is_record {
                 message.push_str(" - neuer Rekord!");
+            }
+
+            if let Some((slowest_user, slowest_ms)) = slowest {
+                if slowest_user != *fastest_user || slowest_ms != fastest_ms {
+                    message.push_str(&format!(
+                        " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+                    ));
+                }
             }
         }
 

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -457,6 +457,7 @@ pub async fn run_1337_handler<T, L>(
                 .iter()
                 .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
                 .max_by_key(|(_, ms)| *ms);
+                // magie_023 as usual
 
             (count, user_vec, fastest, slowest)
         };

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -448,15 +448,12 @@ pub async fn run_1337_handler<T, L>(
             let mut user_vec: Vec<String> = users.keys().cloned().collect();
             user_vec.sort();
 
-            let fastest: Option<(String, u64)> = users
-                .iter()
-                .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
+            let timed_users = users.iter().map(|(name, ms)| (name.clone(), *ms));
+            let fastest: Option<(String, u64)> = timed_users
+                .clone()
+                .filter(|(_, ms)| *ms < 1000)
                 .min_by_key(|(_, ms)| *ms);
-
-            let slowest: Option<(String, u64)> = users
-                .iter()
-                .filter_map(|(name, ms)| ms.map(|ms| (name.clone(), ms)))
-                .max_by_key(|(_, ms)| *ms);
+            let slowest: Option<(String, u64)> = timed_users.max_by_key(|(_, ms)| *ms);
 
             (count, user_vec, fastest, slowest)
         };
@@ -464,25 +461,33 @@ pub async fn run_1337_handler<T, L>(
         let mut message = generate_stats_message(count, &user_list);
 
         if let Some((ref fastest_user, fastest_ms)) = fastest {
-            let leaderboard_guard = leaderboard.read().await;
-            let previous_pb = leaderboard_guard.get(fastest_user).map(|pb| pb.ms);
-            let is_record = previous_pb.is_none_or(|best| fastest_ms < best);
-            drop(leaderboard_guard);
-
             message.push_str(&format!(
-                " | {fastest_user} war am schnellsten mit {fastest_ms}ms"
+                " | {fastest_user} war mass schnellste mit {fastest_ms}ms"
             ));
-            if is_record {
-                message.push_str(" - neuer Rekord!");
+
+            if fastest_ms < 1000 {
+                let leaderboard_guard = leaderboard.read().await;
+                let previous_pb = leaderboard_guard.get(fastest_user).map(|pb| pb.ms);
+                let is_record = previous_pb.is_none_or(|best| fastest_ms < best);
+                drop(leaderboard_guard);
+
+                if is_record {
+                    message.push_str(" - neuer Rekord!");
+                }
             }
 
-            if let Some((slowest_user, slowest_ms)) = slowest
-                && (slowest_user != *fastest_user || slowest_ms != fastest_ms)
-            {
-                message.push_str(&format!(
-                    " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
-                ));
-            }
+        }
+
+        if let Some((slowest_user, slowest_ms)) = slowest
+            && fastest
+                .as_ref()
+                .is_none_or(|(fastest_user, fastest_ms)| {
+                    slowest_user != *fastest_user || slowest_ms != *fastest_ms
+                })
+        {
+            message.push_str(&format!(
+                " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+            ));
         }
 
         // Update leaderboard with today's sub-1s times
@@ -493,8 +498,8 @@ pub async fn run_1337_handler<T, L>(
         {
             let users = total_users.lock().await;
             let mut leaderboard_guard = leaderboard.write().await;
-            for (username, timing) in users.iter() {
-                if let Some(ms) = timing {
+            for (username, ms) in users.iter() {
+                if *ms < 1000 {
                     let update = match leaderboard_guard.get(username) {
                         Some(existing) => *ms < existing.ms,
                         None => true,

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -328,7 +328,7 @@ pub(crate) async fn save_leaderboard(
 #[instrument(skip(broadcast_rx, total_users))]
 pub(crate) async fn monitor_1337_messages(
     mut broadcast_rx: broadcast::Receiver<ServerMessage>,
-    total_users: Arc<Mutex<HashMap<String, Option<u64>>>>,
+    total_users: Arc<Mutex<HashMap<String, u64>>>,
 ) {
     loop {
         match broadcast_rx.recv().await {
@@ -354,11 +354,10 @@ pub(crate) async fn monitor_1337_messages(
                             + u64::from(local.timestamp_subsec_millis());
                         if ms_since_minute < 1000 {
                             debug!(user = %username, ms = ms_since_minute, "User said 1337 at 13:37 (sub-second)");
-                            users.insert(username, Some(ms_since_minute));
                         } else {
-                            debug!(user = %username, "User said 1337 at 13:37");
-                            users.insert(username, None);
+                            debug!(user = %username, ms = ms_since_minute, "User said 1337 at 13:37");
                         }
+                        users.insert(username, ms_since_minute);
                     }
                 }
             }

--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -476,12 +476,12 @@ pub async fn run_1337_handler<T, L>(
                 message.push_str(" - neuer Rekord!");
             }
 
-            if let Some((slowest_user, slowest_ms)) = slowest {
-                if slowest_user != *fastest_user || slowest_ms != fastest_ms {
-                    message.push_str(&format!(
-                        " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
-                    ));
-                }
+            if let Some((slowest_user, slowest_ms)) = slowest
+                && (slowest_user != *fastest_user || slowest_ms != fastest_ms)
+            {
+                message.push_str(&format!(
+                    " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+                ));
             }
         }
 

--- a/tests/news.rs
+++ b/tests/news.rs
@@ -1,0 +1,136 @@
+mod common;
+
+use std::time::Duration;
+
+use common::TestBotBuilder;
+use serial_test::serial;
+
+#[tokio::test]
+#[serial]
+async fn news_command_summarizes_since_previous_user_message() {
+    let mut bot = TestBotBuilder::new()
+        .with_ai()
+        .with_config(|c| {
+            if let Some(ai) = c.ai.as_mut() {
+                ai.history_length = 10;
+            }
+        })
+        .spawn()
+        .await;
+
+    bot.send("bob", "old topic before alice").await;
+    bot.send("alice", "ich bin kurz weg").await;
+    bot.send("carol", "first relevant update").await;
+    bot.send("dave", "second relevant update").await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    bot.llm.push_chat("carol und dave haben Updates gepostet");
+    bot.send("alice", "!news").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    let body = out.strip_prefix(". ").unwrap_or(&out);
+    assert_eq!(body, "carol und dave haben Updates gepostet");
+
+    let calls = bot.llm.chat_calls();
+    assert_eq!(calls.len(), 1, "expected exactly one chat completion call");
+    let user_msg = calls[0]
+        .messages
+        .iter()
+        .find(|m| m.role == "user")
+        .expect("request has a user message");
+
+    assert!(
+        user_msg.content.contains("carol: first relevant update"),
+        "missing relevant carol line: {}",
+        user_msg.content
+    );
+    assert!(
+        user_msg.content.contains("dave: second relevant update"),
+        "missing relevant dave line: {}",
+        user_msg.content
+    );
+    assert!(
+        !user_msg.content.contains("old topic before alice"),
+        "included message before alice's previous line: {}",
+        user_msg.content
+    );
+    assert!(
+        !user_msg.content.contains("!news"),
+        "included triggering command: {}",
+        user_msg.content
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn news_command_uses_full_history_without_previous_user_message() {
+    let mut bot = TestBotBuilder::new()
+        .with_ai()
+        .with_config(|c| {
+            if let Some(ai) = c.ai.as_mut() {
+                ai.history_length = 10;
+            }
+        })
+        .spawn()
+        .await;
+
+    bot.send("bob", "channel started talking").await;
+    bot.send("carol", "another update").await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    bot.llm.push_chat("der ganze Verlauf wurde zusammengefasst");
+    bot.send("alice", "!news").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    let body = out.strip_prefix(". ").unwrap_or(&out);
+    assert_eq!(body, "der ganze Verlauf wurde zusammengefasst");
+
+    let calls = bot.llm.chat_calls();
+    assert_eq!(calls.len(), 1, "expected exactly one chat completion call");
+    let user_msg = calls[0]
+        .messages
+        .iter()
+        .find(|m| m.role == "user")
+        .expect("request has a user message");
+
+    assert!(
+        user_msg.content.contains("bob: channel started talking"),
+        "missing first history line: {}",
+        user_msg.content
+    );
+    assert!(
+        user_msg.content.contains("carol: another update"),
+        "missing second history line: {}",
+        user_msg.content
+    );
+    assert!(
+        !user_msg.content.contains("!news"),
+        "included triggering command: {}",
+        user_msg.content
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn news_command_without_history_does_not_call_llm() {
+    let mut bot = TestBotBuilder::new().with_ai().spawn().await;
+
+    bot.send("bob", "this will not be recorded").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    bot.send("alice", "!news").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        out.contains("noch keine Chat-Historie"),
+        "unexpected empty-history reply: {out}"
+    );
+
+    let calls = bot.llm.chat_calls();
+    assert!(calls.is_empty(), "no LLM call expected, got: {calls:?}");
+
+    bot.shutdown().await;
+}


### PR DESCRIPTION
- Introduced the NewsCommand struct to handle the !news command, summarizing chat history since the last user message.
- Added cooldown management to prevent spam and ensure user-friendly interactions.
- Implemented relevant history retrieval and response generation using an LLM client.
- Included handling for cases with no chat history or new messages.
- Added unit tests to verify functionality, including summarization accuracy and LLM call behavior.