### PR TITLE
Integrate Aviationstack API for flight tracking

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -39,6 +39,17 @@ client_secret = "your_client_secret"
 # up = 30        # !up command (default: 30)
 # feedback = 300 # !fb command (default: 300)
 
+# Optional: Aviationstack metadata enrichment for !track.
+# The bot uses this at most once per newly tracked flight to fetch route and
+# actual departure time. Live tracking still uses ADSB.lol.
+# Free Aviationstack accounts have a small monthly request quota, so keep this
+# disabled unless you have configured an API key.
+# [aviationstack]
+# enabled = false
+# api_key = "your_aviationstack_api_key_here"
+# base_url = "https://api.aviationstack.com/v1"
+# timeout_secs = 5
+
 # Optional: Suspend configuration
 # Controls the default suspend duration applied when no explicit duration is given.
 # Must be between 1 second and 604800 seconds (7 days).

--- a/src/aviation.rs
+++ b/src/aviation.rs
@@ -1,4 +1,6 @@
+use chrono::{DateTime, Utc};
 use eyre::{Result, WrapErr};
+use secrecy::ExposeSecret as _;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -9,7 +11,9 @@ use twitch_irc::{
     TwitchIRCClient, login::LoginCredentials, message::PrivmsgMessage, transport::Transport,
 };
 
+use crate::config::AviationstackConfig;
 use crate::cooldown::format_cooldown_remaining;
+use crate::flight_tracker::FlightIdentifier;
 use crate::util::{APP_USER_AGENT, MAX_RESPONSE_LENGTH, truncate_response};
 
 const ADSBDB_BASE_URL: &str = "https://api.adsbdb.com/v0";
@@ -153,6 +157,16 @@ fn is_iata_flight_number(s: &str) -> bool {
         && bytes[2..].iter().all(u8::is_ascii_digit)
 }
 
+fn is_icao_flight_number(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.len() < 4 || bytes.len() > 7 {
+        return false;
+    }
+    bytes[..3].iter().all(u8::is_ascii_uppercase)
+        && bytes[..3].iter().all(u8::is_ascii_alphabetic)
+        && bytes[3..].iter().all(u8::is_ascii_digit)
+}
+
 fn is_icao_pattern(s: &str) -> bool {
     s.len() == 4 && s.chars().all(|c| c.is_ascii_alphabetic())
 }
@@ -259,6 +273,145 @@ struct AdsbDbAirline {
     icao: String,
 }
 
