### PR TITLE
fix: init token storage as expiring now

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,3 +26,7 @@ logs:
 
 # Deploy image and restart pod
 deploy: build push restart
+
+# Run locally with data dir in current directory and debug logging
+dev:
+    DATA_DIR=./data RUST_LOG=info,twitch_1337=debug cargo run

--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ cargo run
 
 Configuration is entirely via `config.toml` - see `config.toml.example` for all available options.
 
+### Rotating credentials
+
+To replace the OAuth refresh token (e.g. after revoking the old one):
+
+1. Obtain a new refresh token via the Twitch OAuth flow for your client ID/secret.
+2. Update `refresh_token` in `config.toml`.
+3. Restart the bot.
+
+On startup, `FileBasedTokenStorage` compares the token stored in `$DATA_DIR/token.ron`
+against the value in config. When they differ it discards the stored access token, substitutes
+the new refresh token, and marks the credentials as expired — forcing an immediate re-auth
+before the IRC connection is opened. No manual deletion of `token.ron` is required.
+
 ### Docker
 
 ```bash

--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -27,6 +27,16 @@ impl FileBasedTokenStorage {
             initial_refresh_token,
         }
     }
+
+    fn fresh_token_from_config(&self) -> UserAccessToken {
+        let now = Utc::now();
+        UserAccessToken {
+            access_token: String::new(),
+            refresh_token: self.initial_refresh_token.expose_secret().to_string(),
+            created_at: now,
+            expires_at: Some(now),
+        }
+    }
 }
 
 #[async_trait]
@@ -42,26 +52,17 @@ impl TokenStorage for FileBasedTokenStorage {
                     path = %self.path.display(),
                     "Loading user access token from file"
                 );
-                let mut token: UserAccessToken = ron::from_str(&contents)?;
-                // Config refresh token changed — discard stored credentials and force refresh
-                if token.refresh_token != self.initial_refresh_token.expose_secret().as_ref() {
+                let token: UserAccessToken = ron::from_str(&contents)?;
+                let config_token = self.initial_refresh_token.expose_secret();
+                if token.refresh_token != config_token {
                     warn!("Refresh token in config differs from stored token; using config token");
-                    token.access_token = String::new();
-                    token.refresh_token =
-                        self.initial_refresh_token.expose_secret().to_string();
-                    token.expires_at = Some(Utc::now());
+                    return Ok(self.fresh_token_from_config());
                 }
                 Ok(token)
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 warn!("Token file not found, using refresh token from configuration");
-                let token = UserAccessToken {
-                    access_token: String::new(),
-                    refresh_token: self.initial_refresh_token.expose_secret().to_string(),
-                    created_at: Utc::now(),
-                    expires_at: Some(Utc::now()),
-                };
-                Ok(token)
+                Ok(self.fresh_token_from_config())
             }
             Err(e) => Err(eyre::Report::from(e).wrap_err("Failed to read token file")),
         }

--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -108,9 +108,6 @@ mod tests {
         let s = ron::to_string(&t).unwrap();
         let t2: UserAccessToken = ron::from_str(&s).unwrap();
         // subsecond precision may differ; compare at second granularity
-        assert_eq!(
-            t2.expires_at.unwrap().timestamp(),
-            now.timestamp()
-        );
+        assert_eq!(t2.expires_at.unwrap().timestamp(), now.timestamp());
     }
 }

--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -50,9 +50,8 @@ impl TokenStorage for FileBasedTokenStorage {
                     access_token: String::new(),
                     refresh_token: self.initial_refresh_token.expose_secret().to_string(),
                     created_at: Utc::now(),
-                    expires_at: None,
+                    expires_at: Some(Utc::now()),
                 };
-                self.update_token(&token).await?;
                 Ok(token)
             }
             Err(e) => Err(eyre::Report::from(e).wrap_err("Failed to read token file")),

--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -42,7 +42,16 @@ impl TokenStorage for FileBasedTokenStorage {
                     path = %self.path.display(),
                     "Loading user access token from file"
                 );
-                Ok(ron::from_str(&contents)?)
+                let mut token: UserAccessToken = ron::from_str(&contents)?;
+                // Config refresh token changed — discard stored credentials and force refresh
+                if token.refresh_token != self.initial_refresh_token.expose_secret().as_ref() {
+                    warn!("Refresh token in config differs from stored token; using config token");
+                    token.access_token = String::new();
+                    token.refresh_token =
+                        self.initial_refresh_token.expose_secret().to_string();
+                    token.expires_at = Some(Utc::now());
+                }
+                Ok(token)
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 warn!("Token file not found, using refresh token from configuration");
@@ -66,5 +75,41 @@ impl TokenStorage for FileBasedTokenStorage {
         File::create(&tmp_path).await?.write_all(&buffer).await?;
         fs::rename(&tmp_path, &self.path).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use twitch_irc::login::UserAccessToken;
+
+    fn make_token(expires_at: Option<chrono::DateTime<Utc>>) -> UserAccessToken {
+        UserAccessToken {
+            access_token: "acc".into(),
+            refresh_token: "ref".into(),
+            created_at: Utc::now(),
+            expires_at,
+        }
+    }
+
+    #[test]
+    fn ron_roundtrip_expires_at_none() {
+        let t = make_token(None);
+        let s = ron::to_string(&t).unwrap();
+        let t2: UserAccessToken = ron::from_str(&s).unwrap();
+        assert_eq!(t2.expires_at, None);
+    }
+
+    #[test]
+    fn ron_roundtrip_expires_at_some() {
+        let now = Utc::now();
+        let t = make_token(Some(now));
+        let s = ron::to_string(&t).unwrap();
+        let t2: UserAccessToken = ron::from_str(&s).unwrap();
+        // subsecond precision may differ; compare at second granularity
+        assert_eq!(
+            t2.expires_at.unwrap().timestamp(),
+            now.timestamp()
+        );
     }
 }

--- a/src/twitch_setup.rs
+++ b/src/twitch_setup.rs
@@ -5,14 +5,14 @@
 
 use std::collections::HashSet;
 
-use eyre::{Result, bail};
+use eyre::{Context as _, Result, bail};
 use secrecy::ExposeSecret as _;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::Duration;
 use tracing::{error, info, instrument, trace};
 use twitch_irc::{
     ClientConfig, SecureTCPTransport, TwitchIRCClient,
-    login::RefreshingLoginCredentials,
+    login::{LoginCredentials as _, RefreshingLoginCredentials},
     message::{NoticeMessage, ServerMessage},
 };
 
@@ -20,19 +20,25 @@ use crate::{AuthenticatedTwitchClient, FileBasedTokenStorage, config::Configurat
 
 /// Create the Twitch IRC client and message receiver without connecting.
 #[instrument(skip(config))]
-pub fn setup_twitch_client(
+pub async fn setup_twitch_client(
     config: &Configuration,
-) -> (UnboundedReceiver<ServerMessage>, AuthenticatedTwitchClient) {
+) -> Result<(UnboundedReceiver<ServerMessage>, AuthenticatedTwitchClient)> {
     let credentials = RefreshingLoginCredentials::init_with_username(
         Some(config.twitch.username.clone()),
         config.twitch.client_id.expose_secret().to_string(),
         config.twitch.client_secret.expose_secret().to_string(),
         FileBasedTokenStorage::new(config.twitch.refresh_token.clone()),
     );
+    // refresh token if required
+    credentials
+        .get_credentials()
+        .await
+        .wrap_err("cant get no token")?;
     let twitch_config = ClientConfig::new_simple(credentials);
-    TwitchIRCClient::<SecureTCPTransport, RefreshingLoginCredentials<FileBasedTokenStorage>>::new(
-        twitch_config,
-    )
+    Ok(TwitchIRCClient::<
+        SecureTCPTransport,
+        RefreshingLoginCredentials<FileBasedTokenStorage>,
+    >::new(twitch_config))
 }
 
 /// Connect, join channel(s), and verify authentication via `GlobalUserState`.
@@ -44,7 +50,7 @@ pub async fn setup_and_verify_twitch_client(
 ) -> Result<(UnboundedReceiver<ServerMessage>, AuthenticatedTwitchClient)> {
     info!("Setting up and verifying Twitch connection");
 
-    let (mut incoming_messages, client) = setup_twitch_client(config);
+    let (mut incoming_messages, client) = setup_twitch_client(config).await?;
 
     info!("Connecting to Twitch IRC");
     client.connect().await;

--- a/src/twitch_setup.rs
+++ b/src/twitch_setup.rs
@@ -29,11 +29,10 @@ pub async fn setup_twitch_client(
         config.twitch.client_secret.expose_secret().to_string(),
         FileBasedTokenStorage::new(config.twitch.refresh_token.clone()),
     );
-    // refresh token if required
     credentials
         .get_credentials()
         .await
-        .wrap_err("cant get no token")?;
+        .wrap_err("Failed to obtain initial credentials")?;
     let twitch_config = ClientConfig::new_simple(credentials);
     Ok(TwitchIRCClient::<
         SecureTCPTransport,


### PR DESCRIPTION
token was marked as never expiring. this is wrong. instead mark as expiring now, so we get new access token. closes #82