### PR TITLE
Add Whisper support and send news via whispers

### DIFF
--- a/src/commands/news.rs
+++ b/src/commands/news.rs
@@ -16,7 +16,7 @@ use crate::{ChatHistoryEntry, ChatHistorySource};
 use super::{Command, CommandContext};
 
 const NEWS_PREFIX: &str = "ICYMI:";
-const NEWS_SYSTEM_PROMPT: &str = "Du fasst Twitch-Chat-Verlaeufe hilfreich zusammen. Antworte auf Deutsch, erfinde keine Details und konzentriere dich auf Themen, Highlights und wichtige Antworten. Beginne die Antwort mit \"ICYMI:\". Wenn du mehrere Themen auflistest, trenne sie mit \" | \". Bleibe kompakt, aber du musst dich nicht auf eine einzelne Twitch-Chatnachricht beschraenken.";
+const NEWS_SYSTEM_PROMPT: &str = "Du fasst Twitch-Chat-Verläufe hilfreich zusammen. Antworte auf Deutsch, erfinde keine Details und konzentriere dich auf Themen, Highlights und wichtige Antworten. Beginne die Antwort mit \"ICYMI:\". Wenn du mehrere Themen auflistest, trenne sie mit \" | \". Bleibe kompakt, aber du musst dich nicht auf eine einzelne Twitch-Chatnachricht beschränken.";
 const EMPTY_HISTORY_MESSAGE: &str =
     "Ich habe noch keine Chat-Historie für eine Zusammenfassung FDM";
 const NO_NEW_MESSAGES_MESSAGE: &str =

--- a/src/commands/news.rs
+++ b/src/commands/news.rs
@@ -3,19 +3,20 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use eyre::Result;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, warn};
 use twitch_irc::{login::LoginCredentials, transport::Transport};
 
 use crate::commands::ai::ChatContext;
 use crate::cooldown::{PerUserCooldown, format_cooldown_remaining};
 use crate::llm::{ChatCompletionRequest, LlmClient, Message};
 use crate::util::{MAX_RESPONSE_LENGTH, truncate_response};
+use crate::whisper::{WHISPER_MAX_CHARS, WhisperSender};
 use crate::{ChatHistoryEntry, ChatHistorySource};
 
 use super::{Command, CommandContext};
 
 const NEWS_PREFIX: &str = "ICYMI:";
-const NEWS_SYSTEM_PROMPT: &str = "Du fasst Twitch-Chat-Verlaeufe knapp und hilfreich zusammen. Antworte auf Deutsch, erfinde keine Details und konzentriere dich auf Themen, Highlights und wichtige Antworten. Beginne die Antwort mit \"ICYMI:\". Wenn du mehrere Themen auflistest, trenne sie mit \" | \". Halte die Antwort kurz genug fuer eine einzelne Twitch-Chatnachricht.";
+const NEWS_SYSTEM_PROMPT: &str = "Du fasst Twitch-Chat-Verlaeufe hilfreich zusammen. Antworte auf Deutsch, erfinde keine Details und konzentriere dich auf Themen, Highlights und wichtige Antworten. Beginne die Antwort mit \"ICYMI:\". Wenn du mehrere Themen auflistest, trenne sie mit \" | \". Bleibe kompakt, aber du musst dich nicht auf eine einzelne Twitch-Chatnachricht beschraenken.";
 const EMPTY_HISTORY_MESSAGE: &str =
     "Ich habe noch keine Chat-Historie für eine Zusammenfassung FDM";
 const NO_NEW_MESSAGES_MESSAGE: &str =
