### PR TITLE
fix(ping): add missing @ prefix to {sender} template placeholder

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -268,7 +268,7 @@ impl PingManager {
         let rendered = ping
             .template
             .replace("{mentions}", &mentions)
-            .replace("{sender}", sender);
+            .replace("{sender}", &format!("@{sender}"));
         Some(rendered)
     }
 }
@@ -415,6 +415,24 @@ mod tests {
         let result = mgr.render_template("test", "alice").unwrap();
         assert!(!result.contains("@alice"), "should exclude sender");
         assert!(result.contains("@bob"));
+    }
+
+    #[test]
+    fn render_template_prefixes_sender_with_at() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut mgr = empty_manager(dir.path());
+        mgr.create_ping(
+            "test".into(),
+            "{mentions} {sender}".into(),
+            "admin".into(),
+            None,
+        )
+        .unwrap();
+        mgr.add_member("test", "alice").unwrap();
+        mgr.add_member("test", "bob").unwrap();
+
+        let result = mgr.render_template("test", "alice").unwrap();
+        assert!(result.contains("@alice"), "sender should have @ prefix");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `{sender}` in ping templates rendered as bare login (e.g. `chronophylos`) while `{mentions}` correctly prefixed each name with `@`
- One-line fix in `render_template()`: `sender` → `&format!("@{sender}")`
- Added regression test `render_template_prefixes_sender_with_at`

## Note

Existing templates that worked around this bug by writing `@{sender}` will now produce `@@username`. These would need to be updated — but based on the issue, users expected `{sender}` to behave like `{mentions}`.

Closes #36.

## Test plan

- [x] New unit test `render_template_prefixes_sender_with_at` fails before fix, passes after
- [x] All 200+ existing tests pass
- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)