### PR TITLE
feat(ai): add per-workflow reasoning effort config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Optional behaviors:
 - **Chat history access** (`history_length`) -- recent main-channel messages are kept locally and exposed to the model through the `get_recent_chat` tool only when needed.
 - **Startup prefill** (`[ai.history_prefill]`) -- seeds the buffer from a rustlog-compatible log API so the bot has context right after restart.
 - **Persistent memory** (`memory_enabled`) -- the model itself decides what to remember across conversations via tool calls; facts stored in `data/ai_memory.ron`.
+- **Per-workflow reasoning effort** (`reasoning_effort`) -- optional hints for `!ai`, `[ai.extraction]`, and `[ai.consolidation]`; values are passed through verbatim because support differs by model/provider.
 - **7TV emote grounding** (`[ai.emotes]`) -- loads the current channel + optional global 7TV catalog, intersects it with a manual glossary, and injects only known emotes into the prompt.
 
 Per-user cooldown configurable via `[cooldowns].ai` (default 30s).

--- a/config.toml.example
+++ b/config.toml.example
@@ -59,6 +59,7 @@ client_secret = "your_client_secret"
 # system_prompt = "You are a helpful Twitch chat bot assistant. Keep responses brief (2-3 sentences max) since they'll appear in chat. Be friendly and casual. Respond in the same language the user writes in (German or English)."
 # instruction_template = "{message}"                  # Use {message} as the instruction placeholder
 # timeout = 30                                        # Optional, AI request timeout in seconds (default: 30)
+# reasoning_effort = "medium"                         # Optional reasoning hint for !ai. Keep provider/model-specific values as-is.
 # history_length = 200                               # Optional, local chat messages available via get_recent_chat (0 = disabled, max 5000)
 # memory_enabled = false                             # Enable persistent AI memory (default: false)
 # history_length = 10                                # Optional, number of chat messages to keep as context (0 = disabled, max 100)
@@ -95,6 +96,7 @@ client_secret = "your_client_secret"
 # system_prompt = "You are a helpful Twitch chat bot assistant. Keep responses brief (2-3 sentences max) since they'll appear in chat. Be friendly and casual. Respond in the same language the user writes in (German or English)."
 # instruction_template = "{message}"                  # Use {message} as the instruction placeholder
 # timeout = 30                                        # Optional, AI request timeout in seconds (default: 30)
+# reasoning_effort = "medium"                         # Optional reasoning hint for !ai. Keep provider/model-specific values as-is.
 # history_length = 200                               # Optional, local chat messages available via get_recent_chat (0 = disabled, max 5000)
 # memory_enabled = false                             # Enable persistent AI memory (default: false)
 # history_length = 10                                # Optional, number of chat messages to keep as context (0 = disabled, max 100)
@@ -136,6 +138,7 @@ client_secret = "your_client_secret"
 # [ai.extraction]
 # enabled    = true
 # model      = "qwen2.5:14b"   # fallback → [ai].model
+# reasoning_effort = "low"     # fallback → [ai].reasoning_effort
 # timeout    = 30
 # max_rounds = 3
 
@@ -145,6 +148,7 @@ client_secret = "your_client_secret"
 # [ai.consolidation]
 # enabled  = true
 # model    = "gpt-5"           # fallback → [ai.extraction].model → [ai].model
+# reasoning_effort = "high"    # fallback → [ai.extraction].reasoning_effort → [ai].reasoning_effort
 # run_at   = "04:00"           # HH:MM in Europe/Berlin
 # timeout  = 120
 

--- a/src/commands/ai.rs
+++ b/src/commands/ai.rs
@@ -40,6 +40,7 @@ pub struct AiExtractionDeps {
     pub enabled: bool,
     pub llm: Arc<dyn LlmClient>,
     pub model: String,
+    pub reasoning_effort: Option<String>,
     pub timeout: Duration,
     pub max_rounds: usize,
 }