@@ -27,6 +28,7 @@ pub struct NewsCommand {
     cooldown: PerUserCooldown,
     timeout: Duration,
     chat_ctx: Option<ChatContext>,
+    whisper: Option<Arc<dyn WhisperSender>>,
 }
 
 impl NewsCommand {
@@ -36,6 +38,7 @@ impl NewsCommand {
         timeout: Duration,
         cooldown: Duration,
         chat_ctx: Option<ChatContext>,
+        whisper: Option<Arc<dyn WhisperSender>>,
     ) -> Self {
         Self {
             llm_client,
@@ -43,6 +46,7 @@ impl NewsCommand {
             cooldown: PerUserCooldown::new(cooldown),
             timeout,
             chat_ctx,
+            whisper,
         }
     }
 
@@ -84,6 +88,44 @@ impl NewsCommand {
 
         Some(messages)
     }
+
+    async fn send_news_response<T, L>(
+        &self,
+        ctx: &CommandContext<'_, T, L>,
+        response: &str,
+    ) -> String
+    where
+        T: Transport,
+        L: LoginCredentials,
+    {
+        if let Some(whisper) = &self.whisper {
+            match whisper.send_whisper(&ctx.privmsg.sender.id, response).await {
+                Ok(sent) => return sent,
+                Err(error) => {
+                    warn!(
+                        error = ?error,
+                        user = %ctx.privmsg.sender.login,
+                        "News whisper is not authenticated or unavailable; falling back to chat"
+                    );
+                }
+            }
+        } else {
+            warn!(
+                user = %ctx.privmsg.sender.login,
+                "News whisper is not configured or authenticated; falling back to chat"
+            );
+        }
+
+        let chat_response = truncate_response(response, MAX_RESPONSE_LENGTH);
+        if let Err(error) = ctx
+            .client
+            .say_in_reply_to(ctx.privmsg, chat_response.clone())
+            .await
+        {
+            error!(error = ?error, "Failed to send news response");
+        }
+        chat_response
+    }
 }
 
 fn is_news_response(chat: &ChatContext, entry: &ChatHistoryEntry) -> bool {
@@ -92,7 +134,7 @@ fn is_news_response(chat: &ChatContext, entry: &ChatHistoryEntry) -> bool {
         && entry.text.trim_start().starts_with(NEWS_PREFIX)
 }
 
-fn format_news_response(text: &str) -> String {
+fn format_news_response(text: &str, max_chars: usize) -> String {
     let trimmed = text.trim();
     let prefixed = if trimmed
         .get(..NEWS_PREFIX.len())
@@ -103,7 +145,7 @@ fn format_news_response(text: &str) -> String {
         format!("{NEWS_PREFIX} {trimmed}")
     };
 
-    truncate_response(&prefixed, MAX_RESPONSE_LENGTH)
+    truncate_response(&prefixed, max_chars)
 }
 
 #[async_trait]
@@ -187,7 +229,7 @@ where
             tokio::time::timeout(self.timeout, self.llm_client.chat_completion(request)).await;
 
         let (response, success) = match result {
-            Ok(Ok(text)) => (format_news_response(&text), true),
+            Ok(Ok(text)) => (format_news_response(&text, WHISPER_MAX_CHARS), true),
             Ok(Err(e)) => {
                 error!(error = ?e, "News AI execution failed");
                 ("Da ist was schiefgelaufen FDM".to_string(), false)
@@ -198,15 +240,25 @@ where
             }
         };
 
+        let sent_response = if success {
+            self.send_news_response(&ctx, &response).await
+        } else {
+            let chat_response = truncate_response(&response, MAX_RESPONSE_LENGTH);
+            if let Err(e) = ctx
+                .client
+                .say_in_reply_to(ctx.privmsg, chat_response.clone())
+                .await
+            {
+                error!(error = ?e, "Failed to send news response");
+            }
+            chat_response
+        };
+
         if let (true, Some(chat)) = (success, &self.chat_ctx) {
             chat.history
                 .lock()
                 .await
-                .push_bot(chat.bot_username.clone(), response.clone());
-        }
-
-        if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, response).await {
-            error!(error = ?e, "Failed to send news response");
+                .push_bot(chat.bot_username.clone(), sent_response);
         }
 
         Ok(())

--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -17,6 +17,7 @@ use crate::{
     seventv::SevenTvEmoteProvider,
     suspend::SuspensionManager,
     web_search,
+    whisper::WhisperSender,
 };
 
 /// Configuration for the generic command handler.
@@ -40,6 +41,7 @@ pub struct CommandHandlerConfig<T: Transport, L: LoginCredentials> {
     pub cooldowns: CooldownsConfig,
     pub tracker_tx: Option<tokio::sync::mpsc::Sender<flight_tracker::TrackerCommand>>,
     pub aviation_client: Option<aviation::AviationClient>,
+    pub whisper: Option<Arc<dyn WhisperSender>>,
     pub admin_channel: Option<String>,
     pub bot_username: String,
     pub channel: String,
@@ -71,6 +73,7 @@ where
         cooldowns,
         tracker_tx,
         aviation_client,
+        whisper,
         admin_channel,
         bot_username,
         channel,
@@ -214,6 +217,7 @@ where
             Duration::from_secs(cfg.timeout),
             Duration::from_secs(cooldowns.news),
             chat_ctx,
+            whisper,
         )));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod token_storage;
 pub mod twitch_setup;
 pub mod util;
 pub mod web_search;
+pub mod whisper;
 
 use std::path::PathBuf;
 use std::sync::{Arc, atomic::AtomicU32};
