### PR TITLE
feat(memory): richer, cache-stable memory rendering (#75)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -112,9 +112,12 @@ client_secret = "your_client_secret"
 #   - AI personality lives in [ai].system_prompt — never written by the store.
 # ────────────────────────────────────────────────────────────────────────────
 
-# Caps are channel-wide totals per scope, NOT per individual user.
-# When a scope is full, the lowest-scoring entry (across all users in that
-# scope) is evicted. Score combines confidence × exp-decay × hit-boost.
+# Caps serve two purposes:
+#   1. Eviction ceiling — when a scope is full, the lowest-scoring entry
+#      (confidence × exp-decay × hit-boost) is evicted to make room.
+#   2. Render breadth — format_for_prompt shows at most cap entries per scope
+#      per turn, sorted by descending confidence, so the system prompt stays
+#      cache-stable across turns (no timestamps or access counters in output).
 # [ai.memory]
 # enabled        = false         # Enable persistent AI memory (default: false)
 # max_user = 50                  # total User-scope entries (all users combined)

--- a/docs/superpowers/plans/2026-04-25-cacheable-memory-rendering.md
+++ b/docs/superpowers/plans/2026-04-25-cacheable-memory-rendering.md
@@ -1,0 +1,637 @@
+# Cacheable Memory Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render AI memories in the system prompt with full nuance (scope, confidence, resolved username) while keeping the system prompt prefix-stable across turns so OpenAI/Ollama prompt caching hits.
+
+**Architecture:** Split the chat completion into a stable system message (bot personality + deterministic memory snapshot) and a volatile user message (chat history, current time, instruction). Memory rendering becomes a pure read — no `last_accessed`/`access_count` mutation on render — so the system prompt only changes when the store is mutated by `save_memory`/consolidation. Memories are grouped by scope with `subject_id → username` resolution from the existing `identities` map and confidence shown inline; per-scope cap reuses `Caps` (top-N by confidence then alphabetical, fully deterministic).
+
+**Tech Stack:** Rust, `tokio::sync::RwLock`, `chrono`, `chrono-tz`, RON-serialized store at `$DATA_DIR/ai_memory.ron`. LLM clients are OpenAI-compatible and Ollama (`src/llm/`). No new deps.
+
+**Issue:** GitHub #75 ("improve rendering of memories in prompt").
+
+**Out of scope:** semantic/embedding relevance filtering, per-query top-N by score, exposing access bumps to the consolidator. Those are follow-ups.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/memory/store.rs` | modify | `format_for_prompt` becomes `&self`, pure, grouped, capped, resolves identities, includes confidence. Replace mutating tests. |
+| `src/commands/ai.rs` | modify | Move `Current time:` line + chat history out of system prompt into the user message. Drop `&mut` lock on store. |
+| `config.toml.example` | modify | Document that memory rendering is stable/cacheable; note `max_user`/`max_lore`/`max_pref` also gate render breadth. |
+| `tests/` (existing integration tests under `tests/`) | modify only if a test pins the old prompt shape | Snapshot updates, if any. |
+
+No new files. No new config keys. The existing per-scope `Caps` from `[ai.memory]` are reused as render caps so we don't introduce a second knob.
+
+---
+
+### Task 1: Pure, identity-resolving, confidence-aware `format_for_prompt`
+
+**Files:**
+- Modify: `src/memory/store.rs:217-232` (the function body)
+- Modify: `src/memory/store.rs:1472-1537` (existing render tests — replace, don't extend)
+
+This task changes the rendering contract. After this task, `format_for_prompt` takes `&self` (not `&mut self`), takes a `&Caps` parameter to bound output size per scope, ignores `now` (kept in signature for future relevance use → drop the parameter entirely; callers updated in Task 3), groups output by scope with usernames, and emits confidence inline. `last_accessed`/`access_count` are no longer touched by rendering at all.
+
+- [ ] **Step 1: Replace the three render tests with the new contract**
+
+Delete `format_for_prompt_bumps_access_for_rendered_memories` (lines 1472–1509), `format_for_prompt_empty_store_does_not_mutate` (1511–1519), and `format_for_prompt_repeated_calls_accumulate_count` (1521–1537). In their place add the following block in the same `mod tests` (preserve surrounding `use` statements):
+
+```rust
+fn caps_unbounded() -> Caps {
+    Caps {
+        max_user: 1000,
+        max_lore: 1000,
+        max_pref: 1000,
+    }
+}
+
+#[test]
+fn format_for_prompt_does_not_mutate_store() {
+    use chrono::Duration;
+    let t0 = Utc::now() - Duration::hours(1);
+    let mut s = MemoryStore::default();
+    s.memories.insert(
+        "user::1::a".into(),
+        Memory::new(
+            "alice likes cats".into(),
+            Scope::User { subject_id: "1".into() },
+            "alice".into(),
+            70,
+            t0,
+        ),
+    );
+    s.upsert_identity("1", "alice", t0);
+
+    let snapshot_before = s.memories.clone();
+    let _ = s.format_for_prompt(&caps_unbounded());
+    assert_eq!(s.memories, snapshot_before, "render must not mutate");
+}
+
+#[test]
+fn format_for_prompt_empty_returns_none() {
+    let s = MemoryStore::default();
+    assert!(s.format_for_prompt(&caps_unbounded()).is_none());
+}
+
+#[test]
+fn format_for_prompt_groups_and_resolves_usernames() {
+    let now = Utc::now();
+    let mut s = MemoryStore::default();
+    s.upsert_identity("1", "alice", now);
+    s.upsert_identity("2", "bob", now);
+    s.memories.insert(
+        "user::1::likes-cats".into(),
+        Memory::new(
+            "likes cats".into(),
+            Scope::User { subject_id: "1".into() },
+            "alice".into(),
+            70,
+            now,
+        ),
+    );
+    s.memories.insert(
+        "user::2::is-pilot".into(),
+        Memory::new(
+            "is a pilot".into(),
+            Scope::User { subject_id: "2".into() },
+            "bob".into(),
+            85,
+            now,
+        ),
+    );
+    s.memories.insert(
+        "pref::1::call-me-al".into(),
+        Memory::new(
+            "address as Al".into(),
+            Scope::Pref { subject_id: "1".into() },
+            "alice".into(),
+            70,
+            now,
+        ),
+    );
+    s.memories.insert(
+        "lore::channel-vibe".into(),
+        Memory::new("channel is German-friendly".into(), Scope::Lore, "mod".into(), 90, now),
+    );
+
+    let out = s.format_for_prompt(&caps_unbounded()).unwrap();
+
+    // Sections present, in canonical order: Lore, About <user>, <user>'s preferences.
+    let lore_idx = out.find("### Channel lore").expect("lore section");
+    let about_alice_idx = out.find("### About alice").expect("about-alice section");
+    let about_bob_idx = out.find("### About bob").expect("about-bob section");
+    let pref_alice_idx = out.find("### alice's preferences").expect("pref section");
+    assert!(lore_idx < about_alice_idx);
+    assert!(about_alice_idx < about_bob_idx, "users sorted alphabetically");
+    assert!(about_bob_idx < pref_alice_idx);
+
+    // Lines carry confidence inline.
+    assert!(out.contains("- likes cats (conf 70)"));
+    assert!(out.contains("- is a pilot (conf 85)"));
+    assert!(out.contains("- channel is German-friendly (conf 90)"));
+    assert!(out.contains("- address as Al (conf 70)"));
+
+    // Users without a known username fall back to `user <id>`.
+    let mut s2 = MemoryStore::default();
+    s2.memories.insert(
+        "user::99::x".into(),
+        Memory::new("foo".into(), Scope::User { subject_id: "99".into() }, "ghost".into(), 50, now),
+    );
+    let out2 = s2.format_for_prompt(&caps_unbounded()).unwrap();
+    assert!(out2.contains("### About user 99"), "got: {out2}");
+}
+
+#[test]
+fn format_for_prompt_is_deterministic_across_calls() {
+    let now = Utc::now();
+    let mut s = MemoryStore::default();
+    s.upsert_identity("1", "alice", now);
+    for i in 0..10u32 {
+        s.memories.insert(
+            format!("user::1::fact-{i}"),
+            Memory::new(
+                format!("fact {i}"),
+                Scope::User { subject_id: "1".into() },
+                "alice".into(),
+                70,
+                now,
+            ),
+        );
+    }
+    let a = s.format_for_prompt(&caps_unbounded()).unwrap();
+    let b = s.format_for_prompt(&caps_unbounded()).unwrap();
+    let c = s.format_for_prompt(&caps_unbounded()).unwrap();
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+}
+
+#[test]
+fn format_for_prompt_respects_per_scope_caps() {
+    let now = Utc::now();
+    let mut s = MemoryStore::default();
+    s.upsert_identity("1", "alice", now);
+    // 5 user-scope memories, varying confidence.
+    for (i, conf) in [10u8, 90, 50, 30, 70].iter().enumerate() {
+        s.memories.insert(
+            format!("user::1::f{i}"),
+            Memory::new(
+                format!("fact {i}"),
+                Scope::User { subject_id: "1".into() },
+                "alice".into(),
+                *conf,
+                now,
+            ),
+        );
+    }
+    let caps = Caps { max_user: 2, max_lore: 1000, max_pref: 1000 };
+    let out = s.format_for_prompt(&caps).unwrap();
+
+    // Only the top-2 by confidence (90, 70) survive the cap.
+    assert!(out.contains("(conf 90)"));
+    assert!(out.contains("(conf 70)"));
+    assert!(!out.contains("(conf 50)"));
+    assert!(!out.contains("(conf 30)"));
+    assert!(!out.contains("(conf 10)"));
+}
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+cargo test --lib memory::store -- format_for_prompt
+```
+
+Expected: compile error or failing assertions — current `format_for_prompt` takes `DateTime<Utc>` (not `&Caps`), is `&mut self`, and renders flat `slug: fact` lines.
+
+- [ ] **Step 3: Rewrite `format_for_prompt`**
+
+Replace `src/memory/store.rs:217-232` with:
+
+```rust
+/// Render a stable, prefix-cacheable snapshot of the store for injection
+/// into the system prompt. Pure read — does NOT touch `last_accessed` or
+/// `access_count`, so the same store state always produces byte-identical
+/// output. Cache invalidation is therefore tied to *store mutation* (writes
+/// via `save_memory` or consolidation), not to per-turn render calls.
+///
+/// Output structure, in this fixed order:
+///   ## Known facts
+///   ### Channel lore
+///   - <fact> (conf <n>)
+///   ### About <username>     (one section per user, alphabetical by username)
+///   - <fact> (conf <n>)
+///   ### <username>'s preferences
+///   - <fact> (conf <n>)
+///
+/// Within each section, lines are sorted by `(-confidence, slug)` so the
+/// highest-confidence facts come first and ties are deterministic. When a
+/// scope's entry count exceeds the matching cap, only the top-cap rows by
+/// that ordering are rendered.
+///
+/// `subject_id` is resolved to the current `username` via `identities`;
+/// unknown ids fall back to the literal `user <id>` so output never leaks
+/// raw numeric ids when a mapping exists.
+///
+/// Returns `None` only when the store is completely empty.
+pub fn format_for_prompt(&self, caps: &Caps) -> Option<String> {
+    if self.memories.is_empty() {
+        return None;
+    }
+
+    // Bucket by section key.
+    let mut lore: Vec<(&str, &Memory)> = Vec::new();
+    // BTreeMap → alphabetical username iteration for deterministic ordering.
+    let mut user_buckets: std::collections::BTreeMap<String, Vec<&Memory>> =
+        std::collections::BTreeMap::new();
+    let mut pref_buckets: std::collections::BTreeMap<String, Vec<&Memory>> =
+        std::collections::BTreeMap::new();
+
+    for (key, mem) in &self.memories {
+        match &mem.scope {
+            Scope::Lore => lore.push((key.as_str(), mem)),
+            Scope::User { subject_id } => {
+                let name = self.resolve_username(subject_id);
+                user_buckets.entry(name).or_default().push(mem);
+            }
+            Scope::Pref { subject_id } => {
+                let name = self.resolve_username(subject_id);
+                pref_buckets.entry(name).or_default().push(mem);
+            }
+        }
+    }
+
+    let mut out = String::from("\n\n## Known facts");
+
+    if !lore.is_empty() {
+        out.push_str("\n### Channel lore");
+        // Sort by (-confidence, slug); cap.
+        let mut rows: Vec<&(&str, &Memory)> = lore.iter().collect();
+        rows.sort_by(|a, b| {
+            b.1.confidence
+                .cmp(&a.1.confidence)
+                .then_with(|| a.0.cmp(b.0))
+        });
+        for (_, mem) in rows.iter().take(caps.max_lore) {
+            out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+        }
+    }
+
+    for (username, mems) in &user_buckets {
+        out.push_str(&format!("\n### About {username}"));
+        let mut rows: Vec<&&Memory> = mems.iter().collect();
+        rows.sort_by(|a, b| {
+            b.confidence
+                .cmp(&a.confidence)
+                .then_with(|| a.fact.cmp(&b.fact))
+        });
+        for mem in rows.iter().take(caps.max_user) {
+            out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+        }
+    }
+
+    for (username, mems) in &pref_buckets {
+        out.push_str(&format!("\n### {username}'s preferences"));
+        let mut rows: Vec<&&Memory> = mems.iter().collect();
+        rows.sort_by(|a, b| {
+            b.confidence
+                .cmp(&a.confidence)
+                .then_with(|| a.fact.cmp(&b.fact))
+        });
+        for mem in rows.iter().take(caps.max_pref) {
+            out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+        }
+    }
+
+    Some(out)
+}
+
+fn resolve_username(&self, subject_id: &str) -> String {
+    self.identities
+        .get(subject_id)
+        .map(|i| i.username.clone())
+        .unwrap_or_else(|| format!("user {subject_id}"))
+}
+```
+
+- [ ] **Step 4: Run the rewritten tests**
+
+```bash
+cargo test --lib memory::store -- format_for_prompt
+```
+
+Expected: PASS — all five new tests green.
+
+- [ ] **Step 5: Run full memory suite to catch collateral damage**
+
+```bash
+cargo test --lib memory
+```
+
+Expected: PASS. If a different test referenced the old signature, fix it now (it should not — `format_for_prompt` is only called from `commands/ai.rs`, addressed in Task 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/memory/store.rs
+git commit -m "refactor(memory): make format_for_prompt pure, grouped, capped, identity-resolved
+
+Render is now &self with no access_count/last_accessed mutation, so the
+same store state produces byte-identical output across calls. Output is
+grouped by scope (Lore / About <user> / <user>'s preferences) with
+confidence inline, deterministic sort, and per-scope Caps applied at
+render time. Sets up the system prompt to be prefix-cacheable across
+turns when no store write occurs in between (refs #75)."
+```
+
+---
+
+### Task 2: Split system vs user message in the `!ai` handler for cacheability
+
+**Files:**
+- Modify: `src/commands/ai.rs:134-185` (system/user message construction)
+- (No test file changes here — handler tests live in `tests/` under integration; cacheability check lives in Task 4 against the unit-level renderer.)
+
+After this task, the system prompt is `{prompts.system}{facts_block_or_empty}` — nothing time-dependent. The user message holds the volatile bits in this order: a `Current time:` line, the optional `## Recent chat\n...` block, the rendered instruction template. This way OpenAI's automatic prefix cache and Ollama's KV cache hit on every turn until either (a) the operator edits `[ai].system_prompt` or (b) a memory write changes the store.
+
+- [ ] **Step 1: Read the current handler block to confirm starting state**
+
+```bash
+sed -n '130,190p' src/commands/ai.rs
+```
+
+Expected: matches the structure shown in the prior investigation (system prompt concatenates personality + `facts` + `Current time:` line; user message is `instruction_template` with `{chat_history}` substitution).
+
+- [ ] **Step 2: Replace the prompt construction**
+
+In `src/commands/ai.rs`, replace the block from `let now = Utc::now();` through the `Message { role: "user", content: user_message }` construction (currently lines 134–185) with:
+
+```rust
+let now = Utc::now();
+let facts = if let Some(ref mem) = self.memory {
+    let store_guard = mem.config.store.read().await;
+    store_guard
+        .format_for_prompt(&mem.config.caps)
+        .unwrap_or_default()
+} else {
+    String::new()
+};
+
+// System prompt: personality + stable memory snapshot only. Must NOT
+// contain time, chat history, or anything else that varies per turn,
+// so OpenAI/Ollama prefix caching can reuse it across turns until the
+// store mutates.
+let system_prompt = format!("{}{}", self.prompts.system, facts);
+
+let chat_history_text = if let Some(ref chat) = self.chat_ctx {
+    let buf = chat.history.lock().await;
+    if buf.is_empty() {
+        String::new()
+    } else {
+        buf.iter()
+            .map(|(user, msg, ts)| {
+                let ts_berlin = ts.with_timezone(&chrono_tz::Europe::Berlin);
+                format!("[{}] {user}: {msg}", ts_berlin.format("%H:%M"))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+} else {
+    String::new()
+};
+
+// User message: all volatile per-turn context lives here. Time first
+// so the model anchors before reading history/instruction.
+let now_berlin = now
+    .with_timezone(&chrono_tz::Europe::Berlin)
+    .format("%Y-%m-%d %H:%M %Z");
+let instruction_rendered = self
+    .prompts
+    .instruction_template
+    .replace("{message}", &instruction)
+    .replace("{chat_history}", &chat_history_text);
+let user_message = format!("Current time: {now_berlin}\n\n{instruction_rendered}");
+
+let request = ChatCompletionRequest {
+    model: self.model.clone(),
+    messages: vec![
+        Message { role: "system".to_string(), content: system_prompt },
+        Message { role: "user".to_string(), content: user_message },
+    ],
+};
+```
+
+Note the lock change: `mem.config.store.write().await` becomes `read().await` because `format_for_prompt` is now `&self`.
+
+- [ ] **Step 3: Build to confirm it compiles**
+
+```bash
+cargo build
+```
+
+Expected: clean build. If a downstream caller of `format_for_prompt` exists outside `commands/ai.rs`, the compiler will surface it; there should be none — verify with:
+
+```bash
+rg -n "format_for_prompt" src/
+```
+
+Expected: only `src/memory/store.rs` (definition + tests) and `src/commands/ai.rs` (the call updated above).
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+cargo test
+```
+
+Expected: PASS. Integration tests that prefilled chat history into the user message via `{chat_history}` placeholders will continue to work — the substitution still happens, only the surrounding scaffold changed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/ai.rs
+git commit -m "refactor(ai): split system vs user message for prompt-cache stability
+
+System prompt now holds only personality + stable memory snapshot.
+Current time and chat history move to the user message so the system
+prefix is byte-identical across turns until the memory store mutates,
+letting OpenAI prefix caching and Ollama KV reuse hit on every turn.
+Switches the store lock to read() since format_for_prompt is now &self
+(refs #75)."
+```
+
+---
+
+### Task 3: Cacheability regression test — same store state, byte-identical render
+
+**Files:**
+- Modify: `src/memory/store.rs` test module (add one focused test alongside the Task-1 tests)
+
+This is the load-bearing guarantee for #75. We pin it with a unit test so a future change that re-introduces per-render mutation, time-dependent output, or non-deterministic iteration order fails CI immediately.
+
+- [ ] **Step 1: Add the regression test**
+
+Append inside `mod tests` in `src/memory/store.rs`:
+
+```rust
+#[test]
+fn format_for_prompt_byte_identical_across_unrelated_clock_motion() {
+    // Cacheability guarantee: with the store untouched, two renders separated
+    // by wall-clock time must produce the exact same bytes. If this fails,
+    // the system prompt's prefix has drifted and prompt caching will miss.
+    use chrono::Duration;
+    let t0 = Utc::now() - Duration::hours(2);
+    let mut s = MemoryStore::default();
+    s.upsert_identity("1", "alice", t0);
+    s.upsert_identity("2", "bob", t0);
+    s.memories.insert(
+        "user::1::a".into(),
+        Memory::new(
+            "fact a".into(),
+            Scope::User { subject_id: "1".into() },
+            "alice".into(),
+            70,
+            t0,
+        ),
+    );
+    s.memories.insert(
+        "user::2::b".into(),
+        Memory::new(
+            "fact b".into(),
+            Scope::User { subject_id: "2".into() },
+            "bob".into(),
+            70,
+            t0,
+        ),
+    );
+    s.memories.insert(
+        "lore::c".into(),
+        Memory::new("lore c".into(), Scope::Lore, "mod".into(), 80, t0),
+    );
+
+    let caps = Caps { max_user: 50, max_lore: 50, max_pref: 50 };
+    let first = s.format_for_prompt(&caps).expect("non-empty");
+    // Simulate "another turn happens" — no store mutation, just elapsed time
+    // and an unrelated hashmap insertion-order shuffle via a clone round-trip.
+    let s2: MemoryStore = ron::from_str(&ron::to_string(&s).unwrap()).unwrap();
+    let second = s2.format_for_prompt(&caps).expect("non-empty");
+    assert_eq!(first, second, "render must be deterministic post-serde");
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cargo test --lib memory::store::tests::format_for_prompt_byte_identical_across_unrelated_clock_motion
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/memory/store.rs
+git commit -m "test(memory): pin byte-identical render across clock motion + serde
+
+Regression guard for #75: a future change that reintroduces non-pure
+or time-dependent rendering will fail CI immediately."
+```
+
+---
+
+### Task 4: Document the new contract in `config.toml.example`
+
+**Files:**
+- Modify: `config.toml.example:88-110` (the `# AI memory` block)
+
+The schema doesn't change, but the comments need to reflect (a) that `max_*` caps now also bound rendered breadth in the system prompt and (b) that rendering is stable / cache-friendly.
+
+- [ ] **Step 1: Update the comment block**
+
+In `config.toml.example`, replace the paragraph above `[ai.memory]` (currently lines around 105–110, beginning "Caps are channel-wide totals…") with:
+
+```toml
+# Caps are channel-wide totals per scope, NOT per individual user.
+# When a scope is full, the lowest-scoring entry (across all users in that
+# scope) is evicted. Score combines confidence × exp-decay × hit-boost.
+#
+# The same caps also bound how many entries from each scope are rendered
+# into the !ai system prompt. Within a scope, rendering picks the top-N by
+# (-confidence, slug) so the highest-confidence facts always reach the LLM.
+# Rendering is pure: it does not mutate access counters, so the system
+# prompt is byte-identical across turns until the store is written. That
+# preserves OpenAI prefix-cache and Ollama KV-cache hits on every turn.
+```
+
+- [ ] **Step 2: Sanity-check the file still parses**
+
+```bash
+cargo run -- --help >/dev/null 2>&1 || true
+cargo build
+```
+
+Expected: clean build (the example file is not parsed at build time, but this confirms nothing else regressed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config.toml.example
+git commit -m "docs(config): note that memory caps also gate rendered breadth
+
+Render is pure and deterministic, so the system prompt is stable across
+turns until the store is mutated — preserves prompt-cache hits."
+```
+
+---
+
+### Task 5: Pre-merge gate
+
+- [ ] **Step 1: Run the full CI gate locally**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: all three clean. Fix any clippy nag inline; do not `#[allow]` without a one-line reason.
+
+- [ ] **Step 2: Manual smoke (only if a dev twitch creds + LLM endpoint are available)**
+
+```bash
+RUST_LOG=debug cargo run
+```
+
+In two consecutive `!ai` turns with no `save_memory` writes between them, expect identical system-prompt bytes in the debug logs (the LLM client logs request payloads at debug level).
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "feat(ai): cacheable, nuance-rich memory rendering (#75)" --body "$(cat <<'EOF'
+## Summary
+- `format_for_prompt` is now pure, grouped by scope, identity-resolved, and confidence-aware.
+- Per-scope `Caps` gate render breadth (top-N by `(-confidence, slug)`).
+- System prompt = personality + stable memory snapshot. Time + chat history move to the user message so the system prefix is byte-identical across turns until the store mutates — preserves OpenAI prefix-cache and Ollama KV-cache hits.
+
+Closes #75.
+
+## Test plan
+- [ ] `cargo fmt --all`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+- [ ] Manual: two back-to-back `!ai` turns produce identical system-prompt bytes in debug logs (no store write between them).
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Issue #75 asks for (a) relevance and (b) confidence in rendered memories. Confidence: Task 1 inlines `(conf N)`. Relevance: addressed via per-scope `Caps` cap + confidence-first sort, intentionally avoiding per-query relevance because that breaks the cache (called out as out-of-scope, not silently dropped). Cacheability requirement from the user's directive: Tasks 2 + 3 enforce it (split layout + regression test).
+
+**Placeholder scan:** none. Every code step shows the exact code; every command is concrete; expected outputs are stated.
+
+**Type consistency:** new `format_for_prompt(&self, caps: &Caps) -> Option<String>` is referenced identically in Tasks 1, 2, 3. `Caps` field names (`max_user`, `max_lore`, `max_pref`) match `src/config.rs:91-96`. `resolve_username` is defined in Task 1 Step 3 and used inside the same function in the same step. `Scope::User { subject_id }` / `Scope::Pref { subject_id }` / `Scope::Lore` match `src/memory/scope.rs:4-8`.

--- a/src/commands/ai.rs
+++ b/src/commands/ai.rs
@@ -418,13 +418,7 @@ where
         } else {
             String::new()
         };
-        let mut system_prompt = format!(
-            "{}{}\n\nCurrent time: {}",
-            self.prompts.system,
-            facts,
-            now.with_timezone(&chrono_tz::Europe::Berlin)
-                .format("%Y-%m-%d %H:%M %Z")
-        );
+        let mut system_prompt = format!("{}{}", self.prompts.system, facts);
 
         if let Some(ref emotes) = self.emotes
             && let Some(block) = emotes.prompt_block(&ctx.privmsg.channel_id).await
@@ -435,11 +429,6 @@ where
         if self.chat_ctx.is_some() {
             system_prompt.push_str(CHAT_HISTORY_SYSTEM_APPENDIX);
         }
-
-        let user_message = self
-            .prompts
-            .instruction_template
-            .replace("{message}", &instruction);
 
         let chat_history_text = if let Some(ref chat) = self.chat_ctx {
             let buf = chat.history.lock().await;
@@ -464,7 +453,17 @@ where
             String::new()
         };
 
-        let user_message = user_message.replace("{chat_history}", &chat_history_text);
+        // User message: all volatile per-turn context lives here. Time first
+        // so the model anchors before reading history/instruction.
+        let now_berlin = now
+            .with_timezone(&chrono_tz::Europe::Berlin)
+            .format("%Y-%m-%d %H:%M %Z");
+        let instruction_rendered = self
+            .prompts
+            .instruction_template
+            .replace("{message}", &instruction)
+            .replace("{chat_history}", &chat_history_text);
+        let user_message = format!("Current time: {now_berlin}\n\n{instruction_rendered}");
 
         let result = if let Some(ref web) = self.web {
             self.chat_with_web_tools(system_prompt, user_message, web)

--- a/src/commands/ai.rs
+++ b/src/commands/ai.rs
@@ -411,8 +411,10 @@ where
 
         let now = Utc::now();
         let facts = if let Some(ref mem) = self.memory {
-            let mut store_guard = mem.config.store.write().await;
-            store_guard.format_for_prompt(now).unwrap_or_default()
+            let store_guard = mem.config.store.read().await;
+            store_guard
+                .format_for_prompt(&mem.config.caps)
+                .unwrap_or_default()
         } else {
             String::new()
         };

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -208,32 +208,69 @@ impl MemoryStore {
                 .then_with(|| a.0.cmp(b.0))
         }
 
+        // Render a capped, grouped section for User or Pref scope.
+        //
+        // Sort ALL entries across all subject_ids by (-confidence, slug), take
+        // the scope-level cap once, then group survivors by subject_id for the
+        // per-user headers. This keeps per-scope budget honest regardless of how
+        // many distinct users have memories. Distinct subject_ids that happen to
+        // share a username are disambiguated with a `(user <id>)` suffix.
+        let render_keyed_section = |entries: &mut Vec<(&str, &str, &Memory)>,
+                                    cap: usize,
+                                    header_fn: &dyn Fn(&str, bool, &str) -> String,
+                                    out: &mut String| {
+            if entries.is_empty() {
+                return;
+            }
+            entries.sort_by(|a, b| by_conf_then_slug(&(a.1, a.2), &(b.1, b.2)));
+
+            // Group cap-limited survivors by subject_id.
+            let mut by_subject: std::collections::BTreeMap<&str, Vec<&Memory>> =
+                std::collections::BTreeMap::new();
+            for &(subject_id, _, mem) in entries.iter().take(cap) {
+                by_subject.entry(subject_id).or_default().push(mem);
+            }
+
+            // Detect username collisions so we can disambiguate in headers.
+            let mut name_count: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::new();
+            for &subject_id in by_subject.keys() {
+                *name_count
+                    .entry(self.resolve_username(subject_id))
+                    .or_default() += 1;
+            }
+
+            // Emit sections in alphabetical username order for determinism.
+            let mut subject_ids: Vec<&&str> = by_subject.keys().collect();
+            subject_ids.sort_by_key(|&&id| self.resolve_username(id));
+
+            for &&subject_id in &subject_ids {
+                let name = self.resolve_username(subject_id);
+                let collision = name_count.get(&name).copied().unwrap_or(0) > 1;
+                out.push_str(&header_fn(&name, collision, subject_id));
+                for mem in &by_subject[subject_id] {
+                    out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+                }
+            }
+        };
+
         if self.memories.is_empty() {
             return None;
         }
 
         let mut lore: Vec<(&str, &Memory)> = Vec::new();
-        let mut user_buckets: std::collections::BTreeMap<String, Vec<(&str, &Memory)>> =
-            std::collections::BTreeMap::new();
-        let mut pref_buckets: std::collections::BTreeMap<String, Vec<(&str, &Memory)>> =
-            std::collections::BTreeMap::new();
+        // (subject_id, slug, &Memory) — keyed by subject_id to avoid username-collision merges
+        let mut user_entries: Vec<(&str, &str, &Memory)> = Vec::new();
+        let mut pref_entries: Vec<(&str, &str, &Memory)> = Vec::new();
 
         for (key, mem) in &self.memories {
             match &mem.scope {
                 Scope::Lore => lore.push((key.as_str(), mem)),
                 Scope::User { subject_id } => {
-                    let name = self.resolve_username(subject_id);
-                    user_buckets
-                        .entry(name)
-                        .or_default()
-                        .push((key.as_str(), mem));
+                    user_entries.push((subject_id.as_str(), key.as_str(), mem));
                 }
                 Scope::Pref { subject_id } => {
-                    let name = self.resolve_username(subject_id);
-                    pref_buckets
-                        .entry(name)
-                        .or_default()
-                        .push((key.as_str(), mem));
+                    pref_entries.push((subject_id.as_str(), key.as_str(), mem));
                 }
             }
         }
@@ -248,21 +285,31 @@ impl MemoryStore {
             }
         }
 
-        for (username, mems) in &mut user_buckets {
-            out.push_str(&format!("\n### About {username}"));
-            mems.sort_by(by_conf_then_slug);
-            for (_, mem) in mems.iter().take(caps.max_user) {
-                out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
-            }
-        }
+        render_keyed_section(
+            &mut user_entries,
+            caps.max_user,
+            &|name, collision, id| {
+                if collision {
+                    format!("\n### About {name} (user {id})")
+                } else {
+                    format!("\n### About {name}")
+                }
+            },
+            &mut out,
+        );
 
-        for (username, mems) in &mut pref_buckets {
-            out.push_str(&format!("\n### {username}'s preferences"));
-            mems.sort_by(by_conf_then_slug);
-            for (_, mem) in mems.iter().take(caps.max_pref) {
-                out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
-            }
-        }
+        render_keyed_section(
+            &mut pref_entries,
+            caps.max_pref,
+            &|name, collision, id| {
+                if collision {
+                    format!("\n### {name}'s preferences (user {id})")
+                } else {
+                    format!("\n### {name}'s preferences")
+                }
+            },
+            &mut out,
+        );
 
         Some(out)
     }
