### PR TITLE
fix(docker): bundle CA certs into scratch runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=clang
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 RUN apt-get update \
-  && apt-get install --no-install-recommends --assume-yes musl-tools mold clang \
+  && apt-get install --no-install-recommends --assume-yes musl-tools mold clang ca-certificates \
   && rm -rf /var/lib/apt/lists/* \
   && rustup target add x86_64-unknown-linux-musl
 
@@ -46,6 +46,9 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 FROM scratch
 LABEL org.opencontainers.image.description="Rust Twitch IRC bot: 1337 tracker, community pings, AI/flight commands, and scheduled messages — single persistent IRC connection with broadcast-based handler routing."
 ENV DATA_DIR=/data
+
+# Copy CA bundle so rustls-platform-verifier can load system roots
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy the static binary
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/twitch-1337 /twitch-1337


### PR DESCRIPTION
## Summary
- Startup crashed with `No CA certificates were loaded from the system` (whisper.rs:102) — `reqwest` is built with `rustls-no-provider`, which uses `rustls-platform-verifier` and expects a system CA store; `FROM scratch` has none.
- Install `ca-certificates` in the debian builder and copy `/etc/ssl/certs/ca-certificates.crt` into the scratch runtime image.
- Twitch IRC was unaffected because it uses bundled `webpki-roots`; this fixes every other `reqwest::Client` (whisper, aviation, AI, 7TV, prefill, web search).

## Test plan
- [ ] `just build` succeeds
- [ ] `just push && just restart` — bot starts without the CA error
- [ ] Whisper, aviation, AI calls all reach upstream over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)