@@ -54,13 +55,17 @@ use crate::{
         tracker_1337::{TARGET_HOUR, TARGET_MINUTE, load_leaderboard, run_1337_handler},
     },
     llm::LlmClient,
+    whisper::WhisperSender,
 };
+
+pub type AuthenticatedLoginCredentials =
+    RefreshingLoginCredentials<crate::token_storage::FileBasedTokenStorage>;
 
 /// Generic alias for any authenticated Twitch IRC client. The production
 /// default is `SecureTCPTransport` + file-backed refreshing credentials.
 pub type AuthenticatedTwitchClient<
     T = twitch_irc::SecureTCPTransport,
-    L = RefreshingLoginCredentials<crate::token_storage::FileBasedTokenStorage>,
+    L = AuthenticatedLoginCredentials,
 > = TwitchIRCClient<T, L>;
 
 pub use chat_history::{
@@ -85,6 +90,7 @@ pub struct Services {
     pub clock: Arc<dyn Clock>,
     pub llm: Option<Arc<dyn LlmClient>>,
     pub aviation: Option<AviationClient>,
+    pub whisper: Option<Arc<dyn WhisperSender>>,
     pub data_dir: PathBuf,
 }
 
@@ -108,6 +114,7 @@ where
         clock,
         llm,
         aviation,
+        whisper,
         data_dir,
     } = services;
 
@@ -338,6 +345,7 @@ where
                 cooldowns: config.cooldowns.clone(),
                 tracker_tx,
                 aviation_client: aviation_for_commands,
+                whisper,
                 admin_channel: config.twitch.admin_channel.clone(),
                 bot_username: config.twitch.username.clone(),
                 channel: config.twitch.channel.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use color_eyre::eyre::Result;
+use secrecy::ExposeSecret as _;
 use tokio::sync::oneshot;
 use tracing::info;
 use twitch_1337::{
     Services, aviation, clock::SystemClock, ensure_data_dir, get_data_dir, install_crypto_provider,
-    install_tracing, llm, load_configuration, run_bot, setup_and_verify_twitch_client,
+    install_tracing, llm, load_configuration, run_bot, setup_and_verify_twitch_client, whisper,
 };
 
 #[tokio::main]
@@ -30,7 +31,8 @@ pub async fn main() -> Result<()> {
 
     ensure_data_dir().await?;
 
-    let (incoming, client) = setup_and_verify_twitch_client(&config).await?;
+    let (incoming, client, credentials, bot_user_id) =
+        setup_and_verify_twitch_client(&config).await?;
     let client = Arc::new(client);
 
     let llm_client = llm::build_llm_client(config.ai.as_ref())?;
@@ -46,10 +48,20 @@ pub async fn main() -> Result<()> {
         }
     };
 
+    let whisper = whisper::HelixWhisperSender::new(
+        credentials,
+        config.twitch.client_id.expose_secret().to_string(),
+        bot_user_id,
+        get_data_dir(),
+    )
+    .await
+    .map(|sender| Arc::new(sender) as Arc<dyn whisper::WhisperSender>)?;
+
     let services = Services {
         clock: Arc::new(SystemClock),
         llm: llm_client,
         aviation: aviation_client,
+        whisper: Some(whisper),
         data_dir: get_data_dir(),
     };
 

--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -14,7 +14,7 @@ use crate::util::get_data_dir;
 /// Token storage implementation that persists tokens to disk.
 ///
 /// Falls back to initial refresh token from config on first load if no token file exists.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileBasedTokenStorage {
     path: std::path::PathBuf,
     initial_refresh_token: SecretString,

--- a/src/twitch_setup.rs
+++ b/src/twitch_setup.rs
@@ -16,13 +16,20 @@ use twitch_irc::{
     message::{NoticeMessage, ServerMessage},
 };
 
