### PR TITLE
refactor: util::persist helpers + slim run_bot

### DIFF
--- a/src/ai/command.rs
+++ b/src/ai/command.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::Utc;
 use eyre::{Result, eyre};
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, warn};
 use twitch_irc::{login::LoginCredentials, transport::Transport};
 
 use crate::ai::chat_history::{ChatHistory, ChatHistoryQuery, MAX_TOOL_RESULT_MESSAGES};
@@ -641,5 +641,117 @@ where
         }
 
         Ok(())
+    }
+}
+
+/// Outcome of attempting to build the AI memory bundle from config + an LLM
+/// handle. All three fields are `None` when AI is disabled or memory load
+/// failed; otherwise they are populated and ready to feed into the command
+/// handler + the daily consolidation task.
+pub struct AiMemoryBundle {
+    pub ai_memory: Option<AiMemory>,
+    pub consolidation_model: Option<String>,
+    pub consolidation_reasoning_effort: Option<String>,
+}
+
+/// Construct the optional AI memory bundle from config + an LLM handle.
+///
+/// Returns an empty bundle when AI is disabled, no LLM is wired, or
+/// `[ai.memory].enabled = false`. Logs (warn!) on deprecated fields and
+/// (error!) on store load failure.
+pub fn build_ai_memory(
+    ai: Option<&crate::config::AiConfig>,
+    llm: Option<&Arc<dyn LlmClient>>,
+    data_dir: &std::path::Path,
+) -> AiMemoryBundle {
+    let empty = || AiMemoryBundle {
+        ai_memory: None,
+        consolidation_model: None,
+        consolidation_reasoning_effort: None,
+    };
+
+    let (Some(ai), Some(llm_arc)) = (ai, llm) else {
+        return empty();
+    };
+    if !ai.memory.enabled {
+        return empty();
+    }
+
+    let extraction_model = ai
+        .extraction
+        .model
+        .clone()
+        .unwrap_or_else(|| ai.model.clone());
+    let extraction_reasoning_effort = ai
+        .extraction
+        .reasoning_effort
+        .clone()
+        .or_else(|| ai.reasoning_effort.clone());
+    let consolidation_model = ai
+        .consolidation
+        .model
+        .clone()
+        .or_else(|| ai.extraction.model.clone())
+        .unwrap_or_else(|| ai.model.clone());
+    let consolidation_reasoning_effort = ai
+        .consolidation
+        .reasoning_effort
+        .clone()
+        .or_else(|| ai.extraction.reasoning_effort.clone())
+        .or_else(|| ai.reasoning_effort.clone());
+
+    match memory::MemoryStore::load(data_dir) {
+        Ok((store, path)) => {
+            // Back-compat: honor the deprecated `ai.max_memories` when the
+            // user hasn't overridden `[ai.memory].max_user`. Either way,
+            // emit a warn! so stale configs surface.
+            let max_user = if let Some(legacy_n) = ai.max_memories {
+                if ai.memory.max_user == crate::config::default_max_user() {
+                    warn!(
+                        "ai.max_memories is deprecated; migrating to [ai.memory].max_user = {legacy_n}. Please update your config."
+                    );
+                    legacy_n
+                } else {
+                    warn!(
+                        "ai.max_memories={} is deprecated AND ignored because [ai.memory].max_user={} is explicitly set. Remove the deprecated field.",
+                        legacy_n, ai.memory.max_user
+                    );
+                    ai.memory.max_user
+                }
+            } else {
+                ai.memory.max_user
+            };
+
+            let config = memory::MemoryConfig {
+                store: Arc::new(tokio::sync::RwLock::new(store)),
+                path,
+                caps: memory::Caps {
+                    max_user,
+                    max_lore: ai.memory.max_lore,
+                    max_pref: ai.memory.max_pref,
+                },
+                half_life_days: ai.memory.half_life_days,
+            };
+            let ai_memory = AiMemory {
+                config,
+                extraction_deps: AiExtractionDeps {
+                    enabled: ai.extraction.enabled,
+                    llm: llm_arc.clone(),
+                    model: extraction_model,
+                    reasoning_effort: extraction_reasoning_effort,
+                    timeout: Duration::from_secs(ai.extraction.timeout.unwrap_or(ai.timeout)),
+                    max_rounds: ai.extraction.max_rounds,
+                },
+            };
+            AiMemoryBundle {
+                ai_memory: Some(ai_memory),
+                consolidation_model: Some(consolidation_model),
+                consolidation_reasoning_effort,
+            }
+        }
+        Err(e) => {
+            error!(error = ?e, "Failed to load AI memory store, memory disabled");
+            empty()
+        }
     }
 }