@@ -58,6 +59,7 @@ pub struct AiCommand {
     cooldown: PerUserCooldown,
     prompts: AiPrompts,
     timeout: Duration,
+    reasoning_effort: Option<String>,
     chat_ctx: Option<ChatContext>,
     memory: Option<AiMemory>,
     emotes: Option<Arc<SevenTvEmoteProvider>>,
@@ -68,6 +70,7 @@ pub struct AiCommandDeps {
     pub model: String,
     pub prompts: AiPrompts,
     pub timeout: Duration,
+    pub reasoning_effort: Option<String>,
     pub cooldown: Duration,
     pub chat_ctx: Option<ChatContext>,
     pub memory: Option<AiMemory>,
@@ -90,6 +93,7 @@ impl AiCommand {
             cooldown: PerUserCooldown::new(deps.cooldown),
             prompts: deps.prompts,
             timeout: deps.timeout,
+            reasoning_effort: deps.reasoning_effort,
             chat_ctx: deps.chat_ctx,
             memory: deps.memory,
             emotes: deps.emotes,
@@ -105,6 +109,7 @@ impl AiCommand {
                 .chat_completion(ChatCompletionRequest {
                     model: self.model.clone(),
                     messages: build_base_messages(system_prompt, user_message),
+                    reasoning_effort: self.reasoning_effort.clone(),
                 })
                 .await
         }
@@ -124,6 +129,7 @@ impl AiCommand {
                 model: self.model.clone(),
                 messages: messages.clone(),
                 tools: tools.clone(),
+                reasoning_effort: self.reasoning_effort.clone(),
                 prior_rounds: prior_rounds.clone(),
             };
 
@@ -398,6 +404,7 @@ where
                 memory::ExtractionDeps {
                     llm: mem.extraction_deps.llm.clone(),
                     model: mem.extraction_deps.model.clone(),
+                    reasoning_effort: mem.extraction_deps.reasoning_effort.clone(),
                     store: mem.config.store.clone(),
                     store_path: mem.config.path.clone(),
                     caps: mem.config.caps.clone(),

--- a/src/commands/news.rs
+++ b/src/commands/news.rs
@@ -149,6 +149,7 @@ where
                     content: user_message,
                 },
             ],
+            reasoning_effort: None,
         };
 
         let result =

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,8 +126,9 @@ impl Default for MemoryConfigSection {
     }
 }
 
-/// Knobs for the per-turn memory extractor. `model` / `timeout` fall back
-/// to the main `[ai]` values when omitted. See `[ai.extraction]`.
+/// Knobs for the per-turn memory extractor. `model` / `timeout` /
+/// `reasoning_effort` fall back to the main `[ai]` values when omitted.
+/// See `[ai.extraction]`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExtractionConfigSection {
     #[serde(default = "default_true")]
@@ -136,6 +137,8 @@ pub struct ExtractionConfigSection {
     pub model: Option<String>,
     #[serde(default)]
     pub timeout: Option<u64>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
     #[serde(default = "default_max_rounds")]
     pub max_rounds: usize,
 }
@@ -146,18 +149,23 @@ impl Default for ExtractionConfigSection {
             enabled: true,
             model: None,
             timeout: None,
+            reasoning_effort: None,
             max_rounds: default_max_rounds(),
         }
     }
 }
 
-/// Knobs for the daily memory-consolidation pass. See `[ai.consolidation]`.
+/// Knobs for the daily memory-consolidation pass.
+/// `reasoning_effort` falls back to `[ai.extraction]` then `[ai]`.
+/// See `[ai.consolidation]`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConsolidationConfigSection {
     #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
     #[serde(default = "default_run_at")]
     pub run_at: String,
     #[serde(default = "default_consolidation_timeout")]
