### PR TITLE
fix(llm): alias "reasoning" field for DeepSeek/OpenRouter compatibility

### DIFF
--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -95,7 +95,8 @@ struct ApiToolChoice {
 struct ApiToolResponseMessage {
     content: Option<String>,
     tool_calls: Option<Vec<ApiToolCall>>,
-    #[serde(default)]
+    // DeepSeek/OpenRouter returns this as "reasoning"; standard field is "reasoning_content"
+    #[serde(default, alias = "reasoning")]
     reasoning_content: Option<String>,
 }
 
@@ -155,6 +156,12 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
                 "tool_call_id": tr.tool_call_id,
                 "content": tr.content,
             }));
+        }
+    }
+
+    for (i, msg) in messages.iter().enumerate() {
+        if msg.get("reasoning_content").is_some() {
+            debug!(index = i, message = %msg, "Built message with reasoning_content");
         }
     }
 
@@ -369,7 +376,11 @@ impl LlmClient for OpenAiClient {
             reasoning,
         };
 
-        debug!(model = %self.model, "Sending tool request to OpenAI-compatible API");
+        if let Ok(req_json) = serde_json::to_string(&api_request) {
+            debug!(request_body = %req_json, "Sending tool request to OpenAI-compatible API");
+        } else {
+            debug!(model = %self.model, "Sending tool request to OpenAI-compatible API");
+        }
 
         let response = self
             .http
@@ -393,6 +404,7 @@ impl LlmClient for OpenAiClient {
             .json()
             .await
             .wrap_err("Failed to parse OpenAI-compatible API tool response")?;
+        debug!(response_body = %body, "OpenAI-compatible API raw tool response");
         if let Some(msg) = extract_api_error(&body) {
             return Err(eyre::eyre!("OpenAI-compatible API error: {}", msg));
         }
@@ -404,6 +416,13 @@ impl LlmClient for OpenAiClient {
             .into_iter()
             .next()
             .ok_or_else(|| eyre::eyre!("No choices in API tool response"))?;
+
+        debug!(
+            content = ?choice.message.content,
+            reasoning_content = ?choice.message.reasoning_content,
+            has_tool_calls = choice.message.tool_calls.is_some(),
+            "Parsed assistant message from tool response"
+        );
 
         if let Some(tool_calls) = choice.message.tool_calls
             && !tool_calls.is_empty()

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr as _};
 use reqwest::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument, trace, warn};
 
 use super::{
     ChatCompletionRequest, LlmClient, ToolChatCompletionRequest, ToolChatCompletionResponse,
@@ -156,12 +156,6 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
                 "tool_call_id": tr.tool_call_id,
                 "content": tr.content,
             }));
-        }
-    }
-
-    for (i, msg) in messages.iter().enumerate() {
-        if msg.get("reasoning_content").is_some() {
-            debug!(index = i, message = %msg, "Built message with reasoning_content");
         }
     }
 
@@ -377,7 +371,7 @@ impl LlmClient for OpenAiClient {
         };
 
         if let Ok(req_json) = serde_json::to_string(&api_request) {
-            debug!(request_body = %req_json, "Sending tool request to OpenAI-compatible API");
+            trace!(request_body = %req_json, "Sending tool request to OpenAI-compatible API");
         } else {
             debug!(model = %self.model, "Sending tool request to OpenAI-compatible API");
         }
@@ -404,7 +398,7 @@ impl LlmClient for OpenAiClient {
             .json()
             .await
             .wrap_err("Failed to parse OpenAI-compatible API tool response")?;
-        debug!(response_body = %body, "OpenAI-compatible API raw tool response");
+        trace!(response_body = %body, "OpenAI-compatible API raw tool response");
         if let Some(msg) = extract_api_error(&body) {
             return Err(eyre::eyre!("OpenAI-compatible API error: {}", msg));
         }


### PR DESCRIPTION
## Summary

- DeepSeek via OpenRouter returns reasoning content as `"reasoning"` in tool-call responses; the standard field name is `"reasoning_content"`
- Without the serde alias, the field deserialized as `None` → not echoed back in subsequent assistant turns → model looped until the web-tool round limit was hit
- Adds `#[serde(alias = "reasoning")]` to `ApiToolResponseMessage::reasoning_content` to handle both field names

## Debug logging

Also adds structured `debug!` logging for:
- Full tool request body (serialized JSON)
- Full tool response body
- Parsed assistant message (`content`, `reasoning_content`, `has_tool_calls`)

These were the instrumentation added during diagnosis; useful to keep for future debugging.

## Test plan

- [ ] `cargo test` passes (existing unit tests cover `reasoning_content` round-trip)
- [ ] `!ai` with a web-search question no longer loops to round limit when using DeepSeek via OpenRouter
- [ ] All 7 CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)