-use crate::{AuthenticatedTwitchClient, FileBasedTokenStorage, config::Configuration};
+use crate::{
+    AuthenticatedLoginCredentials, AuthenticatedTwitchClient, FileBasedTokenStorage,
+    config::Configuration,
+};
 
 /// Create the Twitch IRC client and message receiver without connecting.
 #[instrument(skip(config))]
 pub async fn setup_twitch_client(
     config: &Configuration,
-) -> Result<(UnboundedReceiver<ServerMessage>, AuthenticatedTwitchClient)> {
+) -> Result<(
+    UnboundedReceiver<ServerMessage>,
+    AuthenticatedTwitchClient,
+    AuthenticatedLoginCredentials,
+)> {
     let credentials = RefreshingLoginCredentials::init_with_username(
         Some(config.twitch.username.clone()),
         config.twitch.client_id.expose_secret().to_string(),
@@ -33,11 +40,12 @@ pub async fn setup_twitch_client(
         .get_credentials()
         .await
         .wrap_err("Failed to obtain initial credentials")?;
-    let twitch_config = ClientConfig::new_simple(credentials);
-    Ok(TwitchIRCClient::<
+    let twitch_config = ClientConfig::new_simple(credentials.clone());
+    let (incoming, client) = TwitchIRCClient::<
         SecureTCPTransport,
         RefreshingLoginCredentials<FileBasedTokenStorage>,
-    >::new(twitch_config))
+    >::new(twitch_config);
+    Ok((incoming, client, credentials))
 }
 
 /// Connect, join channel(s), and verify authentication via `GlobalUserState`.
@@ -46,10 +54,15 @@ pub async fn setup_twitch_client(
 #[instrument(skip(config))]
 pub async fn setup_and_verify_twitch_client(
     config: &Configuration,
-) -> Result<(UnboundedReceiver<ServerMessage>, AuthenticatedTwitchClient)> {
+) -> Result<(
+    UnboundedReceiver<ServerMessage>,
+    AuthenticatedTwitchClient,
+    AuthenticatedLoginCredentials,
+    String,
+)> {
     info!("Setting up and verifying Twitch connection");
 
-    let (mut incoming_messages, client) = setup_twitch_client(config).await?;
+    let (mut incoming_messages, client, credentials) = setup_twitch_client(config).await?;
 
     info!("Connecting to Twitch IRC");
     client.connect().await;
@@ -90,9 +103,9 @@ pub async fn setup_and_verify_twitch_client(
                         Check your TWITCH_ACCESS_TOKEN and TWITCH_REFRESH_TOKEN."
                     );
                 }
-                ServerMessage::GlobalUserState(_) => {
+                ServerMessage::GlobalUserState(state) => {
                     info!("Connection verified and authenticated");
-                    return Ok(());
+                    return Ok(state.user_id);
                 }
                 _ => {}
             }
@@ -100,7 +113,7 @@ pub async fn setup_and_verify_twitch_client(
         bail!("Connection closed during verification")
     };
 
-    match tokio::time::timeout(Duration::from_secs(30), verification).await {
+    let bot_user_id = match tokio::time::timeout(Duration::from_secs(30), verification).await {
         Err(_) => {
             error!("Connection to Twitch IRC Server timed out");
             bail!("Connection to Twitch timed out")
@@ -108,5 +121,5 @@ pub async fn setup_and_verify_twitch_client(
         Ok(result) => result?,
     };
 
-    Ok((incoming_messages, client))
+    Ok((incoming_messages, client, credentials, bot_user_id))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,17 +44,36 @@ pub fn resolve_berlin_time(naive: chrono::NaiveDateTime) -> chrono::DateTime<chr
 /// Truncates a string to the maximum number of characters at a word boundary.
 pub fn truncate_response(text: &str, max_chars: usize) -> String {
     let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let suffix = "...";
+    let suffix_len = suffix.chars().count();
+    let content_limit = max_chars.saturating_sub(suffix_len);
+    if content_limit == 0 {
+        return collapsed.chars().take(max_chars).collect();
+    }
 
     let byte_limit = match collapsed.char_indices().nth(max_chars) {
         Some((byte_idx, _)) => byte_idx,
         None => return collapsed,
     };
 
-    let truncated = &collapsed[..byte_limit];
+    let content_byte_limit = collapsed
+        .char_indices()
+        .nth(content_limit)
+        .map_or(collapsed.len(), |(byte_idx, _)| byte_idx);
+    let truncated = &collapsed[..content_byte_limit.min(byte_limit)];
     if let Some(last_space) = truncated.rfind(' ') {
-        format!("{}...", &truncated[..last_space])
+        let prefix = &truncated[..last_space];
+        if prefix.is_empty() {
+            format!("{truncated}{suffix}")
+        } else {
+            format!("{prefix}{suffix}")
+        }
     } else {
-        format!("{}...", truncated)
+        format!("{truncated}{suffix}")
     }
 }
 

--- a/src/whisper.rs
+++ b/src/whisper.rs
@@ -1,0 +1,196 @@
+use std::{
+    collections::HashSet,
+    fmt::{self, Display},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use eyre::{Result, WrapErr as _};
+use reqwest::StatusCode;
+use serde_json::json;
+use tokio::{
+    fs::{self, File},
+    io::AsyncWriteExt,
+    sync::Mutex,
+};
+use tracing::warn;
+use twitch_irc::login::LoginCredentials;
+
+use crate::util::{APP_USER_AGENT, truncate_response};
+
+pub const FIRST_WHISPER_MAX_CHARS: usize = 500;
+pub const WHISPER_MAX_CHARS: usize = 10_000;
+
+#[derive(Debug)]
+pub enum WhisperError {
+    MissingToken,
+    Credentials(String),
+    EmptyMessage,
+    Api { status: StatusCode, body: String },
+    Http(reqwest::Error),
+    Unavailable(String),
+}
+
+impl WhisperError {
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable(reason.into())
+    }
+}
+
+impl Display for WhisperError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingToken => write!(f, "missing user access token for whisper API"),
+            Self::Credentials(error) => write!(f, "failed to obtain Twitch credentials: {error}"),
+            Self::EmptyMessage => write!(f, "whisper message is empty"),
+            Self::Api { status, body } => {
+                write!(f, "Twitch whisper API returned {status}: {body}")
+            }
+            Self::Http(error) => write!(f, "Twitch whisper API request failed: {error}"),
+            Self::Unavailable(reason) => write!(f, "whisper unavailable: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for WhisperError {}
+
+impl From<reqwest::Error> for WhisperError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Http(error)
+    }
+}
+
+#[async_trait]
+pub trait WhisperSender: Send + Sync {
+    /// Sends a whisper and returns the actual text submitted to Twitch.
+    async fn send_whisper(&self, to_user_id: &str, message: &str) -> Result<String, WhisperError>;
+}
+
+pub fn truncate_whisper_message(message: &str, known_recipient: bool) -> String {
+    let limit = if known_recipient {
+        WHISPER_MAX_CHARS
+    } else {
+        FIRST_WHISPER_MAX_CHARS
+    };
+    truncate_response(message, limit)
+}
+
+pub struct HelixWhisperSender<L>
+where
+    L: LoginCredentials,
+{
+    http: reqwest::Client,
+    credentials: L,
+    client_id: String,
+    from_user_id: String,
+    known_recipients: Arc<Mutex<HashSet<String>>>,
+    store_path: PathBuf,
+}
+
+impl<L> HelixWhisperSender<L>
+where
+    L: LoginCredentials,
+{
+    pub async fn new(
+        credentials: L,
+        client_id: String,
+        from_user_id: String,
+        data_dir: impl AsRef<Path>,
+    ) -> Result<Self> {
+        let store_path = data_dir.as_ref().join("whisper_recipients.ron");
+        let known_recipients = load_known_recipients(&store_path).await?;
+        let http = reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            .build()
+            .wrap_err("failed to build Twitch whisper HTTP client")?;
+
+        Ok(Self {
+            http,
+            credentials,
+            client_id,
+            from_user_id,
+            known_recipients: Arc::new(Mutex::new(known_recipients)),
+            store_path,
+        })
+    }
+
+    async fn remember_recipient(&self, to_user_id: &str) {
+        let snapshot = {
+            let mut guard = self.known_recipients.lock().await;
+            if !guard.insert(to_user_id.to_owned()) {
+                return;
+            }
+            guard.clone()
+        };
+
+        if let Err(error) = save_known_recipients(&self.store_path, &snapshot).await {
+            warn!(
+                error = ?error,
+                path = %self.store_path.display(),
+                "Failed to persist successful whisper recipient"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl<L> WhisperSender for HelixWhisperSender<L>
+where
+    L: LoginCredentials,
+{
+    async fn send_whisper(&self, to_user_id: &str, message: &str) -> Result<String, WhisperError> {
+        let known_recipient = self.known_recipients.lock().await.contains(to_user_id);
+        let message = truncate_whisper_message(message, known_recipient);
+        if message.trim().is_empty() {
+            return Err(WhisperError::EmptyMessage);
+        }
+
+        let credentials = self
+            .credentials
+            .get_credentials()
+            .await
+            .map_err(|error| WhisperError::Credentials(error.to_string()))?;
+        let token = credentials.token.ok_or(WhisperError::MissingToken)?;
+
+        let response = self
+            .http
+            .post("https://api.twitch.tv/helix/whispers")
+            .query(&[
+                ("from_user_id", self.from_user_id.as_str()),
+                ("to_user_id", to_user_id),
+            ])
+            .header("Client-Id", &self.client_id)
+            .bearer_auth(token)
+            .json(&json!({ "message": message }))
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::NO_CONTENT {
+            self.remember_recipient(to_user_id).await;
+            return Ok(message);
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(WhisperError::Api { status, body })
+    }
+}
+
+async fn load_known_recipients(path: &Path) -> Result<HashSet<String>> {
+    match fs::read_to_string(path).await {
+        Ok(contents) => {
+            ron::from_str(&contents).wrap_err("failed to parse whisper recipient store")
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(HashSet::new()),
+        Err(error) => Err(error).wrap_err("failed to read whisper recipient store"),
+    }
+}
+
+async fn save_known_recipients(path: &Path, recipients: &HashSet<String>) -> Result<()> {
+    let buffer = ron::to_string(recipients)?.into_bytes();
+    let tmp_path = path.with_extension("ron.tmp");
+    File::create(&tmp_path).await?.write_all(&buffer).await?;
+    fs::rename(&tmp_path, path).await?;
+    Ok(())
+}

--- a/tests/common/test_bot.rs
+++ b/tests/common/test_bot.rs
@@ -1,14 +1,15 @@
 //! One-stop integration test fixture. Assembles FakeTransport + FakeClock +
 //! FakeLlm + wiremock + tempdir into a live bot running behind `run_bot`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use eyre::Result;
+use eyre::Result as EyreResult;
 use tempfile::TempDir;
-use tokio::sync::oneshot;
+use tokio::sync::{Mutex, Notify, oneshot};
 use tokio::task::JoinHandle;
 use wiremock::MockServer;
 
@@ -18,6 +19,7 @@ use twitch_1337::{
     config::{AiConfig, Configuration},
     llm::LlmClient,
     run_bot,
+    whisper::{self, WhisperError, WhisperSender},
 };
 use twitch_irc::login::StaticLoginCredentials;
 use twitch_irc::{ClientConfig, TwitchIRCClient};
@@ -37,15 +39,17 @@ pub struct TestBot {
     pub nominatim_mock: MockServer,
     pub seventv_mock: MockServer,
     pub llm: Arc<FakeLlm>,
+    whisper: Arc<FakeWhisperSender>,
     pub channel: String,
     shutdown: Option<oneshot::Sender<()>>,
-    bot_task: Option<JoinHandle<Result<()>>>,
+    bot_task: Option<JoinHandle<EyreResult<()>>>,
 }
 
 pub struct TestBotBuilder {
     config: Configuration,
     now: DateTime<Utc>,
     seeded_leaderboard: Option<HashMap<String, PersonalBest>>,
+    whisper_failure: bool,
 }
 
 impl TestBotBuilder {
@@ -54,6 +58,7 @@ impl TestBotBuilder {
             config: Configuration::test_default(),
             now: "2026-04-18T11:00:00Z".parse().unwrap(),
             seeded_leaderboard: None,
+            whisper_failure: false,
         }
     }
 
@@ -96,6 +101,11 @@ impl TestBotBuilder {
         self
     }
 
+    pub fn with_failing_whispers(mut self) -> Self {
+        self.whisper_failure = true;
+        self
+    }
+
     pub async fn spawn(mut self) -> TestBot {
         let data_dir = TempDir::new().expect("tempdir");
 
@@ -117,6 +127,7 @@ impl TestBotBuilder {
             ai.emotes.base_url = Some(seventv_mock.uri());
         }
         let llm = Arc::new(FakeLlm::new());
+        let whisper = Arc::new(FakeWhisperSender::new(self.whisper_failure));
         let clock = FakeClock::new(self.now);
         let channel = self.config.twitch.channel.clone();
 
@@ -147,6 +158,7 @@ impl TestBotBuilder {
                 .is_some()
                 .then(|| llm.clone() as Arc<dyn LlmClient>),
             aviation: Some(aviation),
+            whisper: Some(whisper.clone() as Arc<dyn WhisperSender>),
             data_dir: data_dir.path().to_path_buf(),
         };
 
@@ -170,6 +182,7 @@ impl TestBotBuilder {
             nominatim_mock,
             seventv_mock,
             llm,
+            whisper,
             channel,
             shutdown: Some(shutdown_tx),
             bot_task: Some(bot_task),
@@ -220,6 +233,10 @@ impl TestBot {
         }
     }
 
+    pub async fn expect_whisper(&self, timeout: Duration) -> WhisperRecord {
+        self.whisper.expect(timeout).await
+    }
+
     pub async fn expect_silent(&mut self, dur: Duration) {
         let deadline = tokio::time::Instant::now() + dur;
         while tokio::time::Instant::now() < deadline {
@@ -253,5 +270,74 @@ impl TestBot {
                 Err(_) => panic!("bot shutdown timed out"),
             }
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WhisperRecord {
+    pub to_user_id: String,
+    pub message: String,
+}
+
+#[derive(Default)]
+struct FakeWhisperState {
+    known_recipients: HashSet<String>,
+    records: VecDeque<WhisperRecord>,
+}
+
+pub struct FakeWhisperSender {
+    state: Mutex<FakeWhisperState>,
+    notify: Notify,
+    fail: bool,
+}
+
+impl FakeWhisperSender {
+    fn new(fail: bool) -> Self {
+        Self {
+            state: Mutex::new(FakeWhisperState::default()),
+            notify: Notify::new(),
+            fail,
+        }
+    }
+
+    async fn expect(&self, timeout: Duration) -> WhisperRecord {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(record) = self.state.lock().await.records.pop_front() {
+                return record;
+            }
+
+            let now = tokio::time::Instant::now();
+            assert!(now < deadline, "timed out waiting for whisper");
+            tokio::time::timeout(deadline - now, self.notify.notified())
+                .await
+                .expect("timed out waiting for whisper");
+        }
+    }
+}
+
+#[async_trait]
+impl WhisperSender for FakeWhisperSender {
+    async fn send_whisper(
+        &self,
+        to_user_id: &str,
+        message: &str,
+    ) -> std::result::Result<String, WhisperError> {
+        if self.fail {
+            return Err(WhisperError::unavailable(
+                "test whisper sender is not authenticated",
+            ));
+        }
+
+        let mut state = self.state.lock().await;
+        let known_recipient = state.known_recipients.contains(to_user_id);
+        let message = whisper::truncate_whisper_message(message, known_recipient);
+        state.known_recipients.insert(to_user_id.to_owned());
+        state.records.push_back(WhisperRecord {
+            to_user_id: to_user_id.to_owned(),
+            message: message.clone(),
+        });
+        self.notify.notify_waiters();
+        Ok(message)
     }
 }

--- a/tests/news.rs
+++ b/tests/news.rs
@@ -4,11 +4,12 @@ use std::time::Duration;
 
 use common::TestBotBuilder;
 use serial_test::serial;
+use twitch_1337::whisper::{FIRST_WHISPER_MAX_CHARS, WHISPER_MAX_CHARS};
 
 #[tokio::test]
 #[serial]
 async fn news_command_summarizes_since_previous_user_message() {
-    let mut bot = TestBotBuilder::new()
+    let bot = TestBotBuilder::new()
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
@@ -27,9 +28,9 @@ async fn news_command_summarizes_since_previous_user_message() {
 
     bot.llm.push_chat("carol und dave haben Updates gepostet");
     bot.send("alice", "!news").await;
-    let out = bot.expect_say(Duration::from_secs(2)).await;
-    let body = out.strip_prefix(". ").unwrap_or(&out);
-    assert_eq!(body, "ICYMI: carol und dave haben Updates gepostet");
+    let out = bot.expect_whisper(Duration::from_secs(2)).await;
+    assert_eq!(out.to_user_id, "67890");
+    assert_eq!(out.message, "ICYMI: carol und dave haben Updates gepostet");
 
     let calls = bot.llm.chat_calls();
     assert_eq!(calls.len(), 1, "expected exactly one chat completion call");
@@ -81,7 +82,7 @@ async fn news_command_summarizes_since_previous_user_message() {
 #[tokio::test]
 #[serial]
 async fn news_command_uses_full_history_without_previous_user_message() {
-    let mut bot = TestBotBuilder::new()
+    let bot = TestBotBuilder::new()
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
@@ -98,9 +99,11 @@ async fn news_command_uses_full_history_without_previous_user_message() {
 
     bot.llm.push_chat("der ganze Verlauf wurde zusammengefasst");
     bot.send("alice", "!news").await;
-    let out = bot.expect_say(Duration::from_secs(2)).await;
-    let body = out.strip_prefix(". ").unwrap_or(&out);
-    assert_eq!(body, "ICYMI: der ganze Verlauf wurde zusammengefasst");
+    let out = bot.expect_whisper(Duration::from_secs(2)).await;
+    assert_eq!(
+        out.message,
+        "ICYMI: der ganze Verlauf wurde zusammengefasst"
+    );
 
     let calls = bot.llm.chat_calls();
     assert_eq!(calls.len(), 1, "expected exactly one chat completion call");
@@ -132,7 +135,7 @@ async fn news_command_uses_full_history_without_previous_user_message() {
 #[tokio::test]
 #[serial]
 async fn news_command_starts_after_previous_news_response() {
-    let mut bot = TestBotBuilder::new()
+    let bot = TestBotBuilder::new()
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
@@ -148,18 +151,16 @@ async fn news_command_starts_after_previous_news_response() {
 
     bot.llm.push_chat("icymi: old topic summary");
     bot.send("alice", "!news").await;
-    let first = bot.expect_say(Duration::from_secs(2)).await;
-    let first_body = first.strip_prefix(". ").unwrap_or(&first);
-    assert_eq!(first_body, "ICYMI: old topic summary");
+    let first = bot.expect_whisper(Duration::from_secs(2)).await;
+    assert_eq!(first.message, "ICYMI: old topic summary");
 
     bot.send("carol", "fresh topic").await;
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     bot.llm.push_chat("fresh topic summary");
     bot.send("dave", "!news").await;
-    let out = bot.expect_say(Duration::from_secs(2)).await;
-    let body = out.strip_prefix(". ").unwrap_or(&out);
-    assert_eq!(body, "ICYMI: fresh topic summary");
+    let out = bot.expect_whisper(Duration::from_secs(2)).await;
+    assert_eq!(out.message, "ICYMI: fresh topic summary");
 
     let calls = bot.llm.chat_calls();
     assert_eq!(calls.len(), 2, "expected two chat completion calls");
@@ -213,6 +214,100 @@ async fn news_command_without_history_does_not_call_llm() {
 
     let calls = bot.llm.chat_calls();
     assert!(calls.is_empty(), "no LLM call expected, got: {calls:?}");
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn news_command_limits_first_whisper_to_500_chars() {
+    let bot = TestBotBuilder::new()
+        .with_ai()
+        .with_config(|c| {
+            if let Some(ai) = c.ai.as_mut() {
+                ai.history_length = 10;
+            }
+        })
+        .spawn()
+        .await;
+
+    bot.send("bob", "lots happened").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    bot.llm.push_chat("sehr ".repeat(300));
+    bot.send_privmsg_as("alice", "alice-id", "!news").await;
+    let out = bot.expect_whisper(Duration::from_secs(2)).await;
+
+    assert_eq!(out.to_user_id, "alice-id");
+    assert!(
+        out.message.chars().count() <= FIRST_WHISPER_MAX_CHARS,
+        "first whisper exceeded limit: {}",
+        out.message.chars().count()
+    );
+    assert!(out.message.starts_with("ICYMI:"));
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn news_command_allows_longer_followup_whisper() {
+    let bot = TestBotBuilder::new()
+        .with_ai()
+        .with_config(|c| {
+            if let Some(ai) = c.ai.as_mut() {
+                ai.history_length = 10;
+            }
+            c.cooldowns.news = 0;
+        })
+        .spawn()
+        .await;
+
+    bot.send("bob", "first update").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    bot.llm.push_chat("first summary");
+    bot.send_privmsg_as("alice", "alice-id", "!news").await;
+    let first = bot.expect_whisper(Duration::from_secs(2)).await;
+    assert_eq!(first.message, "ICYMI: first summary");
+
+    bot.send("carol", "a lot more happened").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    bot.llm.push_chat("lang ".repeat(300));
+    bot.send_privmsg_as("alice", "alice-id", "!news").await;
+    let second = bot.expect_whisper(Duration::from_secs(2)).await;
+
+    let len = second.message.chars().count();
+    assert!(
+        len > FIRST_WHISPER_MAX_CHARS,
+        "follow-up was too short: {len}"
+    );
+    assert!(len <= WHISPER_MAX_CHARS, "follow-up exceeded limit: {len}");
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn news_command_falls_back_to_chat_when_whisper_fails() {
+    let mut bot = TestBotBuilder::new()
+        .with_ai()
+        .with_failing_whispers()
+        .with_config(|c| {
+            if let Some(ai) = c.ai.as_mut() {
+                ai.history_length = 10;
+            }
+        })
+        .spawn()
+        .await;
+
+    bot.send("bob", "fallback topic").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    bot.llm.push_chat("fallback summary");
+    bot.send("alice", "!news").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    let body = out.strip_prefix(". ").unwrap_or(&out);
+    assert_eq!(body, "ICYMI: fallback summary");
 
     bot.shutdown().await;
 }


### PR DESCRIPTION
Introduce Helix whisper support and wire it into the news command and services. Adds a new whisper module with a WhisperSender trait, HelixWhisperSender implementation, and constants for FIRST_WHISPER_MAX_CHARS/WHISPER_MAX_CHARS; messages are truncated appropriately. NewsCommand now attempts to whisper summaries to the requesting user (with fallback to public chat) and uses whisper-aware truncation when composing the message. Integrates whisper sender into service initialization and command handler config; twitch setup now returns authenticated credentials and bot user id so the whisper client can authenticate. Also: improve truncate_response logic to respect character limits/suffix, derive Clone for FileBasedTokenStorage, and update/add tests (FakeWhisperSender, new whisper-related tests, and adjustments to existing news tests).