@@ -169,6 +177,7 @@ impl Default for ConsolidationConfigSection {
         Self {
             enabled: true,
             model: None,
+            reasoning_effort: None,
             run_at: default_run_at(),
             timeout: default_consolidation_timeout(),
         }
@@ -232,6 +241,9 @@ pub struct AiConfig {
     /// Timeout for AI requests in seconds (default: 30)
     #[serde(default = "default_ai_timeout")]
     pub timeout: u64,
+    /// Optional reasoning effort hint. Values are provider/model-specific.
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
     /// Number of recent chat messages to keep in the local tool-readable buffer.
     #[serde(default = "default_history_length")]
     pub history_length: u64,
@@ -253,6 +265,15 @@ pub struct AiConfig {
     /// Deprecated: replaced by `memory.max_user`. Logged as a warning if set.
     #[serde(default)]
     pub max_memories: Option<usize>,
+}
+
+fn validate_reasoning_effort(path: &str, value: Option<&str>) -> Result<()> {
+    if let Some(v) = value
+        && v.trim().is_empty()
+    {
+        bail!("{path} cannot be empty when specified");
+    }
+    Ok(())
 }
 
 fn default_cooldown() -> u64 {
@@ -509,6 +530,18 @@ pub fn validate_config(config: &Configuration) -> Result<()> {
         bail!("ai.max_memories must be between 1 and 200 (got {n})");
     }
 
+    if let Some(ref ai) = config.ai {
+        validate_reasoning_effort("ai.reasoning_effort", ai.reasoning_effort.as_deref())?;
+        validate_reasoning_effort(
+            "ai.extraction.reasoning_effort",
+            ai.extraction.reasoning_effort.as_deref(),
+        )?;
+        validate_reasoning_effort(
+            "ai.consolidation.reasoning_effort",
+            ai.consolidation.reasoning_effort.as_deref(),
+        )?;
+    }
+
     // Parsed again at scheduler spawn; bail here so a typo doesn't take the
     // bot down after startup.
     if let Some(ref ai) = config.ai {
@@ -582,6 +615,7 @@ mod tests {
             system_prompt: default_system_prompt(),
             instruction_template: default_instruction_template(),
             timeout: default_ai_timeout(),
+            reasoning_effort: None,
             history_length: default_history_length(),
             history_prefill: None,
             memory: MemoryConfigSection::default(),
@@ -687,6 +721,32 @@ mod tests {
         ai.emotes.glossary_path = "7tv_emotes.toml".into();
         ai.emotes.refresh_interval_secs = 60;
         ai.emotes.max_prompt_emotes = 40;
+        c.ai = Some(ai);
+
+        validate_config(&c).unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_empty_reasoning_effort() {
+        let mut c = Configuration::test_default();
+        let mut ai = ai_with_run_at("04:00");
+        ai.reasoning_effort = Some("   ".into());
+        c.ai = Some(ai);
+
+        let err = validate_config(&c).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("ai.reasoning_effort"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_non_empty_workflow_reasoning_effort() {
+        let mut c = Configuration::test_default();
+        let mut ai = ai_with_run_at("04:00");
+        ai.reasoning_effort = Some("medium".into());
+        ai.extraction.reasoning_effort = Some("low".into());
+        ai.consolidation.reasoning_effort = Some("high".into());
         c.ai = Some(ai);
 
         validate_config(&c).unwrap();

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -182,6 +182,7 @@ where
                     instruction_template: cfg.instruction_template,
                 },
                 timeout: Duration::from_secs(cfg.timeout),
+                reasoning_effort: cfg.reasoning_effort.clone(),
                 cooldown: Duration::from_secs(cooldowns.ai),
                 chat_ctx: ai_chat_ctx,
                 memory: ai_memory,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,76 +188,96 @@ where
 
     // Build the memory bundle once so both `!ai` (extraction) and the
     // daily consolidation task share the same store handle + path.
-    // Effective model resolution: extraction falls back to the main chat
-    // model; consolidation falls back to extraction and then to chat.
-    let (ai_memory, consolidation_model): (Option<crate::commands::ai::AiMemory>, Option<String>) =
-        match (&config.ai, &llm) {
-            (Some(ai), Some(llm_arc)) if ai.memory.enabled => {
-                let extraction_model = ai
-                    .extraction
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| ai.model.clone());
-                let consolidation_model = ai
-                    .consolidation
-                    .model
-                    .clone()
-                    .or_else(|| ai.extraction.model.clone())
-                    .unwrap_or_else(|| ai.model.clone());
-                match memory::MemoryStore::load(&data_dir) {
-                    Ok((store, path)) => {
-                        // Back-compat: honor the deprecated `ai.max_memories`
-                        // when the user hasn't overridden `[ai.memory].max_user`.
-                        // Either way, emit a warn! so stale configs surface.
-                        let max_user = if let Some(legacy_n) = ai.max_memories {
-                            if ai.memory.max_user == crate::config::default_max_user() {
-                                warn!(
-                                    "ai.max_memories is deprecated; migrating to [ai.memory].max_user = {}. Please update your config.",
-                                    legacy_n
-                                );
+    // Effective fallback resolution:
+    // - model: extraction -> [ai], consolidation -> extraction -> [ai]
+    // - reasoning_effort: extraction -> [ai], consolidation -> extraction -> [ai]
+    let (ai_memory, consolidation_model, consolidation_reasoning_effort): (
+        Option<crate::commands::ai::AiMemory>,
+        Option<String>,
+        Option<String>,
+    ) = match (&config.ai, &llm) {
+        (Some(ai), Some(llm_arc)) if ai.memory.enabled => {
+            let extraction_model = ai
+                .extraction
+                .model
+                .clone()
+                .unwrap_or_else(|| ai.model.clone());
+            let extraction_reasoning_effort = ai
+                .extraction
+                .reasoning_effort
+                .clone()
+                .or_else(|| ai.reasoning_effort.clone());
+            let consolidation_model = ai
+                .consolidation
+                .model
+                .clone()
+                .or_else(|| ai.extraction.model.clone())
+                .unwrap_or_else(|| ai.model.clone());
+            let consolidation_reasoning_effort = ai
+                .consolidation
+                .reasoning_effort
+                .clone()
+                .or_else(|| ai.extraction.reasoning_effort.clone())
+                .or_else(|| ai.reasoning_effort.clone());
+            match memory::MemoryStore::load(&data_dir) {
+                Ok((store, path)) => {
+                    // Back-compat: honor the deprecated `ai.max_memories`
+                    // when the user hasn't overridden `[ai.memory].max_user`.
+                    // Either way, emit a warn! so stale configs surface.
+                    let max_user = if let Some(legacy_n) = ai.max_memories {
+                        if ai.memory.max_user == crate::config::default_max_user() {
+                            warn!(
+                                "ai.max_memories is deprecated; migrating to [ai.memory].max_user = {}. Please update your config.",
                                 legacy_n
-                            } else {
-                                warn!(
-                                    "ai.max_memories={} is deprecated AND ignored because [ai.memory].max_user={} is explicitly set. Remove the deprecated field.",
-                                    legacy_n, ai.memory.max_user
-                                );
-                                ai.memory.max_user
-                            }
+                            );
+                            legacy_n
                         } else {
+                            warn!(
+                                "ai.max_memories={} is deprecated AND ignored because [ai.memory].max_user={} is explicitly set. Remove the deprecated field.",
+                                legacy_n, ai.memory.max_user
+                            );
                             ai.memory.max_user
-                        };
-                        let config = memory::MemoryConfig {
-                            store: Arc::new(tokio::sync::RwLock::new(store)),
-                            path,
-                            caps: memory::Caps {
-                                max_user,
-                                max_lore: ai.memory.max_lore,
-                                max_pref: ai.memory.max_pref,
-                            },
-                            half_life_days: ai.memory.half_life_days,
-                        };
-                        let ai_memory = crate::commands::ai::AiMemory {
-                            config,
-                            extraction_deps: crate::commands::ai::AiExtractionDeps {
-                                enabled: ai.extraction.enabled,
-                                llm: llm_arc.clone(),
-                                model: extraction_model,
-                                timeout: Duration::from_secs(
-                                    ai.extraction.timeout.unwrap_or(ai.timeout),
-                                ),
-                                max_rounds: ai.extraction.max_rounds,
-                            },
-                        };
-                        (Some(ai_memory), Some(consolidation_model))
-                    }
-                    Err(e) => {
-                        error!(error = ?e, "Failed to load AI memory store, memory disabled");
-                        (None, None)
-                    }
+                        }
+                    } else {
+                        ai.memory.max_user
+                    };
+                    let config = memory::MemoryConfig {
+                        store: Arc::new(tokio::sync::RwLock::new(store)),
+                        path,
+                        caps: memory::Caps {
+                            max_user,
+                            max_lore: ai.memory.max_lore,
+                            max_pref: ai.memory.max_pref,
+                        },
+                        half_life_days: ai.memory.half_life_days,
+                    };
+                    let ai_memory = crate::commands::ai::AiMemory {
+                        config,
+                        extraction_deps: crate::commands::ai::AiExtractionDeps {
+                            enabled: ai.extraction.enabled,
+                            llm: llm_arc.clone(),
+                            model: extraction_model,
+                            reasoning_effort: extraction_reasoning_effort,
+                            timeout: Duration::from_secs(
+                                ai.extraction.timeout.unwrap_or(ai.timeout),
+                            ),
+                            max_rounds: ai.extraction.max_rounds,
+                        },
+                    };
+                    (
+                        Some(ai_memory),
+                        Some(consolidation_model),
+                        consolidation_reasoning_effort,
+                    )
+                }
+                Err(e) => {
+                    error!(error = ?e, "Failed to load AI memory store, memory disabled");
+                    (None, None, None)
                 }
             }
-            _ => (None, None),
-        };
+        }
+        _ => (None, None, None),
+    };
 
     let latency = Arc::new(AtomicU32::new(config.twitch.expected_latency));
 
@@ -342,7 +362,10 @@ where
             .expect("ai.consolidation.run_at is validated at config load");
         memory::spawn_consolidation(
             llm_client,
-            model,
+            memory::consolidation::ConsolidationLlmConfig {
+                model,
+                reasoning_effort: consolidation_reasoning_effort,
+            },
             store,
             path,
             run_at,

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -44,6 +44,8 @@ pub struct ToolCallRound {
 pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<Message>,
+    /// Optional reasoning effort hint (provider/model-specific values).
+    pub reasoning_effort: Option<String>,
 }
 
 /// Request for a chat completion with tool support.
@@ -52,6 +54,8 @@ pub struct ToolChatCompletionRequest {
     pub model: String,
     pub messages: Vec<Message>,
     pub tools: Vec<ToolDefinition>,
+    /// Optional reasoning effort hint (provider/model-specific values).
+    pub reasoning_effort: Option<String>,
     /// Prior tool-call rounds, threaded back in order.
     pub prior_rounds: Vec<ToolCallRound>,
 }

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -307,6 +307,7 @@ mod tests {
                 },
             ],
             tools: vec![],
+            reasoning_effort: None,
             prior_rounds: vec![
                 ToolCallRound {
                     calls: vec![ToolCall {

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -22,6 +22,15 @@ struct ApiMessage {
 struct ApiRequest {
     model: String,
     messages: Vec<ApiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<ApiReasoning>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiReasoning {
+    effort: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,6 +68,10 @@ struct ApiToolRequest {
     model: String,
     messages: Vec<serde_json::Value>,
     tools: Vec<ApiTool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<ApiReasoning>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -188,15 +201,25 @@ pub struct OpenAiClient {
     http: reqwest::Client,
     base_url: String,
     model: String,
+    is_openrouter: bool,
 }
 
 const DEFAULT_BASE_URL: &str = "https://openrouter.ai/api/v1";
 
 impl OpenAiClient {
+    fn map_reasoning(&self, effort: Option<String>) -> (Option<String>, Option<ApiReasoning>) {
+        if self.is_openrouter {
+            (None, effort.map(|effort| ApiReasoning { effort }))
+        } else {
+            (effort, None)
+        }
+    }
+
     /// Creates a new OpenAI-compatible API client.
     #[instrument(skip(api_key))]
     pub fn new(api_key: &str, model: &str, base_url: Option<&str>) -> Result<Self> {
         let base_url = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
+        let is_openrouter = base_url.contains("openrouter.ai");
 
         let mut headers = header::HeaderMap::new();
         headers.insert(
@@ -226,6 +249,7 @@ impl OpenAiClient {
             http,
             base_url: base_url.to_string(),
             model: model.to_string(),
+            is_openrouter,
         })
     }
 }
@@ -236,16 +260,24 @@ impl LlmClient for OpenAiClient {
     async fn chat_completion(&self, request: ChatCompletionRequest) -> Result<String> {
         let url = format!("{}/chat/completions", self.base_url);
 
+        let ChatCompletionRequest {
+            model,
+            messages,
+            reasoning_effort,
+        } = request;
+        let (reasoning_effort, reasoning) = self.map_reasoning(reasoning_effort);
+
         let api_request = ApiRequest {
-            model: request.model,
-            messages: request
-                .messages
+            model,
+            messages: messages
                 .into_iter()
                 .map(|m| ApiMessage {
                     role: m.role,
                     content: m.content,
                 })
                 .collect(),
+            reasoning_effort,
+            reasoning,
         };
 
         debug!(model = %self.model, "Sending request to OpenAI-compatible API");
@@ -297,6 +329,23 @@ impl LlmClient for OpenAiClient {
     ) -> Result<ToolChatCompletionResponse> {
         let url = format!("{}/chat/completions", self.base_url);
 
+        let ToolChatCompletionRequest {
+            model,
+            messages,
+            tools,
+            reasoning_effort,
+            prior_rounds,
+        } = request;
+        let (reasoning_effort, reasoning) = self.map_reasoning(reasoning_effort);
+
+        let request = ToolChatCompletionRequest {
+            model,
+            messages,
+            tools,
+            reasoning_effort: None,
+            prior_rounds,
+        };
+
         let messages = build_openai_messages(&request);
 
         let tools: Vec<ApiTool> = request
@@ -316,6 +365,8 @@ impl LlmClient for OpenAiClient {
             model: request.model,
             messages,
             tools,
+            reasoning_effort,
+            reasoning,
         };
 
         debug!(model = %self.model, "Sending tool request to OpenAI-compatible API");
@@ -391,6 +442,15 @@ mod tests {
         Message, ToolCall, ToolCallRound, ToolChatCompletionRequest, ToolResultMessage,
     };
 
+    fn test_client(is_openrouter: bool) -> OpenAiClient {
+        OpenAiClient {
+            http: reqwest::Client::new(),
+            base_url: "https://example.test".to_string(),
+            model: "test-model".to_string(),
+            is_openrouter,
+        }
+    }
+
     fn req_with_rounds(rounds: Vec<ToolCallRound>) -> ToolChatCompletionRequest {
         ToolChatCompletionRequest {
             model: "test-model".to_string(),
@@ -405,6 +465,7 @@ mod tests {
                 },
             ],
             tools: vec![],
+            reasoning_effort: None,
             prior_rounds: rounds,
         }
     }
@@ -578,5 +639,22 @@ mod tests {
         assert!(err.raw.starts_with(&"x".repeat(512)));
         assert!(err.raw.contains("more chars"));
         assert!(err.raw.chars().count() < raw.chars().count());
+    }
+
+    #[test]
+    fn map_reasoning_openrouter_uses_nested_reasoning_object() {
+        let client = test_client(true);
+        let (reasoning_effort, reasoning) = client.map_reasoning(Some("high".to_string()));
+        assert!(reasoning_effort.is_none());
+        let reasoning = reasoning.expect("reasoning object must be set");
+        assert_eq!(reasoning.effort, "high");
+    }
+
+    #[test]
+    fn map_reasoning_non_openrouter_uses_reasoning_effort_field() {
+        let client = test_client(false);
+        let (reasoning_effort, reasoning) = client.map_reasoning(Some("xhigh".to_string()));
+        assert_eq!(reasoning_effort.as_deref(), Some("xhigh"));
+        assert!(reasoning.is_none());
     }
 }

--- a/src/memory/consolidation.rs
+++ b/src/memory/consolidation.rs
@@ -15,6 +15,12 @@ use crate::memory::Memory;
 use crate::memory::store::MemoryStore;
 use crate::memory::tools::consolidator_tools;
 
+#[derive(Clone)]
+pub struct ConsolidationLlmConfig {
+    pub model: String,
+    pub reasoning_effort: Option<String>,
+}
+
 /// Returns a list of `(key, reason)` tuples for memories flagged by the
 /// deterministic pre-filter: confidence below 10 and last access older than
 /// 60 days. Reported by the consolidation pass to the caller before any
@@ -76,7 +82,7 @@ pub fn corroboration_boost(m: &Memory) -> u8 {
 /// consolidated state.
 pub async fn run_consolidation(
     llm: Arc<dyn llm::LlmClient>,
-    model: String,
+    llm_config: ConsolidationLlmConfig,
     store: Arc<RwLock<MemoryStore>>,
     store_path: PathBuf,
     timeout: Duration,
@@ -146,7 +152,7 @@ pub async fn run_consolidation(
         let mut prior: Vec<ToolCallRound> = Vec::new();
         loop {
             let req = ToolChatCompletionRequest {
-                model: model.clone(),
+                model: llm_config.model.clone(),
                 messages: vec![
                     Message {
                         role: "system".into(),
@@ -158,6 +164,7 @@ pub async fn run_consolidation(
                     },
                 ],
                 tools: consolidator_tools(),
+                reasoning_effort: llm_config.reasoning_effort.clone(),
                 prior_rounds: prior.clone(),
             };
             let resp = tokio::time::timeout(timeout, llm.chat_completion_with_tools(req))
@@ -228,7 +235,7 @@ pub async fn run_consolidation(
 /// logged at `warn!` and do not kill the loop.
 pub fn spawn_consolidation(
     llm: Arc<dyn llm::LlmClient>,
-    model: String,
+    llm_config: ConsolidationLlmConfig,
     store: Arc<RwLock<MemoryStore>>,
     store_path: PathBuf,
     run_at: NaiveTime,
@@ -273,7 +280,7 @@ pub fn spawn_consolidation(
                 () = tokio::time::sleep(wait) => {
                     if let Err(e) = run_consolidation(
                         llm.clone(),
-                        model.clone(),
+                        llm_config.clone(),
                         store.clone(),
                         store_path.clone(),
                         timeout,
@@ -444,7 +451,10 @@ mod tests {
 
         run_consolidation(
             fake,
-            "fake-model".into(),
+            ConsolidationLlmConfig {
+                model: "fake-model".into(),
+                reasoning_effort: None,
+            },
             store.clone(),
             path.clone(),
             Duration::from_secs(5),

--- a/src/memory/extraction.rs
+++ b/src/memory/extraction.rs
@@ -40,6 +40,7 @@ pub struct ExtractionContext {
 pub struct ExtractionDeps {
     pub llm: Arc<dyn llm::LlmClient>,
     pub model: String,
+    pub reasoning_effort: Option<String>,
     pub store: Arc<RwLock<MemoryStore>>,
     pub store_path: PathBuf,
     pub caps: Caps,
@@ -123,6 +124,7 @@ pub async fn run_memory_extraction(deps: ExtractionDeps, ctx: ExtractionContext)
             model: deps.model.clone(),
             messages: messages.clone(),
             tools: tools.clone(),
+            reasoning_effort: deps.reasoning_effort.clone(),
             prior_rounds: prior_rounds.clone(),
         };
         let resp = tokio::time::timeout(deps.timeout, deps.llm.chat_completion_with_tools(req))

--- a/tests/common/test_bot.rs
+++ b/tests/common/test_bot.rs
@@ -67,6 +67,7 @@ impl TestBotBuilder {
                 system_prompt: "test prompt".into(),
                 instruction_template: "{message}".into(),
                 timeout: 30,
+                reasoning_effort: None,
                 history_length: twitch_1337::DEFAULT_HISTORY_LENGTH,
                 history_prefill: None,
                 memory: twitch_1337::config::MemoryConfigSection::default(),

--- a/tests/memory_integration.rs
+++ b/tests/memory_integration.rs
@@ -237,7 +237,10 @@ async fn consolidation_merges_dupes() {
 
     consolidation::run_consolidation(
         fake.clone() as Arc<dyn LlmClient>,
-        "fake-model".into(),
+        consolidation::ConsolidationLlmConfig {
+            model: "fake-model".into(),
+            reasoning_effort: None,
+        },
         store.clone(),
         path.clone(),
         Duration::from_secs(5),


### PR DESCRIPTION
## Summary
- Add optional `reasoning_effort` config for each AI workflow: chat (`[ai]`), extraction (`[ai.extraction]`), and consolidation (`[ai.consolidation]`), with fallback chaining across workflows.
- Thread reasoning effort through all LLM request paths and map provider-specific payloads: OpenAI-compatible APIs use `reasoning_effort`, while OpenRouter uses `reasoning: { effort }`.
- Keep values provider/model-specific via pass-through strings, add validation for non-empty values, and update docs/tests accordingly.

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test