@@ -1695,6 +1742,97 @@ mod tests {
         assert!(!out.contains("(conf 50)"));
         assert!(!out.contains("(conf 30)"));
         assert!(!out.contains("(conf 10)"));
+    }
+
+    #[test]
+    fn format_for_prompt_cap_is_per_scope_not_per_user_bucket() {
+        // max_user=2 with 3 facts for alice and 3 for bob → only the top-2
+        // across the whole User scope should render, not top-2 per user (6 total).
+        let now = Utc::now();
+        let mut s = MemoryStore::default();
+        s.upsert_identity("1", "alice", now);
+        s.upsert_identity("2", "bob", now);
+        for (slug, subj, conf) in [
+            ("a", "1", 90u8), // alice — highest
+            ("b", "1", 60),   // alice
+            ("c", "1", 40),   // alice
+            ("d", "2", 85),   // bob — second highest
+            ("e", "2", 55),   // bob
+            ("f", "2", 30),   // bob
+        ] {
+            s.memories.insert(
+                format!("user:{subj}:{slug}"),
+                Memory::new(
+                    format!("fact {slug}"),
+                    Scope::User {
+                        subject_id: subj.into(),
+                    },
+                    if subj == "1" { "alice" } else { "bob" }.into(),
+                    conf,
+                    now,
+                ),
+            );
+        }
+        let caps = Caps {
+            max_user: 2,
+            max_lore: 1000,
+            max_pref: 1000,
+        };
+        let out = s.format_for_prompt(&caps).unwrap();
+        // Top-2 across scope: alice/a (90) and bob/d (85)
+        assert!(out.contains("(conf 90)"), "got: {out}");
+        assert!(out.contains("(conf 85)"), "got: {out}");
+        assert!(!out.contains("(conf 60)"), "got: {out}");
+        assert!(!out.contains("(conf 55)"), "got: {out}");
+        assert!(!out.contains("(conf 40)"), "got: {out}");
+        assert!(!out.contains("(conf 30)"), "got: {out}");
+        // Sections for both users still present (survivors from distinct subject_ids)
+        assert!(out.contains("### About alice"), "got: {out}");
+        assert!(out.contains("### About bob"), "got: {out}");
+    }
+
+    #[test]
+    fn format_for_prompt_disambiguates_username_collision() {
+        // Two distinct subject_ids that both resolve to "alice" must not have
+        // their memories silently merged — headers get a `(user <id>)` suffix.
+        let now = Utc::now();
+        let mut s = MemoryStore::default();
+        s.upsert_identity("1", "alice", now); // original alice
+        s.upsert_identity("5", "alice", now); // username reclaimed by another user
+        s.memories.insert(
+            "user:1:secret".into(),
+            Memory::new(
+                "hates spinach".into(),
+                Scope::User {
+                    subject_id: "1".into(),
+                },
+                "alice".into(),
+                80,
+                now,
+            ),
+        );
+        s.memories.insert(
+            "user:5:secret".into(),
+            Memory::new(
+                "loves spinach".into(),
+                Scope::User {
+                    subject_id: "5".into(),
+                },
+                "alice".into(),
+                80,
+                now,
+            ),
+        );
+        let out = s.format_for_prompt(&caps_unbounded()).unwrap();
+        assert!(out.contains("(user 1)"), "got: {out}");
+        assert!(out.contains("(user 5)"), "got: {out}");
+        assert!(out.contains("hates spinach"), "got: {out}");
+        assert!(out.contains("loves spinach"), "got: {out}");
+        // No un-disambiguated "### About alice" header should appear
+        assert!(
+            !out.contains("\n### About alice\n"),
+            "plain header must not appear on collision, got: {out}"
+        );
     }
 
     #[test]

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -200,32 +200,14 @@ impl MemoryStore {
         Ok(())
     }
 
