### PR TITLE
fix(memory): drop write lock before blocking save() I/O

### DIFF
--- a/src/memory/consolidation.rs
+++ b/src/memory/consolidation.rs
@@ -95,24 +95,21 @@ pub async fn run_consolidation(
         r.clone()
     };
 
-    // 2. Pre-filter hard-drops (deterministic, no LLM)
+    // 2+3. Hard-drops + corroboration boost (both deterministic; single write lock)
     let hard_drops = hard_drop_candidates(&snapshot, now);
-    if !hard_drops.is_empty() {
-        let mut w = store.write().await;
-        for (k, reason) in &hard_drops {
-            w.memories.remove(k);
-            debug!(%k, %reason, "pre-filter hard-drop");
-        }
-        w.save(&store_path)?;
-    }
-
-    // 3. Corroboration boost (deterministic)
     {
-        let mut w = store.write().await;
-        for m in w.memories.values_mut() {
-            m.confidence = corroboration_boost(m);
-        }
-        w.save(&store_path)?;
+        let save_snapshot = {
+            let mut w = store.write().await;
+            for (k, reason) in &hard_drops {
+                w.memories.remove(k);
+                debug!(%k, %reason, "pre-filter hard-drop");
+            }
+            for m in w.memories.values_mut() {
+                m.confidence = corroboration_boost(m);
+            }
+            w.clone()
+        };
+        save_snapshot.save(&store_path)?;
     }
 
     // 4. LLM pass per scope (user, lore, pref)
@@ -178,31 +175,34 @@ pub async fn run_consolidation(
                     reasoning_content,
                 } => {
                     let mut results = Vec::with_capacity(calls.len());
-                    let mut w = store.write().await;
-                    // Apply ops in order: drop → merge → edit (sort once).
-                    let mut sorted = calls.clone();
-                    sorted.sort_by_key(|c| match c.name.as_str() {
-                        "drop_memory" => 0,
-                        "merge_memories" => 1,
-                        "edit_memory" => 2,
-                        _ => 3,
-                    });
-                    for call in &sorted {
-                        let out = w.execute_consolidator_tool(call, now);
-                        match call.name.as_str() {
-                            "merge_memories" if out.starts_with("Merged") => merged += 1,
-                            "drop_memory" if out.starts_with("Dropped") => dropped += 1,
-                            "edit_memory" if out.starts_with("Edited") => edited += 1,
-                            _ => {}
-                        }
-                        info!(tool = %call.name, result = %out, "consolidation tool executed");
-                        results.push(ToolResultMessage {
-                            tool_call_id: call.id.clone(),
-                            tool_name: call.name.clone(),
-                            content: out,
+                    let save_snapshot = {
+                        let mut w = store.write().await;
+                        // Apply ops in order: drop → merge → edit (sort once).
+                        let mut sorted = calls.clone();
+                        sorted.sort_by_key(|c| match c.name.as_str() {
+                            "drop_memory" => 0,
+                            "merge_memories" => 1,
+                            "edit_memory" => 2,
+                            _ => 3,
                         });
-                    }
-                    w.save(&store_path)?;
+                        for call in &sorted {
+                            let out = w.execute_consolidator_tool(call, now);
+                            match call.name.as_str() {
+                                "merge_memories" if out.starts_with("Merged") => merged += 1,
+                                "drop_memory" if out.starts_with("Dropped") => dropped += 1,
+                                "edit_memory" if out.starts_with("Edited") => edited += 1,
+                                _ => {}
+                            }
+                            info!(tool = %call.name, result = %out, "consolidation tool executed");
+                            results.push(ToolResultMessage {
+                                tool_call_id: call.id.clone(),
+                                tool_name: call.name.clone(),
+                                content: out,
+                            });
+                        }
+                        w.clone()
+                    };
+                    save_snapshot.save(&store_path)?;
                     prior.push(ToolCallRound {
                         calls,
                         results,

--- a/src/memory/extraction.rs
+++ b/src/memory/extraction.rs
@@ -85,7 +85,9 @@ pub async fn run_memory_extraction(deps: ExtractionDeps, ctx: ExtractionContext)
     {
         let mut w = deps.store.write().await;
         if w.upsert_identity(&ctx.speaker_id, &ctx.speaker_username, Utc::now()) {
-            w.save(&deps.store_path)?;
+            let save_snapshot = w.clone();
+            drop(w);
+            save_snapshot.save(&deps.store_path)?;
         }
     }
 
@@ -146,25 +148,28 @@ pub async fn run_memory_extraction(deps: ExtractionDeps, ctx: ExtractionContext)
                     "Memory extraction: processing tool calls"
                 );
                 let mut results: Vec<ToolResultMessage> = Vec::with_capacity(calls.len());
-                let mut w = deps.store.write().await;
-                for call in &calls {
-                    let dctx = DispatchContext {
-                        speaker_id: &ctx.speaker_id,
-                        speaker_username: &ctx.speaker_username,
-                        speaker_role: ctx.speaker_role,
-                        caps: deps.caps.clone(),
-                        half_life_days: deps.half_life_days,
-                        now: Utc::now(),
-                    };
-                    let result = w.execute_tool_call(call, &dctx);
-                    info!(tool = %call.name, result = %result, "extraction tool executed");
-                    results.push(ToolResultMessage {
-                        tool_call_id: call.id.clone(),
-                        tool_name: call.name.clone(),
-                        content: result,
-                    });
-                }
-                w.save(&deps.store_path)?;
+                let save_snapshot = {
+                    let mut w = deps.store.write().await;
+                    for call in &calls {
+                        let dctx = DispatchContext {
+                            speaker_id: &ctx.speaker_id,
+                            speaker_username: &ctx.speaker_username,
+                            speaker_role: ctx.speaker_role,
+                            caps: deps.caps.clone(),
+                            half_life_days: deps.half_life_days,
+                            now: Utc::now(),
+                        };
+                        let result = w.execute_tool_call(call, &dctx);
+                        info!(tool = %call.name, result = %result, "extraction tool executed");
+                        results.push(ToolResultMessage {
+                            tool_call_id: call.id.clone(),
+                            tool_name: call.name.clone(),
+                            content: result,
+                        });
+                    }
+                    w.clone()
+                };
+                save_snapshot.save(&deps.store_path)?;
                 prior_rounds.push(ToolCallRound {
                     calls,
                     results,


### PR DESCRIPTION
## Summary

- Write lock on `Arc<RwLock<MemoryStore>>` was held across the synchronous `save()` call (`std::fs::write` + rename), blocking all concurrent `!ai` requests for the full disk-write duration.
- Fix: clone `MemoryStore` while the write guard is held (cheap in-memory copy), drop the guard at end of the block, then call `save()` on the clone — lock is free before any I/O starts.
- Bonus: merged the hard-drop and corroboration-boost steps in `consolidation.rs` into a single write lock + clone instead of two, saving one unnecessary clone + lock cycle.

Closes #20.

### Why not `spawn_blocking`?

`spawn_blocking` was tried first but caused a timing race in `memory_extractor_rejects_web_tool_calls`: extraction is fire-and-forget, and the blocking thread-pool latency caused the test to inspect `bot.llm.tool_calls()` before the second LLM call completed. The clone-and-drop pattern achieves the same lock-release guarantee without the non-determinism.

## Test plan

- [ ] `cargo test` — all existing tests pass (no new tests needed; the fix is structural)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Confirm CI green on all 7 required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)