### PR TITLE
fix(schedules): prevent config watcher reload loop on IN_OPEN events

### DIFF
--- a/src/handlers/schedules.rs
+++ b/src/handlers/schedules.rs
@@ -146,6 +146,7 @@ pub async fn run_config_watcher_service(cache: Arc<tokio::sync::RwLock<database:
     let mut watcher_handle = tokio::task::spawn_blocking(move || {
         let tx = tx;
         let config_path = watcher_config_path;
+        let filter_path = config_path.clone();
 
         // Create debouncer with 2 second timeout
         let mut debouncer = match new_debouncer(
@@ -157,6 +158,10 @@ pub async fn run_config_watcher_service(cache: Arc<tokio::sync::RwLock<database:
                 match res {
                     Ok(events) => {
                         for event in events {
+                            // Only forward events for config.toml; ignore token.ron etc.
+                            if event.path != filter_path {
+                                continue;
+                            }
                             debug!(path = ?event.path, "File change event received");
                             // Use blocking_send since we're in a sync context
                             if tx.blocking_send(()).is_err() {
@@ -193,10 +198,25 @@ pub async fn run_config_watcher_service(cache: Arc<tokio::sync::RwLock<database:
         let _ = shutdown_rx.blocking_recv();
     });
 
+    // Track mtime to skip spurious events (notify 8.x subscribes to IN_OPEN, so reading
+    // config.toml in the reload handler triggers another event 2s later without this guard).
+    let mut last_config_mtime: Option<std::time::SystemTime> = None;
+
     // Main loop: handle file change events
     loop {
         tokio::select! {
             Some(()) = rx.recv() => {
+                let current_mtime = tokio::fs::metadata(&config_path)
+                    .await
+                    .and_then(|m| m.modified())
+                    .ok();
+
+                if current_mtime.is_some() && current_mtime == last_config_mtime {
+                    debug!("Config event ignored: mtime unchanged (spurious IN_OPEN/IN_ATTRIB)");
+                    continue;
+                }
+                last_config_mtime = current_mtime;
+
                 info!("Config file changed, reloading schedules");
 
                 if let Some(schedules) = reload_schedules_from_config() {


### PR DESCRIPTION
## Summary

- `notify` 8.x subscribes to `IN_OPEN` in its inotify watch mask; reading `config.toml` inside the reload handler triggered another debounced event 2 seconds later, creating an infinite reload loop whenever schedules were active
- Added path filter in the debouncer callback so only `config.toml` events are forwarded (ignores `token.ron`, `pings.ron`, etc.)
- Added mtime guard before reloading: skips reload if mtime is unchanged (`IN_OPEN`/`IN_ATTRIB` don't modify mtime, breaking the feedback loop)
- Replaced `std::fs::metadata` with `tokio::fs::metadata` to avoid blocking a Tokio worker thread

Closes #61

## Test plan

- [ ] Deploy with `[[schedules]]` configured and verify no continuous reload loop in logs
- [ ] Edit `config.toml` while bot is running and verify schedule reloads exactly once
- [ ] Verify other `/data/` writes (token refresh, ping saves) do not trigger spurious reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)