-    /// Render a stable, prefix-cacheable snapshot of the store for injection
-    /// into the system prompt. Pure read — does NOT touch `last_accessed` or
-    /// `access_count`, so the same store state always produces byte-identical
-    /// output. Cache invalidation is therefore tied to *store mutation* (writes
-    /// via `save_memory` or consolidation), not to per-turn render calls.
-    ///
-    /// Output structure, in this fixed order:
-    ///   ## Known facts
-    ///   ### Channel lore
-    ///   - <fact> (conf <n>)
-    ///   ### About <username>     (one section per user, alphabetical by username)
-    ///   - <fact> (conf <n>)
-    ///   ### <username>'s preferences
-    ///   - <fact> (conf <n>)
-    ///
-    /// Within each section, lines are sorted by `(-confidence, slug)` so the
-    /// highest-confidence facts come first and ties are deterministic. When a
-    /// scope's entry count exceeds the matching cap, only the top-cap rows by
-    /// that ordering are rendered.
-    ///
-    /// `subject_id` is resolved to the current `username` via `identities`;
-    /// unknown ids fall back to the literal `user <id>` so output never leaks
-    /// raw numeric ids when a mapping exists.
-    ///
-    /// Returns `None` only when the store is completely empty.
+    /// Pure read; output is byte-identical for identical store state, enabling prefix caching.
     pub fn format_for_prompt(&self, caps: &Caps) -> Option<String> {
+        fn by_conf_then_slug(a: &(&str, &Memory), b: &(&str, &Memory)) -> std::cmp::Ordering {
+            b.1.confidence
+                .cmp(&a.1.confidence)
+                .then_with(|| a.0.cmp(b.0))
+        }
+
         if self.memories.is_empty() {
             return None;
         }
@@ -260,11 +242,7 @@ impl MemoryStore {
 
         if !lore.is_empty() {
             out.push_str("\n### Channel lore");
-            lore.sort_by(|a, b| {
-                b.1.confidence
-                    .cmp(&a.1.confidence)
-                    .then_with(|| a.0.cmp(b.0))
-            });
+            lore.sort_by(by_conf_then_slug);
             for (_, mem) in lore.iter().take(caps.max_lore) {
                 out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
             }
@@ -272,11 +250,7 @@ impl MemoryStore {
 
         for (username, mems) in &mut user_buckets {
             out.push_str(&format!("\n### About {username}"));
-            mems.sort_by(|a, b| {
-                b.1.confidence
-                    .cmp(&a.1.confidence)
-                    .then_with(|| a.0.cmp(b.0))
-            });
+            mems.sort_by(by_conf_then_slug);
             for (_, mem) in mems.iter().take(caps.max_user) {
                 out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
             }
@@ -284,11 +258,7 @@ impl MemoryStore {
 
         for (username, mems) in &mut pref_buckets {
             out.push_str(&format!("\n### {username}'s preferences"));
-            mems.sort_by(|a, b| {
-                b.1.confidence
-                    .cmp(&a.1.confidence)
-                    .then_with(|| a.0.cmp(b.0))
-            });
+            mems.sort_by(by_conf_then_slug);
             for (_, mem) in mems.iter().take(caps.max_pref) {
                 out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
             }
@@ -1725,6 +1695,61 @@ mod tests {
         assert!(!out.contains("(conf 50)"));
         assert!(!out.contains("(conf 30)"));
         assert!(!out.contains("(conf 10)"));
+    }
+
+    #[test]
+    fn format_for_prompt_byte_identical_across_unrelated_clock_motion() {
+        // Two stores: identical facts but memories created/accessed at different
+        // wall-clock times. Output must be byte-identical — proof that render
+        // encodes no time-varying metadata (cache-stable across turns).
+        use chrono::Duration;
+        let t0 = Utc::now() - Duration::hours(24);
+        let t1 = Utc::now(); // "later" wall clock
+
+        let mut s0 = MemoryStore::default();
+        s0.upsert_identity("1", "alice", t0);
+        s0.memories.insert(
+            "user:1:likes-cats".into(),
+            Memory::new(
+                "likes cats".into(),
+                Scope::User {
+                    subject_id: "1".into(),
+                },
+                "alice".into(),
+                80,
+                t0,
+            ),
+        );
+        s0.memories.insert(
+            "lore::vibe".into(),
+            Memory::new("channel is chill".into(), Scope::Lore, "mod".into(), 90, t0),
+        );
+
+        let mut s1 = MemoryStore::default();
+        s1.upsert_identity("1", "alice", t1);
+        s1.memories.insert(
+            "user:1:likes-cats".into(),
+            Memory::new(
+                "likes cats".into(),
+                Scope::User {
+                    subject_id: "1".into(),
+                },
+                "alice".into(),
+                80,
+                t1,
+            ),
+        );
+        s1.memories.insert(
+            "lore::vibe".into(),
+            Memory::new("channel is chill".into(), Scope::Lore, "mod".into(), 90, t1),
+        );
+
+        let caps = caps_unbounded();
+        assert_eq!(
+            s0.format_for_prompt(&caps),
+            s1.format_for_prompt(&caps),
+            "render must not encode timestamps — output must be byte-identical regardless of when memories were created/accessed"
+        );
     }
 
     #[test]

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -231,9 +231,9 @@ impl MemoryStore {
         }
 
         let mut lore: Vec<(&str, &Memory)> = Vec::new();
-        let mut user_buckets: std::collections::BTreeMap<String, Vec<&Memory>> =
+        let mut user_buckets: std::collections::BTreeMap<String, Vec<(&str, &Memory)>> =
             std::collections::BTreeMap::new();
-        let mut pref_buckets: std::collections::BTreeMap<String, Vec<&Memory>> =
+        let mut pref_buckets: std::collections::BTreeMap<String, Vec<(&str, &Memory)>> =
             std::collections::BTreeMap::new();
 
         for (key, mem) in &self.memories {
@@ -241,11 +241,17 @@ impl MemoryStore {
                 Scope::Lore => lore.push((key.as_str(), mem)),
                 Scope::User { subject_id } => {
                     let name = self.resolve_username(subject_id);
-                    user_buckets.entry(name).or_default().push(mem);
+                    user_buckets
+                        .entry(name)
+                        .or_default()
+                        .push((key.as_str(), mem));
                 }
                 Scope::Pref { subject_id } => {
                     let name = self.resolve_username(subject_id);
-                    pref_buckets.entry(name).or_default().push(mem);
+                    pref_buckets
+                        .entry(name)
+                        .or_default()
+                        .push((key.as_str(), mem));
                 }
             }
         }
@@ -254,39 +260,36 @@ impl MemoryStore {
 
         if !lore.is_empty() {
             out.push_str("\n### Channel lore");
-            let mut rows: Vec<&(&str, &Memory)> = lore.iter().collect();
-            rows.sort_by(|a, b| {
+            lore.sort_by(|a, b| {
                 b.1.confidence
                     .cmp(&a.1.confidence)
                     .then_with(|| a.0.cmp(b.0))
             });
-            for (_, mem) in rows.iter().take(caps.max_lore) {
+            for (_, mem) in lore.iter().take(caps.max_lore) {
                 out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
             }
         }
 
-        for (username, mems) in &user_buckets {
+        for (username, mems) in &mut user_buckets {
             out.push_str(&format!("\n### About {username}"));
-            let mut rows: Vec<&&Memory> = mems.iter().collect();
-            rows.sort_by(|a, b| {
-                b.confidence
-                    .cmp(&a.confidence)
-                    .then_with(|| a.fact.cmp(&b.fact))
+            mems.sort_by(|a, b| {
+                b.1.confidence
+                    .cmp(&a.1.confidence)
+                    .then_with(|| a.0.cmp(b.0))
             });
-            for mem in rows.iter().take(caps.max_user) {
+            for (_, mem) in mems.iter().take(caps.max_user) {
                 out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
             }
         }
 
-        for (username, mems) in &pref_buckets {
+        for (username, mems) in &mut pref_buckets {
             out.push_str(&format!("\n### {username}'s preferences"));
-            let mut rows: Vec<&&Memory> = mems.iter().collect();
-            rows.sort_by(|a, b| {
-                b.confidence
-                    .cmp(&a.confidence)
-                    .then_with(|| a.fact.cmp(&b.fact))
+            mems.sort_by(|a, b| {
+                b.1.confidence
+                    .cmp(&a.1.confidence)
+                    .then_with(|| a.0.cmp(b.0))
             });
-            for mem in rows.iter().take(caps.max_pref) {
+            for (_, mem) in mems.iter().take(caps.max_pref) {
                 out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
             }
         }
@@ -1553,7 +1556,7 @@ mod tests {
         let t0 = Utc::now() - Duration::hours(1);
         let mut s = MemoryStore::default();
         s.memories.insert(
-            "user::1::a".into(),
+            "user:1:likes-cats".into(),
             Memory::new(
                 "alice likes cats".into(),
                 Scope::User {
@@ -1584,7 +1587,7 @@ mod tests {
         s.upsert_identity("1", "alice", now);
         s.upsert_identity("2", "bob", now);
         s.memories.insert(
-            "user::1::likes-cats".into(),
+            "user:1:likes-cats".into(),
             Memory::new(
                 "likes cats".into(),
                 Scope::User {
@@ -1596,7 +1599,7 @@ mod tests {
             ),
         );
         s.memories.insert(
-            "user::2::is-pilot".into(),
+            "user:2:is-pilot".into(),
             Memory::new(
                 "is a pilot".into(),
                 Scope::User {
@@ -1608,7 +1611,7 @@ mod tests {
             ),
         );
         s.memories.insert(
-            "pref::1::call-me-al".into(),
+            "pref:1:call-me-al".into(),
             Memory::new(
                 "address as Al".into(),
                 Scope::Pref {
@@ -1650,7 +1653,7 @@ mod tests {
 
         let mut s2 = MemoryStore::default();
         s2.memories.insert(
-            "user::99::x".into(),
+            "user:99:x".into(),
             Memory::new(
                 "foo".into(),
                 Scope::User {
@@ -1672,7 +1675,7 @@ mod tests {
         s.upsert_identity("1", "alice", now);
         for i in 0..10u32 {
             s.memories.insert(
-                format!("user::1::fact-{i}"),
+                format!("user:1:fact-{i}"),
                 Memory::new(
                     format!("fact {i}"),
                     Scope::User {
@@ -1698,7 +1701,7 @@ mod tests {
         s.upsert_identity("1", "alice", now);
         for (i, conf) in [10u8, 90, 50, 30, 70].iter().enumerate() {
             s.memories.insert(
-                format!("user::1::f{i}"),
+                format!("user:1:f{i}"),
                 Memory::new(
                     format!("fact {i}"),
                     Scope::User {

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -38,7 +38,7 @@ pub struct MemoryConfig {
 }
 
 /// A single remembered fact.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Memory {
     pub fact: String,
     pub scope: Scope,
@@ -200,35 +200,105 @@ impl MemoryStore {
         Ok(())
     }
 
-    /// Format memories for injection into the system prompt.
-    /// Returns None if there are no memories.
+    /// Render a stable, prefix-cacheable snapshot of the store for injection
+    /// into the system prompt. Pure read — does NOT touch `last_accessed` or
+    /// `access_count`, so the same store state always produces byte-identical
+    /// output. Cache invalidation is therefore tied to *store mutation* (writes
+    /// via `save_memory` or consolidation), not to per-turn render calls.
     ///
-    /// Side-effect: for each memory actually rendered into the prompt, bumps
-    /// `last_accessed` to `now` and increments `access_count`. Both feed the
-    /// eviction score (see `Memory::score`).
+    /// Output structure, in this fixed order:
+    ///   ## Known facts
+    ///   ### Channel lore
+    ///   - <fact> (conf <n>)
+    ///   ### About <username>     (one section per user, alphabetical by username)
+    ///   - <fact> (conf <n>)
+    ///   ### <username>'s preferences
+    ///   - <fact> (conf <n>)
     ///
-    /// Buffered-write strategy: this method does NOT fsync the store. The
-    /// caller (the `!ai` handler) runs an extraction pass right after the
-    /// prompt is built, and `execute_tool_call` already persists via `save()`
-    /// after each round — so the just-bumped counters land on disk at the
-    /// end of the turn without a second write. On a crash between render and
-    /// extraction, at most one turn's worth of access bumps is lost; memories
-    /// themselves are unaffected.
-    pub fn format_for_prompt(&mut self, now: DateTime<Utc>) -> Option<String> {
+    /// Within each section, lines are sorted by `(-confidence, slug)` so the
+    /// highest-confidence facts come first and ties are deterministic. When a
+    /// scope's entry count exceeds the matching cap, only the top-cap rows by
+    /// that ordering are rendered.
+    ///
+    /// `subject_id` is resolved to the current `username` via `identities`;
+    /// unknown ids fall back to the literal `user <id>` so output never leaks
+    /// raw numeric ids when a mapping exists.
+    ///
+    /// Returns `None` only when the store is completely empty.
+    pub fn format_for_prompt(&self, caps: &Caps) -> Option<String> {
         if self.memories.is_empty() {
             return None;
         }
-        let mut lines: Vec<String> = self
-            .memories
-            .iter_mut()
-            .map(|(key, mem)| {
-                mem.last_accessed = now;
-                mem.access_count = mem.access_count.saturating_add(1);
-                format!("- {}: {}", key, mem.fact)
-            })
-            .collect();
-        lines.sort(); // Deterministic ordering
-        Some(format!("\n\n## Known facts\n{}", lines.join("\n")))
+
+        let mut lore: Vec<(&str, &Memory)> = Vec::new();
+        let mut user_buckets: std::collections::BTreeMap<String, Vec<&Memory>> =
+            std::collections::BTreeMap::new();
+        let mut pref_buckets: std::collections::BTreeMap<String, Vec<&Memory>> =
+            std::collections::BTreeMap::new();
+
+        for (key, mem) in &self.memories {
+            match &mem.scope {
+                Scope::Lore => lore.push((key.as_str(), mem)),
+                Scope::User { subject_id } => {
+                    let name = self.resolve_username(subject_id);
+                    user_buckets.entry(name).or_default().push(mem);
+                }
+                Scope::Pref { subject_id } => {
+                    let name = self.resolve_username(subject_id);
+                    pref_buckets.entry(name).or_default().push(mem);
+                }
+            }
+        }
+
+        let mut out = String::from("\n\n## Known facts");
+
+        if !lore.is_empty() {
+            out.push_str("\n### Channel lore");
+            let mut rows: Vec<&(&str, &Memory)> = lore.iter().collect();
+            rows.sort_by(|a, b| {
+                b.1.confidence
+                    .cmp(&a.1.confidence)
+                    .then_with(|| a.0.cmp(b.0))
+            });
+            for (_, mem) in rows.iter().take(caps.max_lore) {
+                out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+            }
+        }
+
+        for (username, mems) in &user_buckets {
+            out.push_str(&format!("\n### About {username}"));
+            let mut rows: Vec<&&Memory> = mems.iter().collect();
+            rows.sort_by(|a, b| {
+                b.confidence
+                    .cmp(&a.confidence)
+                    .then_with(|| a.fact.cmp(&b.fact))
+            });
+            for mem in rows.iter().take(caps.max_user) {
+                out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+            }
+        }
+
+        for (username, mems) in &pref_buckets {
+            out.push_str(&format!("\n### {username}'s preferences"));
+            let mut rows: Vec<&&Memory> = mems.iter().collect();
+            rows.sort_by(|a, b| {
+                b.confidence
+                    .cmp(&a.confidence)
+                    .then_with(|| a.fact.cmp(&b.fact))
+            });
+            for mem in rows.iter().take(caps.max_pref) {
+                out.push_str(&format!("\n- {} (conf {})", mem.fact, mem.confidence));
+            }
+        }
+
+        Some(out)
+    }
+
+    fn resolve_username(&self, subject_id: &str) -> String {
+        self.identities
+            .get(subject_id)
+            .map(|i| i.username.clone())
+            .unwrap_or_else(|| format!("user {subject_id}"))
     }
 
     /// Evict the lowest-scoring memory whose scope matches `tag` when the
@@ -1469,15 +1539,23 @@ mod tests {
         assert!(out.contains("too long"));
     }
 
+    fn caps_unbounded() -> Caps {
+        Caps {
+            max_user: 1000,
+            max_lore: 1000,
+            max_pref: 1000,
+        }
+    }
+
     #[test]
-    fn format_for_prompt_bumps_access_for_rendered_memories() {
+    fn format_for_prompt_does_not_mutate_store() {
         use chrono::Duration;
         let t0 = Utc::now() - Duration::hours(1);
         let mut s = MemoryStore::default();
         s.memories.insert(
-            "user:1:a".into(),
+            "user::1::a".into(),
             Memory::new(
-                "alice fact".into(),
+                "alice likes cats".into(),
                 Scope::User {
                     subject_id: "1".into(),
                 },
@@ -1486,54 +1564,164 @@ mod tests {
                 t0,
             ),
         );
-        s.memories.insert(
-            "lore::b".into(),
-            Memory::new("channel fact".into(), Scope::Lore, "mod".into(), 80, t0),
-        );
-        // Pre-conditions: untouched counters.
-        assert_eq!(s.memories["user:1:a"].access_count, 0);
-        assert_eq!(s.memories["user:1:a"].last_accessed, t0);
-        assert_eq!(s.memories["lore::b"].access_count, 0);
-        assert_eq!(s.memories["lore::b"].last_accessed, t0);
+        s.upsert_identity("1", "alice", t0);
 
-        let render_now = Utc::now();
-        let out = s.format_for_prompt(render_now);
-        assert!(out.is_some());
-        // Every memory rendered into the prompt gets its counters bumped.
-        let a = &s.memories["user:1:a"];
-        assert_eq!(a.access_count, 1);
-        assert_eq!(a.last_accessed, render_now);
-        let b = &s.memories["lore::b"];
-        assert_eq!(b.access_count, 1);
-        assert_eq!(b.last_accessed, render_now);
+        let snapshot_before = s.memories.clone();
+        let _ = s.format_for_prompt(&caps_unbounded());
+        assert_eq!(s.memories, snapshot_before, "render must not mutate");
     }
 
     #[test]
-    fn format_for_prompt_empty_store_does_not_mutate() {
-        let mut s = MemoryStore::default();
-        let before = s.memories.clone();
-        let out = s.format_for_prompt(Utc::now());
-        assert!(out.is_none());
-        // Empty store: no memories to bump, identities untouched.
-        assert_eq!(s.memories.len(), before.len());
+    fn format_for_prompt_empty_returns_none() {
+        let s = MemoryStore::default();
+        assert!(s.format_for_prompt(&caps_unbounded()).is_none());
     }
 
     #[test]
-    fn format_for_prompt_repeated_calls_accumulate_count() {
-        // Guards the saturating_add path and confirms multiple render passes
-        // bump the same memory each time — important for the score-boost
-        // behavior over the life of a turn.
-        use chrono::Duration;
-        let t0 = Utc::now() - Duration::hours(1);
+    fn format_for_prompt_groups_and_resolves_usernames() {
+        let now = Utc::now();
         let mut s = MemoryStore::default();
+        s.upsert_identity("1", "alice", now);
+        s.upsert_identity("2", "bob", now);
         s.memories.insert(
-            "lore::x".into(),
-            Memory::new("fact".into(), Scope::Lore, "alice".into(), 60, t0),
+            "user::1::likes-cats".into(),
+            Memory::new(
+                "likes cats".into(),
+                Scope::User {
+                    subject_id: "1".into(),
+                },
+                "alice".into(),
+                70,
+                now,
+            ),
         );
-        let _ = s.format_for_prompt(Utc::now());
-        let _ = s.format_for_prompt(Utc::now());
-        let _ = s.format_for_prompt(Utc::now());
-        assert_eq!(s.memories["lore::x"].access_count, 3);
+        s.memories.insert(
+            "user::2::is-pilot".into(),
+            Memory::new(
+                "is a pilot".into(),
+                Scope::User {
+                    subject_id: "2".into(),
+                },
+                "bob".into(),
+                85,
+                now,
+            ),
+        );
+        s.memories.insert(
+            "pref::1::call-me-al".into(),
+            Memory::new(
+                "address as Al".into(),
+                Scope::Pref {
+                    subject_id: "1".into(),
+                },
+                "alice".into(),
+                70,
+                now,
+            ),
+        );
+        s.memories.insert(
+            "lore::channel-vibe".into(),
+            Memory::new(
+                "channel is German-friendly".into(),
+                Scope::Lore,
+                "mod".into(),
+                90,
+                now,
+            ),
+        );
+
+        let out = s.format_for_prompt(&caps_unbounded()).unwrap();
+
+        let lore_idx = out.find("### Channel lore").expect("lore section");
+        let about_alice_idx = out.find("### About alice").expect("about-alice section");
+        let about_bob_idx = out.find("### About bob").expect("about-bob section");
+        let pref_alice_idx = out.find("### alice's preferences").expect("pref section");
+        assert!(lore_idx < about_alice_idx);
+        assert!(
+            about_alice_idx < about_bob_idx,
+            "users sorted alphabetically"
+        );
+        assert!(about_bob_idx < pref_alice_idx);
+
+        assert!(out.contains("- likes cats (conf 70)"));
+        assert!(out.contains("- is a pilot (conf 85)"));
+        assert!(out.contains("- channel is German-friendly (conf 90)"));
+        assert!(out.contains("- address as Al (conf 70)"));
+
+        let mut s2 = MemoryStore::default();
+        s2.memories.insert(
+            "user::99::x".into(),
+            Memory::new(
+                "foo".into(),
+                Scope::User {
+                    subject_id: "99".into(),
+                },
+                "ghost".into(),
+                50,
+                now,
+            ),
+        );
+        let out2 = s2.format_for_prompt(&caps_unbounded()).unwrap();
+        assert!(out2.contains("### About user 99"), "got: {out2}");
+    }
+
+    #[test]
+    fn format_for_prompt_is_deterministic_across_calls() {
+        let now = Utc::now();
+        let mut s = MemoryStore::default();
+        s.upsert_identity("1", "alice", now);
+        for i in 0..10u32 {
+            s.memories.insert(
+                format!("user::1::fact-{i}"),
+                Memory::new(
+                    format!("fact {i}"),
+                    Scope::User {
+                        subject_id: "1".into(),
+                    },
+                    "alice".into(),
+                    70,
+                    now,
+                ),
+            );
+        }
+        let a = s.format_for_prompt(&caps_unbounded()).unwrap();
+        let b = s.format_for_prompt(&caps_unbounded()).unwrap();
+        let c = s.format_for_prompt(&caps_unbounded()).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn format_for_prompt_respects_per_scope_caps() {
+        let now = Utc::now();
+        let mut s = MemoryStore::default();
+        s.upsert_identity("1", "alice", now);
+        for (i, conf) in [10u8, 90, 50, 30, 70].iter().enumerate() {
+            s.memories.insert(
+                format!("user::1::f{i}"),
+                Memory::new(
+                    format!("fact {i}"),
+                    Scope::User {
+                        subject_id: "1".into(),
+                    },
+                    "alice".into(),
+                    *conf,
+                    now,
+                ),
+            );
+        }
+        let caps = Caps {
+            max_user: 2,
+            max_lore: 1000,
+            max_pref: 1000,
+        };
+        let out = s.format_for_prompt(&caps).unwrap();
+
+        assert!(out.contains("(conf 90)"));
+        assert!(out.contains("(conf 70)"));
+        assert!(!out.contains("(conf 50)"));
+        assert!(!out.contains("(conf 30)"));
+        assert!(!out.contains("(conf 10)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `format_for_prompt` is now pure (`&self`, no `now` arg): same store state → byte-identical system prompt across turns, enabling OpenAI/Ollama prefix KV caching
- Output groups memories by scope (Channel lore → About \<user\> → \<user\>'s preferences), sorted by descending confidence then slug for deterministic ordering
- Subject IDs resolve to usernames via `identities` map; unknown IDs fall back to `user <id>`
- `[ai.memory]` caps now serve dual purpose: eviction ceiling AND render breadth limit
- System prompt = personality + stable memory snapshot; volatile content (current time, chat history, instruction) moves to the user message — cache invalidation tied to store writes, not per-turn render calls
- Per-scope cap applied globally (not per-user bucket): sort all entries in scope, take N, then group survivors by subject_id for headers
- Username collision disambiguation: distinct subject_ids sharing the same resolved username get `(user <id>)` suffix to prevent merging unrelated users' memory sections

## Test plan

- [x] `format_for_prompt_does_not_mutate_store` — render is pure read
- [x] `format_for_prompt_empty_returns_none` — empty store returns None
- [x] `format_for_prompt_groups_and_resolves_usernames` — sections ordered correctly, usernames resolved
- [x] `format_for_prompt_is_deterministic_across_calls` — three consecutive calls produce identical strings
- [x] `format_for_prompt_respects_per_scope_caps` — top-N by confidence rendered, rest excluded
- [x] `format_for_prompt_byte_identical_across_unrelated_clock_motion` — different creation timestamps → same output
- [x] `format_for_prompt_cap_is_per_scope_not_per_user_bucket` — cap applies across all users in scope, not per-user
- [x] `format_for_prompt_disambiguates_username_collision` — two subject_ids sharing a username get `(user <id>)` suffix
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` (172 unit tests + integration tests) all green

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)