--- a/src/ai/memory/store.rs
+++ b/src/ai/memory/store.rs
@@ -190,12 +190,8 @@ impl MemoryStore {
 
     /// Write current state to disk using write+rename for atomicity.
     pub fn save(&self, path: &Path) -> Result<()> {
-        let tmp_path = path.with_extension("ron.tmp");
-        let data = ron::ser::to_string_pretty(self, ron::ser::PrettyConfig::default())
-            .wrap_err("Failed to serialize AI memories")?;
-        std::fs::write(&tmp_path, &data).wrap_err("Failed to write ai_memory.ron.tmp")?;
-        std::fs::rename(&tmp_path, path)
-            .wrap_err("Failed to rename ai_memory.ron.tmp to ai_memory.ron")?;
+        crate::util::persist::atomic_save_ron(self, path)
+            .wrap_err("Failed to save ai_memory.ron")?;
         debug!("Saved AI memories to disk");
         Ok(())
     }

--- a/src/aviation/tracker.rs
+++ b/src/aviation/tracker.rs
@@ -216,24 +216,13 @@ pub(crate) async fn load_tracker_state(data_dir: &Path) -> FlightTrackerState {
 /// Saves tracked flights to the RON file using atomic write+rename.
 pub(crate) async fn save_tracker_state(data_dir: &Path, state: &FlightTrackerState) {
     let path = data_dir.join(FLIGHTS_FILENAME);
-    let tmp_path = path.with_extension("ron.tmp");
-    match ron::to_string(state) {
-        Ok(serialized) => {
-            if let Err(e) = fs::write(&tmp_path, serialized.as_bytes()).await {
-                tracing::error!(error = ?e, "Failed to write flight tracker state tmp");
-            } else if let Err(e) = fs::rename(&tmp_path, &path).await {
-                tracing::error!(error = ?e, "Failed to rename flight tracker state");
-            } else {
-                tracing::debug!(
-                    flights = state.flights.len(),
-                    "Saved flight tracker state to {}",
-                    path.display()
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!(error = ?e, "Failed to serialize flight tracker state");
-        }
+    match crate::util::persist::atomic_save_ron_async(state, &path).await {
+        Ok(()) => tracing::debug!(
+            flights = state.flights.len(),
+            "Saved flight tracker state to {}",
+            path.display()
+        ),
+        Err(e) => tracing::error!(error = ?e, "Failed to save flight tracker state"),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,6 @@ where
         flight_tracker,
         config_watcher,
         scheduled_messages,
-        tracker_tx: _tracker_tx,
         shutdown_notify,
     } = spawn_handlers(SpawnDeps {
         client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use eyre::{Result, WrapErr as _};
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tokio::time::Duration;
-use tracing::{error, info, warn};
+use tracing::info;
 use twitch_irc::{
     TwitchIRCClient,
     login::{LoginCredentials, RefreshingLoginCredentials},
@@ -34,7 +34,7 @@ use crate::{
     aviation::AviationClient,
     config::Configuration,
     twitch::handlers::{
-        spawn::{HandlerSet, SpawnDeps, spawn_handlers},
+        spawn::{SpawnDeps, spawn_handlers},
         tracker_1337::{TARGET_HOUR, TARGET_MINUTE, load_leaderboard},
     },
     twitch::whisper::WhisperSender,
@@ -139,16 +139,7 @@ where
     });
     let consolidation_settings = config.ai.as_ref().map(|a| a.consolidation.clone());
 
-    let HandlerSet {
-        router,
-        latency,
-        tracker_1337,
-        generic_commands,
-        flight_tracker,
-        config_watcher,
-        scheduled_messages,
-        shutdown_notify,
-    } = spawn_handlers(SpawnDeps {
+    let handlers = spawn_handlers(SpawnDeps {
         client,
         incoming,
         config,
@@ -163,6 +154,8 @@ where
         aviation,
         aviation_for_commands,
     });
+
+    let shutdown_notify = handlers.shutdown_notify.clone();
 
     // Daily memory consolidation pass. Shares the memory store handle with
     // the extractor so the pass sees any writes made since the last run, and
@@ -211,38 +204,7 @@ where
     );
     info!("Bot is running. Press Ctrl+C to stop.");
 
-    match (config_watcher, scheduled_messages) {
-        (Some(watcher), Some(mut sched_handler)) => {
-            tokio::select! {
-                _ = shutdown => {
-                    info!("Shutdown signal received, exiting gracefully");
-                    shutdown_notify.notify_waiters();
-                    if let Err(e) = tokio::time::timeout(Duration::from_secs(5), &mut sched_handler).await {
-                        warn!(?e, "Scheduled message handler did not shut down within 5s");
-                    }
-                }
-                result = router => { error!("Message router exited unexpectedly: {result:?}"); }
-                result = watcher => { error!("Config watcher service exited unexpectedly: {result:?}"); }
-                result = tracker_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
-                result = generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
-                result = latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
-                result = flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
-                result = &mut sched_handler => { error!("Scheduled message handler exited unexpectedly: {result:?}"); }
-            }
-        }
-        _ => {
-            tokio::select! {
-                _ = shutdown => {
-                    info!("Shutdown signal received, exiting gracefully");
-                }
-                result = router => { error!("Message router exited unexpectedly: {result:?}"); }
-                result = tracker_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
-                result = generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
-                result = latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
-                result = flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
-            }
-        }
-    }
+    crate::twitch::handlers::spawn::await_shutdown(handlers, shutdown).await;
 
     info!("Bot shutdown complete");
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ pub mod twitch;
 pub mod util;
 
 use std::path::PathBuf;
-use std::sync::{Arc, atomic::AtomicU32};
+use std::sync::Arc;
 
 use eyre::{Result, WrapErr as _};
-use tokio::sync::{broadcast, mpsc::UnboundedReceiver, oneshot};
+use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tokio::time::Duration;
 use tracing::{error, info, warn};
 use twitch_irc::{
@@ -34,13 +34,8 @@ use crate::{
     aviation::AviationClient,
     config::Configuration,
     twitch::handlers::{
-        commands::{CommandHandlerConfig, run_generic_command_handler},
-        latency::run_latency_handler,
-        router::run_message_router,
-        schedules::{
-            load_schedules_from_config, run_config_watcher_service, run_scheduled_message_handler,
-        },
-        tracker_1337::{TARGET_HOUR, TARGET_MINUTE, load_leaderboard, run_1337_handler},
+        spawn::{HandlerSet, SpawnDeps, spawn_handlers},
+        tracker_1337::{TARGET_HOUR, TARGET_MINUTE, load_leaderboard},
     },
     twitch::whisper::WhisperSender,
     util::clock::Clock,
@@ -114,73 +109,10 @@ where
         ping::PingManager::load(&data_dir).wrap_err("Failed to load ping manager")?,
     ));
 
+    let suspension_manager = Arc::new(suspend::SuspensionManager::new());
+
     // Aviation is consumed by the flight tracker; clone first so commands (!up/!fl) also get it.
     let aviation_for_commands = aviation.clone();
-
-    let (tracker_tx, handler_flight_tracker) = match aviation {
-        Some(av) => {
-            let (tx, rx) = tokio::sync::mpsc::channel::<aviation::TrackerCommand>(32);
-            let handle = tokio::spawn({
-                let client = client.clone();
-                let channel = config.twitch.channel.clone();
-                let dir = data_dir.clone();
-                let clk = clock.clone();
-                async move {
-                    aviation::run_flight_tracker(rx, client, channel, av, dir, clk).await;
-                }
-            });
-            (Some(tx), handle)
-        }
-        None => (None, tokio::spawn(std::future::pending::<()>())),
-    };
-
-    let (broadcast_tx, _) = broadcast::channel::<ServerMessage>(100);
-
-    let router_handle = tokio::spawn(run_message_router(incoming, broadcast_tx.clone()));
-
-    // Notify lets the scheduled-message handler drain in-flight sends before exiting.
-    let shutdown_notify = Arc::new(tokio::sync::Notify::new());
-
-    let (watcher_service, handler_scheduled_messages) = if schedules_enabled {
-        info!(
-            count = config.schedules.len(),
-            "Schedules configured, starting scheduled message system"
-        );
-        let initial_schedules = load_schedules_from_config(&config);
-        info!(
-            loaded = initial_schedules.len(),
-            "Loaded initial schedules from config"
-        );
-
-        let mut cache = database::ScheduleCache::new();
-        cache.update(initial_schedules);
-        let schedule_cache = Arc::new(tokio::sync::RwLock::new(cache));
-
-        let watcher = tokio::spawn({
-            let cache = schedule_cache.clone();
-            async move {
-                run_config_watcher_service(cache).await;
-            }
-        });
-
-        let handler = tokio::spawn({
-            let client = client.clone();
-            let cache = schedule_cache.clone();
-            let channel = config.twitch.channel.clone();
-            let notify = shutdown_notify.clone();
-            let clk = clock.clone();
-            async move {
-                run_scheduled_message_handler(client, cache, channel, notify, clk).await;
-            }
-        });
-
-        (Some(watcher), Some(handler))
-    } else {
-        info!("No schedules configured, scheduled messages disabled");
-        (None, None)
-    };
-
-    let suspension_manager = Arc::new(suspend::SuspensionManager::new());
 
     // Build the memory bundle once so both `!ai` (extraction) and the
     // daily consolidation task share the same store handle + path.
@@ -193,35 +125,9 @@ where
         consolidation_reasoning_effort,
     } = crate::ai::command::build_ai_memory(config.ai.as_ref(), llm.as_ref(), &data_dir);
 
-    let latency = Arc::new(AtomicU32::new(config.twitch.expected_latency));
-
-    let handler_latency = tokio::spawn({
-        let client = client.clone();
-        let btx = broadcast_tx.clone();
-        let lat = latency.clone();
-        async move {
-            run_latency_handler(client, btx, lat).await;
-        }
-    });
-
-    let handler_1337 = tokio::spawn({
-        let btx = broadcast_tx.clone();
-        let client = client.clone();
-        let channel = config.twitch.channel.clone();
-        let lat = latency.clone();
-        let lb = leaderboard.clone();
-        let clk = clock.clone();
-        let dd = data_dir.clone();
-        async move {
-            run_1337_handler(btx, client, channel, lat, lb, clk, dd).await;
-        }
-    });
-
     // Capture the store handle + path for the consolidation spawn before
     // `ai_memory` is moved into the command handler. Both `!ai` extraction
-    // (in-handler) and consolidation (below) share these clones. We also
-    // clone the `[ai.consolidation]` knobs so the main chat `config.ai`
-    // can be consumed by the command-handler closure.
+    // (in-handler) and consolidation (below) share these clones.
     let consolidation_handle = ai_memory.as_ref().map(|m| {
         (
             m.config.store.clone(),
@@ -233,34 +139,30 @@ where
     });
     let consolidation_settings = config.ai.as_ref().map(|a| a.consolidation.clone());
 
-    let handler_generic_commands = tokio::spawn({
-        let btx = broadcast_tx.clone();
-        let client = client.clone();
-        async move {
-            run_generic_command_handler(CommandHandlerConfig {
-                broadcast_tx: btx,
-                client,
-                ai_config: config.ai.clone(),
-                llm,
-                ai_memory,
-                leaderboard,
-                ping_manager,
-                hidden_admin_ids: config.twitch.hidden_admins.clone(),
-                default_cooldown: Duration::from_secs(config.pings.cooldown),
-                pings_public: config.pings.public,
-                cooldowns: config.cooldowns.clone(),
-                tracker_tx,
-                aviation_client: aviation_for_commands,
-                whisper,
-                admin_channel: config.twitch.admin_channel.clone(),
-                bot_username: config.twitch.username.clone(),
-                channel: config.twitch.channel.clone(),
-                data_dir: data_dir.clone(),
-                suspension_manager: suspension_manager.clone(),
-                suspend: config.suspend.clone(),
-            })
-            .await;
-        }
+    let HandlerSet {
+        router,
+        latency,
+        tracker_1337,
+        generic_commands,
+        flight_tracker,
+        config_watcher,
+        scheduled_messages,
+        tracker_tx: _tracker_tx,
+        shutdown_notify,
+    } = spawn_handlers(SpawnDeps {
+        client,
+        incoming,
+        config,
+        clock,
+        data_dir,
+        leaderboard,
+        ping_manager,
+        suspension_manager,
+        llm,
+        ai_memory,
+        whisper,
+        aviation,
+        aviation_for_commands,
     });
 
     // Daily memory consolidation pass. Shares the memory store handle with
@@ -310,7 +212,7 @@ where
     );
     info!("Bot is running. Press Ctrl+C to stop.");
 
-    match (watcher_service, handler_scheduled_messages) {
+    match (config_watcher, scheduled_messages) {
         (Some(watcher), Some(mut sched_handler)) => {
             tokio::select! {
                 _ = shutdown => {
@@ -320,12 +222,12 @@ where
                         warn!(?e, "Scheduled message handler did not shut down within 5s");
                     }
                 }
-                result = router_handle => { error!("Message router exited unexpectedly: {result:?}"); }
+                result = router => { error!("Message router exited unexpectedly: {result:?}"); }
                 result = watcher => { error!("Config watcher service exited unexpectedly: {result:?}"); }
-                result = handler_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
-                result = handler_generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
-                result = handler_latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
-                result = handler_flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
+                result = tracker_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
+                result = generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
+                result = latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
+                result = flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
                 result = &mut sched_handler => { error!("Scheduled message handler exited unexpectedly: {result:?}"); }
             }
         }
@@ -334,11 +236,11 @@ where
                 _ = shutdown => {
                     info!("Shutdown signal received, exiting gracefully");
                 }
-                result = router_handle => { error!("Message router exited unexpectedly: {result:?}"); }
-                result = handler_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
-                result = handler_generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
-                result = handler_latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
-                result = handler_flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
+                result = router => { error!("Message router exited unexpectedly: {result:?}"); }
+                result = tracker_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
+                result = generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
+                result = latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
+                result = flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,93 +187,11 @@ where
     // Effective fallback resolution:
     // - model: extraction -> [ai], consolidation -> extraction -> [ai]
     // - reasoning_effort: extraction -> [ai], consolidation -> extraction -> [ai]
-    let (ai_memory, consolidation_model, consolidation_reasoning_effort): (
-        Option<crate::ai::command::AiMemory>,
-        Option<String>,
-        Option<String>,
-    ) = match (&config.ai, &llm) {
-        (Some(ai), Some(llm_arc)) if ai.memory.enabled => {
-            let extraction_model = ai
-                .extraction
-                .model
-                .clone()
-                .unwrap_or_else(|| ai.model.clone());
-            let extraction_reasoning_effort = ai
-                .extraction
-                .reasoning_effort
-                .clone()
-                .or_else(|| ai.reasoning_effort.clone());
-            let consolidation_model = ai
-                .consolidation
-                .model
-                .clone()
-                .or_else(|| ai.extraction.model.clone())
-                .unwrap_or_else(|| ai.model.clone());
-            let consolidation_reasoning_effort = ai
-                .consolidation
-                .reasoning_effort
-                .clone()
-                .or_else(|| ai.extraction.reasoning_effort.clone())
-                .or_else(|| ai.reasoning_effort.clone());
-            match ai::memory::MemoryStore::load(&data_dir) {
-                Ok((store, path)) => {
-                    // Back-compat: honor the deprecated `ai.max_memories`
-                    // when the user hasn't overridden `[ai.memory].max_user`.
-                    // Either way, emit a warn! so stale configs surface.
-                    let max_user = if let Some(legacy_n) = ai.max_memories {
-                        if ai.memory.max_user == crate::config::default_max_user() {
-                            warn!(
-                                "ai.max_memories is deprecated; migrating to [ai.memory].max_user = {}. Please update your config.",
-                                legacy_n
-                            );
-                            legacy_n
-                        } else {
-                            warn!(
-                                "ai.max_memories={} is deprecated AND ignored because [ai.memory].max_user={} is explicitly set. Remove the deprecated field.",
-                                legacy_n, ai.memory.max_user
-                            );
-                            ai.memory.max_user
-                        }
-                    } else {
-                        ai.memory.max_user
-                    };
-                    let config = ai::memory::MemoryConfig {
-                        store: Arc::new(tokio::sync::RwLock::new(store)),
-                        path,
-                        caps: ai::memory::Caps {
-                            max_user,
-                            max_lore: ai.memory.max_lore,
-                            max_pref: ai.memory.max_pref,
-                        },
-                        half_life_days: ai.memory.half_life_days,
-                    };
-                    let ai_memory = crate::ai::command::AiMemory {
-                        config,
-                        extraction_deps: crate::ai::command::AiExtractionDeps {
-                            enabled: ai.extraction.enabled,
-                            llm: llm_arc.clone(),
-                            model: extraction_model,
-                            reasoning_effort: extraction_reasoning_effort,
-                            timeout: Duration::from_secs(
-                                ai.extraction.timeout.unwrap_or(ai.timeout),
-                            ),
-                            max_rounds: ai.extraction.max_rounds,
-                        },
-                    };
-                    (
-                        Some(ai_memory),
-                        Some(consolidation_model),
-                        consolidation_reasoning_effort,
-                    )
-                }
-                Err(e) => {
-                    error!(error = ?e, "Failed to load AI memory store, memory disabled");
-                    (None, None, None)
-                }
-            }
-        }
-        _ => (None, None, None),
-    };
+    let crate::ai::command::AiMemoryBundle {
+        ai_memory,
+        consolidation_model,
+        consolidation_reasoning_effort,
+    } = crate::ai::command::build_ai_memory(config.ai.as_ref(), llm.as_ref(), &data_dir);
 
     let latency = Arc::new(AtomicU32::new(config.twitch.expected_latency));
 

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -77,12 +77,8 @@ impl PingManager {
 
     /// Write current state to disk using write+rename for atomicity.
     fn save(&self) -> Result<()> {
-        let tmp_path = self.path.with_extension("ron.tmp");
-        let data = ron::ser::to_string_pretty(&self.store, ron::ser::PrettyConfig::default())
-            .wrap_err("Failed to serialize pings")?;
-        std::fs::write(&tmp_path, &data).wrap_err("Failed to write pings.ron.tmp")?;
-        std::fs::rename(&tmp_path, &self.path)
-            .wrap_err("Failed to rename pings.ron.tmp to pings.ron")?;
+        crate::util::persist::atomic_save_ron(&self.store, &self.path)
+            .wrap_err("Failed to save pings.ron")?;
         debug!("Saved pings to disk");
         Ok(())
     }

--- a/src/twitch/handlers/mod.rs
+++ b/src/twitch/handlers/mod.rs
@@ -7,4 +7,5 @@ pub mod commands;
 pub mod latency;
 pub mod router;
 pub mod schedules;
+pub mod spawn;
 pub mod tracker_1337;

--- a/src/twitch/handlers/spawn.rs
+++ b/src/twitch/handlers/spawn.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 
 /// All `JoinHandle`s plus the shared state `run_bot` keeps after spawn.
-pub struct HandlerSet {
+pub(crate) struct HandlerSet {
     pub router: JoinHandle<()>,
     pub latency: JoinHandle<()>,
     pub tracker_1337: JoinHandle<()>,
@@ -58,7 +58,7 @@ pub struct HandlerSet {
 }
 
 /// Inputs for [`spawn_handlers`]. Grouped by handler.
-pub struct SpawnDeps<T: Transport, L: LoginCredentials> {
+pub(crate) struct SpawnDeps<T: Transport, L: LoginCredentials> {
     // Shared.
     pub client: Arc<TwitchIRCClient<T, L>>,
     pub incoming: tokio::sync::mpsc::UnboundedReceiver<ServerMessage>,
@@ -84,7 +84,7 @@ pub struct SpawnDeps<T: Transport, L: LoginCredentials> {
 /// Spawn every long-running handler task in the order they currently
 /// appear in `run_bot`. Returns a [`HandlerSet`] owning all handles plus
 /// shared `Notify` / `tracker_tx`.
-pub fn spawn_handlers<T, L>(deps: SpawnDeps<T, L>) -> HandlerSet
+pub(crate) fn spawn_handlers<T, L>(deps: SpawnDeps<T, L>) -> HandlerSet
 where
     T: Transport + Send + Sync + 'static,
     L: LoginCredentials + Send + Sync + 'static,
@@ -247,7 +247,7 @@ where
 /// with `tokio::spawn(std::future::pending::<()>())` when absent so every
 /// `select!` arm is a real `JoinHandle<()>`. This mirrors the existing
 /// fallback used for `flight_tracker` when no aviation client is wired.
-pub async fn await_shutdown(handlers: HandlerSet, shutdown: oneshot::Receiver<()>) {
+pub(crate) async fn await_shutdown(handlers: HandlerSet, shutdown: oneshot::Receiver<()>) {
     let HandlerSet {
         router,
         latency,

--- a/src/twitch/handlers/spawn.rs
+++ b/src/twitch/handlers/spawn.rs
@@ -1,0 +1,246 @@
+//! Handler spawn factory.
+//!
+//! `run_bot` (in `src/lib.rs`) calls [`spawn_handlers`] once with everything
+//! the long-running tasks need. The returned [`HandlerSet`] owns every
+//! `JoinHandle` plus the cross-handler channels (`tracker_tx`) and shared
+//! state needed by post-spawn code (`shutdown_notify`).
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, atomic::AtomicU32},
+};
+
+use tokio::{
+    sync::{Notify, RwLock, broadcast, mpsc},
+    task::JoinHandle,
+    time::Duration,
+};
+use tracing::info;
+use twitch_irc::{
+    TwitchIRCClient, login::LoginCredentials, message::ServerMessage, transport::Transport,
+};
+
+use crate::{
+    ai,
+    aviation::{self, AviationClient},
+    config::Configuration,
+    database, ping,
+    suspend::SuspensionManager,
+    twitch::{
+        handlers::{
+            commands::{CommandHandlerConfig, run_generic_command_handler},
+            latency::run_latency_handler,
+            router::run_message_router,
+            schedules::{
+                load_schedules_from_config, run_config_watcher_service,
+                run_scheduled_message_handler,
+            },
+            tracker_1337::{PersonalBest, run_1337_handler},
+        },
+        whisper::WhisperSender,
+    },
+    util::clock::Clock,
+};
+
+/// All `JoinHandle`s plus the shared state `run_bot` keeps after spawn.
+pub struct HandlerSet {
+    pub router: JoinHandle<()>,
+    pub latency: JoinHandle<()>,
+    pub tracker_1337: JoinHandle<()>,
+    pub generic_commands: JoinHandle<()>,
+    pub flight_tracker: JoinHandle<()>,
+    pub config_watcher: Option<JoinHandle<()>>,
+    pub scheduled_messages: Option<JoinHandle<()>>,
+    /// `mpsc::Sender` flight-tracking commands push onto. `None` when no
+    /// aviation client is configured. Cloned for callers that still need it
+    /// (e.g. command-handler config already consumed the original).
+    pub tracker_tx: Option<mpsc::Sender<aviation::TrackerCommand>>,
+    /// Shared notify so consolidation/shutdown code can drain in-flight
+    /// scheduled-message sends. Cloned, not consumed.
+    pub shutdown_notify: Arc<Notify>,
+}
+
+/// Inputs for [`spawn_handlers`]. Grouped by handler.
+pub struct SpawnDeps<T: Transport, L: LoginCredentials> {
+    // Shared.
+    pub client: Arc<TwitchIRCClient<T, L>>,
+    pub incoming: tokio::sync::mpsc::UnboundedReceiver<ServerMessage>,
+    pub config: Configuration,
+    pub clock: Arc<dyn Clock>,
+    pub data_dir: PathBuf,
+
+    // 1337 tracker.
+    pub leaderboard: Arc<RwLock<HashMap<String, PersonalBest>>>,
+
+    // Generic commands.
+    pub ping_manager: Arc<RwLock<ping::PingManager>>,
+    pub suspension_manager: Arc<SuspensionManager>,
+    pub llm: Option<Arc<dyn ai::llm::LlmClient>>,
+    pub ai_memory: Option<ai::command::AiMemory>,
+    pub whisper: Option<Arc<dyn WhisperSender>>,
+
+    // Flight tracker.
+    pub aviation: Option<AviationClient>,
+    pub aviation_for_commands: Option<AviationClient>,
+}
+
+/// Spawn every long-running handler task in the order they currently
+/// appear in `run_bot`. Returns a [`HandlerSet`] owning all handles plus
+/// shared `Notify` / `tracker_tx`.
+pub fn spawn_handlers<T, L>(deps: SpawnDeps<T, L>) -> HandlerSet
+where
+    T: Transport + Send + Sync + 'static,
+    L: LoginCredentials + Send + Sync + 'static,
+{
+    let SpawnDeps {
+        client,
+        incoming,
+        config,
+        clock,
+        data_dir,
+        leaderboard,
+        ping_manager,
+        suspension_manager,
+        llm,
+        ai_memory,
+        whisper,
+        aviation,
+        aviation_for_commands,
+    } = deps;
+
+    let schedules_enabled = !config.schedules.is_empty();
+
+    // Flight tracker: spawned first so `tracker_tx` exists for the command handler.
+    let (tracker_tx, flight_tracker) = match aviation {
+        Some(av) => {
+            let (tx, rx) = mpsc::channel::<aviation::TrackerCommand>(32);
+            let handle = tokio::spawn({
+                let client = client.clone();
+                let channel = config.twitch.channel.clone();
+                let dir = data_dir.clone();
+                let clk = clock.clone();
+                async move {
+                    aviation::run_flight_tracker(rx, client, channel, av, dir, clk).await;
+                }
+            });
+            (Some(tx), handle)
+        }
+        None => (None, tokio::spawn(std::future::pending::<()>())),
+    };
+
+    let (broadcast_tx, _) = broadcast::channel::<ServerMessage>(100);
+
+    let router = tokio::spawn(run_message_router(incoming, broadcast_tx.clone()));
+
+    // Notify lets the scheduled-message handler drain in-flight sends before exiting.
+    let shutdown_notify = Arc::new(Notify::new());
+
+    let (config_watcher, scheduled_messages) = if schedules_enabled {
+        info!(
+            count = config.schedules.len(),
+            "Schedules configured, starting scheduled message system"
+        );
+        let initial_schedules = load_schedules_from_config(&config);
+        info!(
+            loaded = initial_schedules.len(),
+            "Loaded initial schedules from config"
+        );
+
+        let mut cache = database::ScheduleCache::new();
+        cache.update(initial_schedules);
+        let schedule_cache = Arc::new(RwLock::new(cache));
+
+        let watcher = tokio::spawn({
+            let cache = schedule_cache.clone();
+            async move {
+                run_config_watcher_service(cache).await;
+            }
+        });
+
+        let handler = tokio::spawn({
+            let client = client.clone();
+            let cache = schedule_cache.clone();
+            let channel = config.twitch.channel.clone();
+            let notify = shutdown_notify.clone();
+            let clk = clock.clone();
+            async move {
+                run_scheduled_message_handler(client, cache, channel, notify, clk).await;
+            }
+        });
+
+        (Some(watcher), Some(handler))
+    } else {
+        info!("No schedules configured, scheduled messages disabled");
+        (None, None)
+    };
+
+    let latency_value = Arc::new(AtomicU32::new(config.twitch.expected_latency));
+
+    let latency = tokio::spawn({
+        let client = client.clone();
+        let btx = broadcast_tx.clone();
+        let lat = latency_value.clone();
+        async move {
+            run_latency_handler(client, btx, lat).await;
+        }
+    });
+
+    let tracker_1337 = tokio::spawn({
+        let btx = broadcast_tx.clone();
+        let client = client.clone();
+        let channel = config.twitch.channel.clone();
+        let lat = latency_value.clone();
+        let lb = leaderboard.clone();
+        let clk = clock.clone();
+        let dd = data_dir.clone();
+        async move {
+            run_1337_handler(btx, client, channel, lat, lb, clk, dd).await;
+        }
+    });
+
+    // Clone tracker_tx for HandlerSet before the original moves into the command handler.
+    let tracker_tx_for_set = tracker_tx.clone();
+
+    let generic_commands = tokio::spawn({
+        let btx = broadcast_tx.clone();
+        let client = client.clone();
+        async move {
+            run_generic_command_handler(CommandHandlerConfig {
+                broadcast_tx: btx,
+                client,
+                ai_config: config.ai.clone(),
+                llm,
+                ai_memory,
+                leaderboard,
+                ping_manager,
+                hidden_admin_ids: config.twitch.hidden_admins.clone(),
+                default_cooldown: Duration::from_secs(config.pings.cooldown),
+                pings_public: config.pings.public,
+                cooldowns: config.cooldowns.clone(),
+                tracker_tx,
+                aviation_client: aviation_for_commands,
+                whisper,
+                admin_channel: config.twitch.admin_channel.clone(),
+                bot_username: config.twitch.username.clone(),
+                channel: config.twitch.channel.clone(),
+                data_dir: data_dir.clone(),
+                suspension_manager: suspension_manager.clone(),
+                suspend: config.suspend.clone(),
+            })
+            .await;
+        }
+    });
+
+    HandlerSet {
+        router,
+        latency,
+        tracker_1337,
+        generic_commands,
+        flight_tracker,
+        config_watcher,
+        scheduled_messages,
+        tracker_tx: tracker_tx_for_set,
+        shutdown_notify,
+    }
+}

--- a/src/twitch/handlers/spawn.rs
+++ b/src/twitch/handlers/spawn.rs
@@ -12,11 +12,11 @@ use std::{
 };
 
 use tokio::{
-    sync::{Notify, RwLock, broadcast, mpsc},
+    sync::{Notify, RwLock, broadcast, mpsc, oneshot},
     task::JoinHandle,
-    time::Duration,
+    time::{Duration, timeout},
 };
-use tracing::info;
+use tracing::{error, info, warn};
 use twitch_irc::{
     TwitchIRCClient, login::LoginCredentials, message::ServerMessage, transport::Transport,
 };
@@ -234,5 +234,52 @@ where
         config_watcher,
         scheduled_messages,
         shutdown_notify,
+    }
+}
+
+/// Awaits whichever happens first: shutdown signal, or any handler exiting.
+///
+/// On shutdown, notifies `shutdown_notify` (so the scheduled-message handler
+/// drains in-flight `say()` calls) and waits up to 5s for the scheduled
+/// handler before returning.
+///
+/// Optional handlers (`config_watcher`, `scheduled_messages`) get replaced
+/// with `tokio::spawn(std::future::pending::<()>())` when absent so every
+/// `select!` arm is a real `JoinHandle<()>`. This mirrors the existing
+/// fallback used for `flight_tracker` when no aviation client is wired.
+pub async fn await_shutdown(handlers: HandlerSet, shutdown: oneshot::Receiver<()>) {
+    let HandlerSet {
+        router,
+        latency,
+        tracker_1337,
+        generic_commands,
+        flight_tracker,
+        config_watcher,
+        scheduled_messages,
+        shutdown_notify,
+    } = handlers;
+
+    let watcher = config_watcher.unwrap_or_else(|| tokio::spawn(std::future::pending::<()>()));
+    let has_sched = scheduled_messages.is_some();
+    let mut sched =
+        scheduled_messages.unwrap_or_else(|| tokio::spawn(std::future::pending::<()>()));
+
+    tokio::select! {
+        _ = shutdown => {
+            info!("Shutdown signal received, exiting gracefully");
+            if has_sched {
+                shutdown_notify.notify_waiters();
+                if let Err(e) = timeout(Duration::from_secs(5), &mut sched).await {
+                    warn!(?e, "Scheduled message handler did not shut down within 5s");
+                }
+            }
+        }
+        result = router => { error!("Message router exited unexpectedly: {result:?}"); }
+        result = watcher => { error!("Config watcher service exited unexpectedly: {result:?}"); }
+        result = tracker_1337 => { error!("1337 handler exited unexpectedly: {result:?}"); }
+        result = generic_commands => { error!("Generic Command Handler exited unexpectedly: {result:?}"); }
+        result = latency => { error!("Latency handler exited unexpectedly: {result:?}"); }
+        result = flight_tracker => { error!("Flight tracker exited unexpectedly: {result:?}"); }
+        result = &mut sched => { error!("Scheduled message handler exited unexpectedly: {result:?}"); }
     }
 }

--- a/src/twitch/handlers/spawn.rs
+++ b/src/twitch/handlers/spawn.rs
@@ -2,8 +2,8 @@
 //!
 //! `run_bot` (in `src/lib.rs`) calls [`spawn_handlers`] once with everything
 //! the long-running tasks need. The returned [`HandlerSet`] owns every
-//! `JoinHandle` plus the cross-handler channels (`tracker_tx`) and shared
-//! state needed by post-spawn code (`shutdown_notify`).
+//! `JoinHandle` plus the shared `Arc<Notify>` post-spawn code uses to drain
+//! the scheduled-message handler on shutdown.
 
 use std::{
     collections::HashMap,
@@ -52,10 +52,6 @@ pub struct HandlerSet {
     pub flight_tracker: JoinHandle<()>,
     pub config_watcher: Option<JoinHandle<()>>,
     pub scheduled_messages: Option<JoinHandle<()>>,
-    /// `mpsc::Sender` flight-tracking commands push onto. `None` when no
-    /// aviation client is configured. Cloned for callers that still need it
-    /// (e.g. command-handler config already consumed the original).
-    pub tracker_tx: Option<mpsc::Sender<aviation::TrackerCommand>>,
     /// Shared notify so consolidation/shutdown code can drain in-flight
     /// scheduled-message sends. Cloned, not consumed.
     pub shutdown_notify: Arc<Notify>,
@@ -199,9 +195,6 @@ where
         }
     });
 
-    // Clone tracker_tx for HandlerSet before the original moves into the command handler.
-    let tracker_tx_for_set = tracker_tx.clone();
-
     let generic_commands = tokio::spawn({
         let btx = broadcast_tx.clone();
         let client = client.clone();
@@ -240,7 +233,6 @@ where
         flight_tracker,
         config_watcher,
         scheduled_messages,
-        tracker_tx: tracker_tx_for_set,
         shutdown_notify,
     }
 }

--- a/src/twitch/handlers/tracker_1337.rs
+++ b/src/twitch/handlers/tracker_1337.rs
@@ -302,24 +302,13 @@ pub(crate) async fn save_leaderboard(
     data_dir: &std::path::Path,
 ) {
     let path = data_dir.join(LEADERBOARD_FILENAME);
-    let tmp_path = path.with_extension("ron.tmp");
-    match ron::to_string(leaderboard) {
-        Ok(serialized) => {
-            if let Err(e) = fs::write(&tmp_path, serialized.as_bytes()).await {
-                error!(error = ?e, "Failed to write leaderboard tmp file");
-            } else if let Err(e) = fs::rename(&tmp_path, &path).await {
-                error!(error = ?e, "Failed to rename leaderboard file");
-            } else {
-                info!(
-                    entries = leaderboard.len(),
-                    "Saved leaderboard to {}",
-                    path.display()
-                );
-            }
-        }
-        Err(e) => {
-            error!(error = ?e, "Failed to serialize leaderboard");
-        }
+    match crate::util::persist::atomic_save_ron_async(leaderboard, &path).await {
+        Ok(()) => info!(
+            entries = leaderboard.len(),
+            "Saved leaderboard to {}",
+            path.display()
+        ),
+        Err(e) => error!(error = ?e, "Failed to save leaderboard"),
     }
 }
 

--- a/src/twitch/token_storage.rs
+++ b/src/twitch/token_storage.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chrono::Utc;
-use color_eyre::eyre::{self, Result};
+use color_eyre::eyre::{self, Result, WrapErr as _};
 use secrecy::{ExposeSecret, SecretString};
 use tokio::fs;
 use tracing::{debug, instrument, warn};
@@ -68,7 +68,9 @@ impl TokenStorage for FileBasedTokenStorage {
     #[instrument(skip(self, token))]
     async fn update_token(&mut self, token: &UserAccessToken) -> Result<(), Self::UpdateError> {
         debug!(path = %self.path.display(), "Updating token in file");
-        crate::util::persist::atomic_save_ron_async(token, &self.path).await
+        crate::util::persist::atomic_save_ron_async(token, &self.path)
+            .await
+            .wrap_err("Failed to save token")
     }
 }
 

--- a/src/twitch/token_storage.rs
+++ b/src/twitch/token_storage.rs
@@ -68,9 +68,7 @@ impl TokenStorage for FileBasedTokenStorage {
     #[instrument(skip(self, token))]
     async fn update_token(&mut self, token: &UserAccessToken) -> Result<(), Self::UpdateError> {
         debug!(path = %self.path.display(), "Updating token in file");
-        let buffer = ron::to_string(token)?.into_bytes();
-        crate::util::persist::atomic_write_async(&buffer, &self.path).await?;
-        Ok(())
+        crate::util::persist::atomic_save_ron_async(token, &self.path).await
     }
 }
 

--- a/src/twitch/token_storage.rs
+++ b/src/twitch/token_storage.rs
@@ -2,10 +2,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use color_eyre::eyre::{self, Result};
 use secrecy::{ExposeSecret, SecretString};
-use tokio::{
-    fs::{self, File},
-    io::AsyncWriteExt,
-};
+use tokio::fs;
 use tracing::{debug, instrument, warn};
 use twitch_irc::login::{TokenStorage, UserAccessToken};
 
@@ -72,9 +69,7 @@ impl TokenStorage for FileBasedTokenStorage {
     async fn update_token(&mut self, token: &UserAccessToken) -> Result<(), Self::UpdateError> {
         debug!(path = %self.path.display(), "Updating token in file");
         let buffer = ron::to_string(token)?.into_bytes();
-        let tmp_path = self.path.with_extension("ron.tmp");
-        File::create(&tmp_path).await?.write_all(&buffer).await?;
-        fs::rename(&tmp_path, &self.path).await?;
+        crate::util::persist::atomic_write_async(&buffer, &self.path).await?;
         Ok(())
     }
 }

--- a/src/twitch/whisper.rs
+++ b/src/twitch/whisper.rs
@@ -9,11 +9,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr as _};
 use reqwest::StatusCode;
 use serde_json::json;
-use tokio::{
-    fs::{self, File},
-    io::AsyncWriteExt,
-    sync::Mutex,
-};
+use tokio::{fs, sync::Mutex};
 use tracing::warn;
 use twitch_irc::login::LoginCredentials;
 
@@ -189,8 +185,6 @@ async fn load_known_recipients(path: &Path) -> Result<HashSet<String>> {
 
 async fn save_known_recipients(path: &Path, recipients: &HashSet<String>) -> Result<()> {
     let buffer = ron::to_string(recipients)?.into_bytes();
-    let tmp_path = path.with_extension("ron.tmp");
-    File::create(&tmp_path).await?.write_all(&buffer).await?;
-    fs::rename(&tmp_path, path).await?;
+    crate::util::persist::atomic_write_async(&buffer, path).await?;
     Ok(())
 }

--- a/src/twitch/whisper.rs
+++ b/src/twitch/whisper.rs
@@ -184,5 +184,7 @@ async fn load_known_recipients(path: &Path) -> Result<HashSet<String>> {
 }
 
 async fn save_known_recipients(path: &Path, recipients: &HashSet<String>) -> Result<()> {
-    crate::util::persist::atomic_save_ron_async(recipients, path).await
+    crate::util::persist::atomic_save_ron_async(recipients, path)
+        .await
+        .wrap_err("Failed to save whisper recipients")
 }

--- a/src/twitch/whisper.rs
+++ b/src/twitch/whisper.rs
@@ -184,7 +184,5 @@ async fn load_known_recipients(path: &Path) -> Result<HashSet<String>> {
 }
 
 async fn save_known_recipients(path: &Path, recipients: &HashSet<String>) -> Result<()> {
-    let buffer = ron::to_string(recipients)?.into_bytes();
-    crate::util::persist::atomic_write_async(&buffer, path).await?;
-    Ok(())
+    crate::util::persist::atomic_save_ron_async(recipients, path).await
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod clock;
+pub mod persist;
 pub mod telemetry;
 
 use std::path::PathBuf;

--- a/src/util/persist.rs
+++ b/src/util/persist.rs
@@ -1,0 +1,78 @@
+//! Atomic file persistence helpers.
+//!
+//! Both helpers serialize to RON, write `<path>.tmp`, then rename onto the
+//! target so concurrent readers see either the old or the new file but never
+//! a torn write. Sync (`atomic_save_ron`) and async (`atomic_save_ron_async`)
+//! variants exist because some call-sites run inside `&` (sync) constructors
+//! and others inside `async fn`s with `tokio::fs` already in scope.
+
+use std::path::Path;
+
+use eyre::{Result, WrapErr as _};
+use serde::Serialize;
+
+/// Synchronously serialize `value` as pretty RON and atomically write to `path`.
+pub fn atomic_save_ron<T: Serialize>(value: &T, path: &Path) -> Result<()> {
+    let tmp = path.with_extension("ron.tmp");
+    let data = ron::ser::to_string_pretty(value, ron::ser::PrettyConfig::default())
+        .wrap_err("Failed to serialize value to RON")?;
+    std::fs::write(&tmp, &data)
+        .wrap_err_with(|| format!("Failed to write tmp file {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .wrap_err_with(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Async variant — uses `tokio::fs` so it does not block the runtime.
+/// Serializes with `ron::to_string` (compact) to match the existing tracker
+/// behaviour; switch to pretty if a call-site needs human inspection.
+pub async fn atomic_save_ron_async<T: Serialize>(value: &T, path: &Path) -> Result<()> {
+    let tmp = path.with_extension("ron.tmp");
+    let data = ron::to_string(value).wrap_err("Failed to serialize value to RON")?;
+    tokio::fs::write(&tmp, data.as_bytes())
+        .await
+        .wrap_err_with(|| format!("Failed to write tmp file {}", tmp.display()))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .wrap_err_with(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+    struct Sample {
+        a: u32,
+        b: String,
+    }
+
+    #[test]
+    fn sync_writes_and_renames() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sample.ron");
+        let value = Sample {
+            a: 7,
+            b: "hi".into(),
+        };
+        atomic_save_ron(&value, &path).unwrap();
+        let loaded: Sample = ron::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded, value);
+        assert!(!path.with_extension("ron.tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn async_writes_and_renames() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sample.ron");
+        let value = Sample {
+            a: 1,
+            b: "x".into(),
+        };
+        atomic_save_ron_async(&value, &path).await.unwrap();
+        let loaded: Sample =
+            ron::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(loaded, value);
+    }
+}

--- a/src/util/persist.rs
+++ b/src/util/persist.rs
@@ -41,6 +41,25 @@ pub async fn atomic_save_ron_async<T: Serialize>(value: &T, path: &Path) -> Resu
     Ok(())
 }
 
+/// Async atomic write of pre-serialized bytes (callers that don't use RON).
+///
+/// Tmp path is `<original-extension>.tmp` (e.g. `token.ron` → `token.ron.tmp`).
+/// If `path` has no extension, falls back to `path.tmp`.
+pub async fn atomic_write_async(bytes: &[u8], path: &Path) -> Result<()> {
+    let tmp = path.with_extension(
+        path.extension()
+            .map(|e| format!("{}.tmp", e.to_string_lossy()))
+            .unwrap_or_else(|| "tmp".into()),
+    );
+    tokio::fs::write(&tmp, bytes)
+        .await
+        .wrap_err_with(|| format!("Failed to write tmp file {}", tmp.display()))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .wrap_err_with(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,5 +97,16 @@ mod tests {
             ron::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert_eq!(loaded, value);
         assert!(!path.with_extension("ron.tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn async_write_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob.bin");
+        atomic_write_async(b"hello", &path).await.unwrap();
+        let loaded = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(loaded, b"hello");
+        // tmp gone after rename (extension `bin` → `bin.tmp`)
+        assert!(!path.with_extension("bin.tmp").exists());
     }
 }

--- a/src/util/persist.rs
+++ b/src/util/persist.rs
@@ -41,25 +41,6 @@ pub async fn atomic_save_ron_async<T: Serialize>(value: &T, path: &Path) -> Resu
     Ok(())
 }
 
-/// Async atomic write of pre-serialized bytes (callers that don't use RON).
-///
-/// Tmp path is `<original-extension>.tmp` (e.g. `token.ron` → `token.ron.tmp`).
-/// If `path` has no extension, falls back to `path.tmp`.
-pub async fn atomic_write_async(bytes: &[u8], path: &Path) -> Result<()> {
-    let tmp = path.with_extension(
-        path.extension()
-            .map(|e| format!("{}.tmp", e.to_string_lossy()))
-            .unwrap_or_else(|| "tmp".into()),
-    );
-    tokio::fs::write(&tmp, bytes)
-        .await
-        .wrap_err_with(|| format!("Failed to write tmp file {}", tmp.display()))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .wrap_err_with(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,16 +78,5 @@ mod tests {
             ron::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert_eq!(loaded, value);
         assert!(!path.with_extension("ron.tmp").exists());
-    }
-
-    #[tokio::test]
-    async fn async_write_bytes() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("blob.bin");
-        atomic_write_async(b"hello", &path).await.unwrap();
-        let loaded = tokio::fs::read(&path).await.unwrap();
-        assert_eq!(loaded, b"hello");
-        // tmp gone after rename (extension `bin` → `bin.tmp`)
-        assert!(!path.with_extension("bin.tmp").exists());
     }
 }

--- a/src/util/persist.rs
+++ b/src/util/persist.rs
@@ -1,10 +1,13 @@
 //! Atomic file persistence helpers.
 //!
-//! Both helpers serialize to RON, write `<path>.tmp`, then rename onto the
-//! target so concurrent readers see either the old or the new file but never
-//! a torn write. Sync (`atomic_save_ron`) and async (`atomic_save_ron_async`)
-//! variants exist because some call-sites run inside `&` (sync) constructors
-//! and others inside `async fn`s with `tokio::fs` already in scope.
+//! Both helpers serialize to RON, write the destination with extension
+//! replaced by `ron.tmp`, then rename onto the target so concurrent readers
+//! see either the old or the new file but never a torn write. Callers should
+//! pass a path ending in `.ron`. Sync (`atomic_save_ron`) and async
+//! (`atomic_save_ron_async`) variants exist because some call-sites run
+//! inside sync constructors and others inside `async fn`s with `tokio::fs`
+//! already in scope. "Atomic" here means no torn reads; it does NOT imply
+//! crash-safety (no `fsync` is performed).
 
 use std::path::Path;
 
@@ -74,5 +77,6 @@ mod tests {
         let loaded: Sample =
             ron::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert_eq!(loaded, value);
+        assert!(!path.with_extension("ron.tmp").exists());
     }
 }


### PR DESCRIPTION
## Summary

Two-part refactor pass following plan `docs/superpowers/plans/2026-04-28-refactor-persist-aviation-runbot.md` (parts A + C; part B aviation/mod.rs split deferred).

**Part A — `util::persist` helpers:**
- New `src/util/persist.rs` exposing `atomic_save_ron` (sync, pretty RON) and `atomic_save_ron_async` (async, compact RON, tokio::fs). Both write `<path>.ron.tmp` then rename.
- 6 call-sites migrated: `ping.rs`, `ai/memory/store.rs`, `tracker_1337::save_leaderboard`, `aviation/tracker::save_tracker_state`, `whisper::save_known_recipients`, `token_storage::update_token`.

**Part C — slim `run_bot`:**
- Extracted AI memory bundle construction into `ai::command::build_ai_memory(...) -> AiMemoryBundle`.
- New `src/twitch/handlers/spawn.rs` with `HandlerSet`, `SpawnDeps`, `spawn_handlers(deps)` — moves the 7 inline `tokio::spawn` blocks into a single factory. Spawn order preserved.
- New `await_shutdown(handlers, shutdown)` collapses the dual `tokio::select!` into one helper. Optional handlers backed by `std::future::pending` so every arm is a real `JoinHandle<()>`. Original branching behavior preserved (`notify_waiters` + 5s drain only when scheduled_messages was Some).

**Result:** `src/lib.rs` 430 → 211 lines. Net deletion of ~70 lines of duplicated tmp+rename code. No behavior changes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 243 passed (was 241 + 2 new persist tests)
- [ ] Local smoke: bot starts, Ctrl+C shuts down within 6s
- [ ] Manual sanity in test channel: `!p`, `!ai`, `!up`, `!fl` (if creds available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)