+// --- aviationstack types ---
+
+#[derive(Debug, Deserialize)]
+struct AviationstackFlightsResponse {
+    #[serde(default)]
+    data: Vec<AviationstackFlight>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AviationstackFlight {
+    #[serde(default)]
+    flight: Option<AviationstackFlightIdentity>,
+    #[serde(default)]
+    airline: Option<AviationstackAirline>,
+    #[serde(default)]
+    departure: Option<AviationstackDeparture>,
+    #[serde(default)]
+    arrival: Option<AviationstackArrival>,
+    #[serde(default)]
+    aircraft: Option<AviationstackAircraft>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AviationstackFlightIdentity {
+    number: Option<String>,
+    iata: Option<String>,
+    icao: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AviationstackAirline {
+    name: Option<String>,
+    iata: Option<String>,
+    icao: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AviationstackDeparture {
+    iata: Option<String>,
+    icao: Option<String>,
+    scheduled: Option<String>,
+    actual: Option<String>,
+    actual_runway: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AviationstackArrival {
+    iata: Option<String>,
+    icao: Option<String>,
+    estimated: Option<String>,
+    actual: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AviationstackAircraft {
+    icao24: Option<String>,
+    icao: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AviationstackFlightMetadata {
+    pub flight_iata: Option<String>,
+    pub flight_icao: Option<String>,
+    pub flight_number: Option<String>,
+    pub airline_iata: Option<String>,
+    pub airline_icao: Option<String>,
+    pub airline_name: Option<String>,
+    pub departure_iata: Option<String>,
+    pub departure_icao: Option<String>,
+    pub departure_scheduled: Option<DateTime<Utc>>,
+    pub departure_actual: Option<DateTime<Utc>>,
+    pub departure_actual_runway: Option<DateTime<Utc>>,
+    pub arrival_iata: Option<String>,
+    pub arrival_icao: Option<String>,
+    pub arrival_estimated: Option<DateTime<Utc>>,
+    pub arrival_actual: Option<DateTime<Utc>>,
+    pub aircraft_icao24: Option<String>,
+    pub aircraft_icao: Option<String>,
+}
+
+impl AviationstackFlightMetadata {
+    pub fn takeoff_time(&self) -> Option<DateTime<Utc>> {
+        self.departure_actual_runway
+            .as_ref()
+            .cloned()
+            .or_else(|| self.departure_actual.as_ref().cloned())
+    }
+}
+
+impl From<AviationstackFlight> for AviationstackFlightMetadata {
+    fn from(value: AviationstackFlight) -> Self {
+        let flight = value.flight;
+        let airline = value.airline;
+        let departure = value.departure;
+        let arrival = value.arrival;
+        let aircraft = value.aircraft;
+
+        Self {
+            flight_iata: flight.as_ref().and_then(|f| f.iata.clone()),
+            flight_icao: flight.as_ref().and_then(|f| f.icao.clone()),
+            flight_number: flight.as_ref().and_then(|f| f.number.clone()),
+            airline_iata: airline.as_ref().and_then(|a| a.iata.clone()),
+            airline_icao: airline.as_ref().and_then(|a| a.icao.clone()),
+            airline_name: airline.as_ref().and_then(|a| a.name.clone()),
+            departure_iata: departure.as_ref().and_then(|d| d.iata.clone()),
+            departure_icao: departure.as_ref().and_then(|d| d.icao.clone()),
+            departure_scheduled: departure
+                .as_ref()
+                .and_then(|d| parse_aviationstack_datetime(d.scheduled.as_deref())),
+            departure_actual: departure
+                .as_ref()
+                .and_then(|d| parse_aviationstack_datetime(d.actual.as_deref())),
+            departure_actual_runway: departure
+                .as_ref()
+                .and_then(|d| parse_aviationstack_datetime(d.actual_runway.as_deref())),
+            arrival_iata: arrival.as_ref().and_then(|a| a.iata.clone()),
+            arrival_icao: arrival.as_ref().and_then(|a| a.icao.clone()),
+            arrival_estimated: arrival
+                .as_ref()
+                .and_then(|a| parse_aviationstack_datetime(a.estimated.as_deref())),
+            arrival_actual: arrival
+                .as_ref()
+                .and_then(|a| parse_aviationstack_datetime(a.actual.as_deref())),
+            aircraft_icao24: aircraft.as_ref().and_then(|a| a.icao24.clone()),
+            aircraft_icao: aircraft.as_ref().and_then(|a| a.icao.clone()),
+        }
+    }
+}
+
+fn parse_aviationstack_datetime(value: Option<&str>) -> Option<DateTime<Utc>> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
 // --- Nominatim types ---
 
 #[derive(Debug, Deserialize)]
@@ -276,6 +429,7 @@ pub struct AviationClient {
     adsblol_base_url: String,
     adsbdb_base_url: String,
     nominatim_base_url: String,
+    aviationstack: Option<AviationstackConfig>,
 }
 
 impl AviationClient {
@@ -303,7 +457,17 @@ impl AviationClient {
             adsblol_base_url,
             adsbdb_base_url,
             nominatim_base_url,
+            aviationstack: None,
         }
+    }
+
+    pub fn with_aviationstack_config(mut self, aviationstack: Option<AviationstackConfig>) -> Self {
+        self.aviationstack = aviationstack.filter(|cfg| cfg.enabled);
+        self
+    }
+
+    pub fn aviationstack_enabled(&self) -> bool {
+        self.aviationstack.is_some()
     }
 
     async fn get_aircraft_nearby(
@@ -390,6 +554,52 @@ impl AviationClient {
             .wrap_err("Failed to parse adsbdb response")?;
 
         Ok(body.response.flightroute)
+    }
+
+    pub async fn get_aviationstack_flight_metadata(
+        &self,
+        identifier: &FlightIdentifier,
+        callsign: Option<&str>,
+    ) -> Result<Option<AviationstackFlightMetadata>> {
+        let Some(config) = &self.aviationstack else {
+            return Ok(None);
+        };
+        let Some((query_key, query_value)) = aviationstack_query(identifier, callsign) else {
+            debug!(identifier = %identifier, "Skipping aviationstack lookup: no callsign query");
+            return Ok(None);
+        };
+
+        let url = format!("{}/flights", config.base_url.trim_end_matches('/'));
+        debug!(
+            query_key,
+            query_value = %query_value,
+            "Fetching flight metadata from aviationstack"
+        );
+
+        let timeout = Duration::from_secs(config.timeout_secs);
+        let resp: AviationstackFlightsResponse = self
+            .http
+            .get(&url)
+            .query(&[
+                ("access_key", config.api_key.expose_secret()),
+                (query_key, query_value.as_str()),
+                ("limit", "1"),
+            ])
+            .timeout(timeout)
+            .send()
+            .await
+            .wrap_err("Failed to send request to aviationstack")?
+            .error_for_status()
+            .wrap_err("aviationstack returned error status")?
+            .json()
+            .await
+            .wrap_err("Failed to parse aviationstack response")?;
+
+        Ok(resp
+            .data
+            .into_iter()
+            .next()
+            .map(AviationstackFlightMetadata::from))
     }
 
     /// Resolve a potential IATA flight number to an ICAO callsign.
@@ -503,6 +713,33 @@ impl AviationClient {
             lon,
             display_name,
         }))
+    }
+}
+
+fn aviationstack_query(
+    identifier: &FlightIdentifier,
+    callsign: Option<&str>,
+) -> Option<(&'static str, String)> {
+    let candidate = match identifier {
+        FlightIdentifier::Callsign(value) => value.as_str(),
+        FlightIdentifier::Hex(_) => callsign?,
+    }
+    .trim();
+
+    if candidate.is_empty() {
+        return None;
+    }
+
+    let candidate = candidate.to_uppercase();
+    if is_iata_flight_number(&candidate) {
+        Some(("flight_iata", candidate))
+    } else if is_icao_flight_number(&candidate)
+        || !matches!(identifier, FlightIdentifier::Hex(_))
+        || callsign.is_some()
+    {
+        Some(("flight_icao", candidate))
+    } else {
+        None
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@
 //! tests) can reference them without going through the binary entry point.
 
 use eyre::{Result, WrapErr, bail};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
 use tracing::info;
 
@@ -115,6 +115,25 @@ fn default_web_cache_capacity() -> usize {
 
 fn default_web_base_url() -> String {
     "http://localhost:8080/search".to_string()
+}
+
+fn default_aviationstack_base_url() -> String {
+    "https://api.aviationstack.com/v1".to_string()
+}
+
+fn default_aviationstack_timeout_secs() -> u64 {
+    5
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AviationstackConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    pub api_key: SecretString,
+    #[serde(default = "default_aviationstack_base_url")]
+    pub base_url: String,
+    #[serde(default = "default_aviationstack_timeout_secs")]
+    pub timeout_secs: u64,
 }
 
 /// Per-scope caps + decay policy for the AI memory store. See
@@ -442,6 +461,8 @@ pub struct ScheduleConfig {
 pub struct Configuration {
     pub twitch: TwitchConfiguration,
     #[serde(default)]
+    pub aviationstack: Option<AviationstackConfig>,
+    #[serde(default)]
     pub pings: PingsConfig,
     #[serde(default)]
     pub cooldowns: CooldownsConfig,
@@ -470,6 +491,7 @@ impl Configuration {
                 hidden_admins: Vec::new(),
                 admin_channel: None,
             },
+            aviationstack: None,
             pings: PingsConfig::default(),
             cooldowns: CooldownsConfig::default(),
             suspend: SuspendConfig::default(),
@@ -538,6 +560,24 @@ pub fn validate_config(config: &Configuration) -> Result<()> {
             "suspend.default_duration_secs must be between 1 and 604800 (7 days) (got {})",
             config.suspend.default_duration_secs
         );
+    }
+
+    if let Some(ref aviationstack) = config.aviationstack {
+        if aviationstack.enabled && aviationstack.api_key.expose_secret().trim().is_empty() {
+            bail!("aviationstack.api_key cannot be empty when aviationstack is enabled");
+        }
+        if aviationstack.base_url.trim().is_empty() {
+            bail!("aviationstack.base_url cannot be empty");
+        }
+        reqwest::Url::parse(&aviationstack.base_url).wrap_err_with(|| {
+            format!(
+                "aviationstack.base_url must be a valid URL (got {:?})",
+                aviationstack.base_url
+            )
+        })?;
+        if aviationstack.timeout_secs == 0 {
+            bail!("aviationstack.timeout_secs must be > 0");
+        }
     }
 
     if let Some(ref ai) = config.ai

--- a/src/flight_tracker.rs
+++ b/src/flight_tracker.rs
@@ -11,7 +11,9 @@ use twitch_irc::{
     TwitchIRCClient, login::LoginCredentials, message::PrivmsgMessage, transport::Transport,
 };
 
-use crate::aviation::{AltBaro, AviationClient, NearbyAircraft, iata_to_coords};
+use crate::aviation::{
+    AltBaro, AviationClient, AviationstackFlightMetadata, NearbyAircraft, iata_to_coords,
+};
 use crate::clock::Clock;
 
 const FLIGHTS_FILENAME: &str = "flights.ron";
@@ -158,6 +160,10 @@ pub struct TrackedFlight {
     pub last_seen: Option<DateTime<Utc>>,
     pub last_phase_change: Option<DateTime<Utc>>,
     pub polls_since_change: u32,
+    #[serde(default)]
+    pub takeoff_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub aviationstack_checked: bool,
 
     // Divert detection
     #[serde(default)]
@@ -272,6 +278,17 @@ pub(crate) fn altitude_ft(ac: &NearbyAircraft) -> Option<i64> {
 
 pub(crate) fn vertical_rate(ac: &NearbyAircraft) -> Option<i64> {
     ac.baro_rate.or(ac.geom_rate)
+}
+
+fn is_airborne_phase(phase: FlightPhase) -> bool {
+    matches!(
+        phase,
+        FlightPhase::Takeoff
+            | FlightPhase::Climb
+            | FlightPhase::Cruise
+            | FlightPhase::Descent
+            | FlightPhase::Approach
+    )
 }
 
 /// Determines the new flight phase based on current ADS-B data and previous state.
@@ -399,6 +416,47 @@ fn format_route(route: &Option<(String, String)>) -> String {
     }
 }
 
+fn set_route_from_iata(flight: &mut TrackedFlight, origin: &str, dest: &str) {
+    let origin = origin.trim().to_uppercase();
+    let dest = dest.trim().to_uppercase();
+    if origin.is_empty() || dest.is_empty() {
+        return;
+    }
+
+    if let Some((lat, lon, _)) = iata_to_coords(&dest) {
+        flight.dest_lat = Some(lat);
+        flight.dest_lon = Some(lon);
+    }
+    flight.route = Some((origin, dest));
+}
+
+fn apply_aviationstack_metadata(flight: &mut TrackedFlight, metadata: AviationstackFlightMetadata) {
+    let takeoff_at = metadata.takeoff_time();
+
+    if let (Some(origin), Some(dest)) = (
+        metadata.departure_iata.as_deref(),
+        metadata.arrival_iata.as_deref(),
+    ) {
+        set_route_from_iata(flight, origin, dest);
+    }
+
+    if flight.hex.is_none()
+        && let Some(hex) = metadata.aircraft_icao24
+    {
+        flight.hex = Some(hex.to_uppercase());
+    }
+
+    if flight.aircraft_type.is_none()
+        && let Some(aircraft_type) = metadata.aircraft_icao
+    {
+        flight.aircraft_type = Some(aircraft_type.to_uppercase());
+    }
+
+    if let Some(takeoff_at) = takeoff_at {
+        flight.takeoff_at = Some(takeoff_at);
+    }
+}
+
 /// Formats the flight prefix: "DLH123 (A320) FRA->MUC" with graceful degradation.
 fn format_flight_prefix(flight: &TrackedFlight) -> String {
     let name = flight
@@ -439,12 +497,20 @@ pub(crate) fn msg_approach(flight: &TrackedFlight) -> String {
 }
 
 pub(crate) fn msg_landing(flight: &TrackedFlight, now: DateTime<Utc>) -> String {
-    let duration = now.signed_duration_since(flight.tracked_at);
-    format!(
-        "{} ist gelandet! Flugzeit: {}",
-        format_flight_prefix(flight),
-        format_duration_hm(duration)
-    )
+    match flight.takeoff_at {
+        Some(takeoff_at) => {
+            let duration = now.signed_duration_since(takeoff_at);
+            format!(
+                "{} ist gelandet! Flugzeit: {}",
+                format_flight_prefix(flight),
+                format_duration_hm(duration)
+            )
+        }
+        None => format!(
+            "{} ist gelandet! Flugzeit: unbekannt (Takeoff nicht beobachtet)",
+            format_flight_prefix(flight)
+        ),
+    }
 }
 
 pub(crate) fn msg_squawk_emergency(flight: &TrackedFlight, code: &str, meaning: &str) -> String {
@@ -805,6 +871,8 @@ async fn handle_track<T, L>(
         last_seen: Some(now),
         last_phase_change: None,
         polls_since_change: 0,
+        takeoff_at: None,
+        aviationstack_checked: false,
         divert_consecutive_polls: 0,
         dest_lat: None,
         dest_lon: None,
@@ -813,21 +881,34 @@ async fn handle_track<T, L>(
     // Detect initial phase
     flight.phase = detect_phase(&flight, &ac);
 
-    // Fetch route if we have a callsign
-    if let Some(cs) = &callsign {
+    if aviation_client.aviationstack_enabled() {
+        flight.aviationstack_checked = true;
+        match aviation_client
+            .get_aviationstack_flight_metadata(&identifier, callsign.as_deref())
+            .await
+        {
+            Ok(Some(metadata)) => {
+                apply_aviationstack_metadata(&mut flight, metadata);
+            }
+            Ok(None) => {
+                debug!(identifier = %identifier, "No aviationstack metadata found for flight");
+            }
+            Err(e) => {
+                warn!(error = ?e, identifier = %identifier, "Aviationstack metadata lookup failed");
+            }
+        }
+    }
+
+    // Fetch route if we have a callsign and aviationstack did not provide one.
+    if flight.route.is_none()
+        && let Some(cs) = &callsign
+    {
         match tokio::time::timeout(ROUTE_FETCH_TIMEOUT, aviation_client.get_flight_route(cs)).await
         {
             Ok(Ok(Some(route))) => {
                 let origin = route.origin.iata_code.clone();
                 let dest = route.destination.iata_code.clone();
-
-                // Resolve destination coordinates for divert detection
-                if let Some((lat, lon, _)) = iata_to_coords(&dest) {
-                    flight.dest_lat = Some(lat);
-                    flight.dest_lon = Some(lon);
-                }
-
-                flight.route = Some((origin, dest));
+                set_route_from_iata(&mut flight, &origin, &dest);
             }
             Ok(Ok(None)) => {
                 debug!(callsign = %cs, "No route found for flight");
@@ -1099,6 +1180,13 @@ async fn poll_all_flights<T, L>(
             flight.polls_since_change = 0;
             changed = true;
 
+            if old_phase == FlightPhase::Ground
+                && is_airborne_phase(new_phase)
+                && flight.takeoff_at.is_none()
+            {
+                flight.takeoff_at = Some(now);
+            }
+
             // Post phase change messages
             match new_phase {
                 FlightPhase::Takeoff => messages.push(msg_takeoff(flight)),
@@ -1112,6 +1200,7 @@ async fn poll_all_flights<T, L>(
             // Landing transitions to Ground after posting
             if new_phase == FlightPhase::Landing {
                 flight.phase = FlightPhase::Ground;
+                flight.takeoff_at = None;
             }
         } else {
             flight.polls_since_change += 1;
@@ -1177,5 +1266,118 @@ async fn poll_all_flights<T, L>(
     // Persist if any state changed
     if changed {
         save_tracker_state(data_dir, state).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dt(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn tracked_flight() -> TrackedFlight {
+        TrackedFlight {
+            identifier: FlightIdentifier::Callsign("DLH1234".to_string()),
+            callsign: Some("DLH1234".to_string()),
+            hex: None,
+            phase: FlightPhase::Landing,
+            route: None,
+            aircraft_type: None,
+            altitude_ft: None,
+            vertical_rate_fpm: None,
+            ground_speed_kts: None,
+            lat: None,
+            lon: None,
+            squawk: None,
+            tracked_by: "alice".to_string(),
+            tracked_at: dt("2026-04-18T10:00:00Z"),
+            last_seen: None,
+            last_phase_change: None,
+            polls_since_change: 0,
+            takeoff_at: None,
+            aviationstack_checked: false,
+            divert_consecutive_polls: 0,
+            dest_lat: None,
+            dest_lon: None,
+        }
+    }
+
+    fn metadata() -> AviationstackFlightMetadata {
+        AviationstackFlightMetadata {
+            flight_iata: None,
+            flight_icao: None,
+            flight_number: None,
+            airline_iata: None,
+            airline_icao: None,
+            airline_name: None,
+            departure_iata: None,
+            departure_icao: None,
+            departure_scheduled: None,
+            departure_actual: None,
+            departure_actual_runway: None,
+            arrival_iata: None,
+            arrival_icao: None,
+            arrival_estimated: None,
+            arrival_actual: None,
+            aircraft_icao24: None,
+            aircraft_icao: None,
+        }
+    }
+
+    #[test]
+    fn landing_uses_takeoff_time_not_tracking_time() {
+        let mut flight = tracked_flight();
+        flight.takeoff_at = Some(dt("2026-04-18T10:30:00Z"));
+
+        let msg = msg_landing(&flight, dt("2026-04-18T12:00:00Z"));
+
+        assert!(msg.contains("Flugzeit: 1h30m"), "got: {msg}");
+        assert!(!msg.contains("2h00m"), "got: {msg}");
+    }
+
+    #[test]
+    fn landing_reports_unknown_duration_without_takeoff_time() {
+        let flight = tracked_flight();
+
+        let msg = msg_landing(&flight, dt("2026-04-18T12:00:00Z"));
+
+        assert!(
+            msg.contains("Flugzeit: unbekannt (Takeoff nicht beobachtet)"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn aviationstack_metadata_sets_route_and_actual_runway_takeoff() {
+        let mut flight = tracked_flight();
+        let mut metadata = metadata();
+        metadata.departure_iata = Some("fra".to_string());
+        metadata.arrival_iata = Some("muc".to_string());
+        metadata.departure_actual = Some(dt("2026-04-18T10:00:00Z"));
+        metadata.departure_actual_runway = Some(dt("2026-04-18T10:05:00Z"));
+        metadata.aircraft_icao24 = Some("3c6589".to_string());
+        metadata.aircraft_icao = Some("a320".to_string());
+
+        apply_aviationstack_metadata(&mut flight, metadata);
+
+        assert_eq!(flight.route, Some(("FRA".to_string(), "MUC".to_string())));
+        assert_eq!(flight.takeoff_at, Some(dt("2026-04-18T10:05:00Z")));
+        assert_eq!(flight.hex.as_deref(), Some("3C6589"));
+        assert_eq!(flight.aircraft_type.as_deref(), Some("A320"));
+    }
+
+    #[test]
+    fn aviationstack_metadata_falls_back_to_actual_departure() {
+        let mut flight = tracked_flight();
+        let mut metadata = metadata();
+        metadata.departure_actual = Some(dt("2026-04-18T10:00:00Z"));
+
+        apply_aviationstack_metadata(&mut flight, metadata);
+
+        assert_eq!(flight.takeoff_at, Some(dt("2026-04-18T10:00:00Z")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,9 @@ pub async fn main() -> Result<()> {
 
     let llm_client = llm::build_llm_client(config.ai.as_ref())?;
 
-    let aviation_client = match aviation::AviationClient::new() {
+    let aviation_client = match aviation::AviationClient::new()
+        .map(|client| client.with_aviationstack_config(config.aviationstack.clone()))
+    {
         Ok(c) => Some(c),
         Err(e) => {
             tracing::error!(

--- a/tests/common/test_bot.rs
+++ b/tests/common/test_bot.rs
@@ -120,6 +120,12 @@ impl TestBotBuilder {
             MockServer::start(),
             MockServer::start()
         );
+        if let Some(aviationstack) = self.config.aviationstack.as_mut()
+            && aviationstack.enabled
+            && aviationstack.base_url == "https://api.aviationstack.com/v1"
+        {
+            aviationstack.base_url = adsb_mock.uri();
+        }
         if let Some(ai) = self.config.ai.as_mut()
             && ai.emotes.enabled
             && ai.emotes.base_url.is_none()
@@ -148,7 +154,8 @@ impl TestBotBuilder {
             adsb_mock.uri(),      // adsbdb shares the same mock server in tests
             nominatim_mock.uri(), // nominatim
             http,
-        );
+        )
+        .with_aviationstack_config(self.config.aviationstack.clone());
 
         let services = Services {
             clock: clock.clone(),

--- a/tests/flight_tracker.rs
+++ b/tests/flight_tracker.rs
@@ -3,9 +3,20 @@ mod common;
 use std::time::Duration;
 
 use common::TestBotBuilder;
+use secrecy::SecretString;
 use serial_test::serial;
-use wiremock::matchers::{method, path_regex};
+use twitch_1337::config::AviationstackConfig;
+use wiremock::matchers::{method, path, path_regex, query_param};
 use wiremock::{Mock, ResponseTemplate};
+
+fn enable_aviationstack(config: &mut twitch_1337::config::Configuration) {
+    config.aviationstack = Some(AviationstackConfig {
+        enabled: true,
+        api_key: SecretString::new("test-key".into()),
+        base_url: "https://api.aviationstack.com/v1".to_string(),
+        timeout_secs: 5,
+    });
+}
 
 #[tokio::test]
 #[serial]
@@ -43,6 +54,116 @@ async fn track_command_acknowledges_flight() {
         ack.contains("DLH1234") || ack.to_lowercase().contains("track"),
         "expected track ack, got: {ack}"
     );
+    let aviationstack_requests = bot
+        .adsb_mock
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/flights")
+        .count();
+    assert_eq!(aviationstack_requests, 0);
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn track_command_enriches_flight_from_aviationstack_once() {
+    let bot = TestBotBuilder::new()
+        .with_config(enable_aviationstack)
+        .spawn()
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/callsign/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ac": [{
+                "hex": "3c6589",
+                "flight": "DLH1234",
+                "alt_baro": 35000,
+                "gs": 450.0,
+                "baro_rate": 0,
+                "lat": 50.0,
+                "lon": 8.5,
+                "squawk": "1000"
+            }],
+            "ctime": 0,
+            "now": 0,
+            "total": 1
+        })))
+        .mount(&bot.adsb_mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/flights"))
+        .and(query_param("access_key", "test-key"))
+        .and(query_param("flight_icao", "DLH1234"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{
+                "flight": {
+                    "iata": "LH1234",
+                    "icao": "DLH1234",
+                    "number": "1234"
+                },
+                "airline": {
+                    "iata": "LH",
+                    "icao": "DLH",
+                    "name": "Lufthansa"
+                },
+                "departure": {
+                    "iata": "FRA",
+                    "icao": "EDDF",
+                    "scheduled": "2026-04-18T09:45:00+00:00",
+                    "actual": "2026-04-18T10:00:00+00:00",
+                    "actual_runway": "2026-04-18T10:05:00+00:00"
+                },
+                "arrival": {
+                    "iata": "MUC",
+                    "icao": "EDDM",
+                    "estimated": "2026-04-18T11:00:00+00:00",
+                    "actual": null
+                },
+                "aircraft": {
+                    "icao24": "3c6589",
+                    "icao": "A320"
+                }
+            }]
+        })))
+        .mount(&bot.adsb_mock)
+        .await;
+
+    let mut bot = bot;
+    bot.send("alice", "!track DLH1234").await;
+    let ack = bot.expect_say(Duration::from_secs(5)).await;
+    assert!(ack.contains("FRA") && ack.contains("MUC"), "got: {ack}");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let aviationstack_requests = bot
+        .adsb_mock
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/flights")
+        .count();
+    assert_eq!(aviationstack_requests, 1);
+
+    let state_path = bot.data_dir.path().join("flights.ron");
+    let persisted = tokio::fs::read_to_string(state_path).await.unwrap();
+    let state: twitch_1337::flight_tracker::FlightTrackerState = ron::from_str(&persisted).unwrap();
+    let flight = state.flights.first().expect("persisted flight");
+    assert_eq!(flight.route, Some(("FRA".to_string(), "MUC".to_string())));
+    assert_eq!(
+        flight.takeoff_at.map(|dt| dt.timestamp()),
+        Some(
+            chrono::DateTime::parse_from_rfc3339("2026-04-18T10:05:00+00:00")
+                .unwrap()
+                .timestamp()
+        )
+    );
+    assert!(flight.aviationstack_checked);
 
     bot.shutdown().await;
 }


### PR DESCRIPTION
## Summary
- Add optional Aviationstack metadata enrichment for `!track`
- Use Aviationstack once per newly tracked flight to fetch route and departure timestamps
- Persist `takeoff_at` and use it for landing flight duration
- Stop reporting tracking duration as flight duration when takeoff was not observed

## Details
ADSB.lol remains the live tracking source. Aviationstack is only used at tracking start, with `limit=1`, to minimize API usage.

Flight duration now uses:
1. `departure.actual_runway` from Aviationstack
2. fallback to `departure.actual`
3. fallback to locally observed takeoff
4. otherwise `Flugzeit: unbekannt (Takeoff nicht beobachtet)`

## Tests
- `cargo test --test flight_tracker`
- `cargo test`
