### PR TITLE
Enhance tracker_1337 to filter and display slowest user times

### DIFF
--- a/src/handlers/tracker_1337.rs
+++ b/src/handlers/tracker_1337.rs
@@ -30,6 +30,8 @@ use crate::{clock::Clock, resolve_berlin_time};
 pub const TARGET_HOUR: u32 = 13;
 pub const TARGET_MINUTE: u32 = 37;
 
+const SLOWEST_CHATTER_MIN_MS: u64 = 50_000;
+
 /// Maximum number of unique users to track (prevents unbounded memory growth)
 pub(crate) const MAX_USERS: usize = 10_000;
 
@@ -452,7 +454,9 @@ pub async fn run_1337_handler<T, L>(
                 .clone()
                 .filter(|(_, ms)| *ms < 1000)
                 .min_by_key(|(_, ms)| *ms);
-            let slowest: Option<(String, u64)> = timed_users.max_by_key(|(_, ms)| *ms);
+            let slowest: Option<(String, u64)> = timed_users
+                .filter(|(_, ms)| *ms >= SLOWEST_CHATTER_MIN_MS)
+                .max_by_key(|(_, ms)| *ms);
 
             (count, user_vec, fastest, slowest)
         };
@@ -481,8 +485,9 @@ pub async fn run_1337_handler<T, L>(
                 slowest_user != *fastest_user || slowest_ms != *fastest_ms
             })
         {
+            let slowest_seconds = slowest_ms / 1000;
             message.push_str(&format!(
-                " | Am langsamsten war {slowest_user} mit {slowest_ms}ms"
+                " | Am langsamsten war {slowest_user} mit {slowest_seconds}s"
             ));
         }
 

--- a/tests/tracker_1337.rs
+++ b/tests/tracker_1337.rs
@@ -131,6 +131,92 @@ async fn tracker_1337_updates_leaderboard_with_sub_second_time() {
 
 #[tokio::test]
 #[serial]
+async fn tracker_1337_posts_slowest_only_for_final_ten_seconds() {
+    let mut bot = TestBotBuilder::new()
+        .at(Berlin
+            .with_ymd_and_hms(2026, 4, 18, 13, 35, 0)
+            .unwrap()
+            .with_timezone(&chrono::Utc))
+        .spawn()
+        .await;
+
+    advance_to_1337_window(&mut bot).await;
+
+    let ts_alice_49999ms = TMI_TS_13_37_BERLIN + 49_999;
+    let ts_charlie_58700ms = TMI_TS_13_37_BERLIN + 58_700;
+    let msg_alice = privmsg_at(&bot.channel, "alice", "1337", ts_alice_49999ms);
+    let msg_charlie = privmsg_at(&bot.channel, "charlie", "DANKIES", ts_charlie_58700ms);
+    bot.transport
+        .inject
+        .send(msg_alice)
+        .await
+        .expect("inject alice");
+    bot.transport
+        .inject
+        .send(msg_charlie)
+        .await
+        .expect("inject charlie");
+    yield_a_bit().await;
+
+    bot.clock.advance(ChronoDuration::seconds(90));
+    yield_a_bit().await;
+
+    let stats = bot.expect_say(Duration::from_secs(3)).await;
+    assert!(
+        stats.contains("Am langsamsten war charlie mit 58s"),
+        "expected slowest seconds in stats, got: {stats}"
+    );
+    assert!(
+        !stats.contains("58700ms"),
+        "slowest time should be shown in seconds, got: {stats}"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn tracker_1337_does_not_post_slowest_before_final_ten_seconds() {
+    let mut bot = TestBotBuilder::new()
+        .at(Berlin
+            .with_ymd_and_hms(2026, 4, 18, 13, 35, 0)
+            .unwrap()
+            .with_timezone(&chrono::Utc))
+        .spawn()
+        .await;
+
+    advance_to_1337_window(&mut bot).await;
+
+    let ts_alice_1200ms = TMI_TS_13_37_BERLIN + 1_200;
+    let ts_charlie_49999ms = TMI_TS_13_37_BERLIN + 49_999;
+    let msg_alice = privmsg_at(&bot.channel, "alice", "1337", ts_alice_1200ms);
+    let msg_charlie = privmsg_at(&bot.channel, "charlie", "DANKIES", ts_charlie_49999ms);
+    bot.transport
+        .inject
+        .send(msg_alice)
+        .await
+        .expect("inject alice");
+    bot.transport
+        .inject
+        .send(msg_charlie)
+        .await
+        .expect("inject charlie");
+    yield_a_bit().await;
+
+    bot.clock.advance(ChronoDuration::seconds(90));
+    yield_a_bit().await;
+
+    let stats = bot.expect_say(Duration::from_secs(3)).await;
+    assert!(
+        !stats.contains("Am langsamsten"),
+        "did not expect slowest before final ten seconds, got: {stats}"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn tracker_1337_zero_users_posts_erm_or_fuh() {
     let mut bot = TestBotBuilder::new()
         .at(Berlin


### PR DESCRIPTION

This pull request updates the "1337" tracker logic to only report the slowest chatter if their message was sent at least 50 seconds after the target time, and displays their time in seconds rather than milliseconds. It also adds tests to ensure this new behavior works as expected.

**Tracker logic improvements:**

* Introduced a new constant `SLOWEST_CHATTER_MIN_MS` (50,000 ms) in `tracker_1337.rs` to set a threshold for reporting the slowest chatter.
* Updated the handler to only consider users as the "slowest" if their message was sent at least 50 seconds after the target time, filtering out faster responses.
* Changed the reporting format for the slowest user's time from milliseconds to seconds for improved readability.

**Testing enhancements:**

* Added tests to verify that the slowest chatter is only reported in the final ten seconds and that the time is shown in seconds, not milliseconds. Also added a test to ensure no slowest is reported before the final ten seconds.