### PR TITLE
refactor(llm): adjacent cleanups (model field, dead rebuild, empty content)

### DIFF
--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -136,7 +136,6 @@ fn build_ollama_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
 pub struct OllamaClient {
     http: reqwest::Client,
     base_url: String,
-    model: String,
 }
 
 const DEFAULT_BASE_URL: &str = "http://localhost:11434";
@@ -144,7 +143,7 @@ const DEFAULT_BASE_URL: &str = "http://localhost:11434";
 impl OllamaClient {
     /// Creates a new Ollama API client.
     #[instrument]
-    pub fn new(model: &str, base_url: Option<&str>, user_agent: &str) -> Result<Self> {
+    pub fn new(base_url: Option<&str>, user_agent: &str) -> Result<Self> {
         let base_url = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
 
         let http = reqwest::Client::builder().user_agent(user_agent).build()?;
@@ -152,7 +151,6 @@ impl OllamaClient {
         Ok(Self {
             http,
             base_url: base_url.to_string(),
-            model: model.to_string(),
         })
     }
 }
@@ -176,7 +174,7 @@ impl LlmClient for OllamaClient {
             stream: false,
         };
 
-        debug!(model = %self.model, "Sending request to Ollama API");
+        debug!(model = %api_request.model, "Sending request to Ollama API");
 
         let response = self.http.post(&url).json(&api_request).send().await?;
 
@@ -228,7 +226,7 @@ impl LlmClient for OllamaClient {
             stream: false,
         };
 
-        debug!(model = %self.model, "Sending tool request to Ollama API");
+        debug!(model = %api_request.model, "Sending tool request to Ollama API");
 
         let response = self.http.post(&url).json(&api_request).send().await?;
 

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -265,7 +265,10 @@ impl LlmClient for OllamaClient {
             });
         }
 
-        let content = api_response.message.content.unwrap_or_default();
+        let content = api_response
+            .message
+            .content
+            .ok_or(LlmError::EmptyResponse)?;
         Ok(ToolChatCompletionResponse::Message(content))
     }
 }
@@ -276,6 +279,20 @@ mod tests {
     use crate::types::{
         Message, ToolCall, ToolCallRound, ToolChatCompletionRequest, ToolResultMessage,
     };
+
+    #[test]
+    fn empty_message_content_is_error_not_empty_string() {
+        // Source-level regression: the tool path must surface an
+        // EmptyResponse error rather than handing back Message("").
+        // Assemble the needle at runtime so this assertion does not
+        // self-match the literal it is looking for.
+        let s = include_str!("ollama.rs");
+        let needle = format!("{}.{}()", "content", "unwrap_or_default");
+        assert!(
+            !s.contains(&needle),
+            "tool path must error on empty content, not return Message(\"\")"
+        );
+    }
 
     #[test]
     fn build_messages_two_rounds_emits_correct_sequence() {

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -204,7 +204,6 @@ fn extract_api_error(body: &serde_json::Value) -> Option<String> {
 pub struct OpenAiClient {
     http: reqwest::Client,
     base_url: String,
-    model: String,
     is_openrouter: bool,
 }
 
@@ -221,12 +220,7 @@ impl OpenAiClient {
 
     /// Creates a new OpenAI-compatible API client.
     #[instrument(skip(api_key))]
-    pub fn new(
-        api_key: &str,
-        model: &str,
-        base_url: Option<&str>,
-        user_agent: &str,
-    ) -> Result<Self> {
+    pub fn new(api_key: &str, base_url: Option<&str>, user_agent: &str) -> Result<Self> {
         let base_url = base_url.unwrap_or(DEFAULT_BASE_URL).trim_end_matches('/');
         let is_openrouter = base_url.contains("openrouter.ai");
 
@@ -255,7 +249,6 @@ impl OpenAiClient {
         Ok(Self {
             http,
             base_url: base_url.to_string(),
-            model: model.to_string(),
             is_openrouter,
         })
     }
@@ -287,7 +280,7 @@ impl LlmClient for OpenAiClient {
             reasoning,
         };
 
-        debug!(model = %self.model, "Sending request to OpenAI-compatible API");
+        debug!(model = %api_request.model, "Sending request to OpenAI-compatible API");
 
         let response = self.http.post(&url).json(&api_request).send().await?;
 
@@ -363,7 +356,7 @@ impl LlmClient for OpenAiClient {
         if let Ok(req_json) = serde_json::to_string(&api_request) {
             trace!(request_body = %req_json, "Sending tool request to OpenAI-compatible API");
         } else {
-            debug!(model = %self.model, "Sending tool request to OpenAI-compatible API");
+            debug!(model = %api_request.model, "Sending tool request to OpenAI-compatible API");
         }
 
         let response = self.http.post(&url).json(&api_request).send().await?;
@@ -456,7 +449,6 @@ mod tests {
         OpenAiClient {
             http: reqwest::Client::new(),
             base_url: "https://example.test".to_string(),
-            model: "test-model".to_string(),
             is_openrouter,
         }
     }

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -113,9 +113,11 @@ struct ApiToolResponse {
 /// Per the OpenAI spec, `tool_calls[].function.arguments` is a JSON-encoded
 /// **string** (not an object), so we re-stringify the parsed `Value` from the
 /// response.
-fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json::Value> {
-    let mut messages: Vec<serde_json::Value> = request
-        .messages
+fn build_openai_messages(
+    messages: &[crate::types::Message],
+    prior_rounds: &[crate::types::ToolCallRound],
+) -> Vec<serde_json::Value> {
+    let mut wire: Vec<serde_json::Value> = messages
         .iter()
         .map(|m| {
             serde_json::json!({
@@ -125,7 +127,7 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
         })
         .collect();
 
-    for round in &request.prior_rounds {
+    for round in prior_rounds {
         let tool_calls: Vec<serde_json::Value> = round
             .calls
             .iter()
@@ -149,10 +151,10 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
         if let Some(rc) = &round.reasoning_content {
             assistant_msg["reasoning_content"] = serde_json::Value::String(rc.clone());
         }
-        messages.push(assistant_msg);
+        wire.push(assistant_msg);
 
         for tr in &round.results {
-            messages.push(serde_json::json!({
+            wire.push(serde_json::json!({
                 "role": "tool",
                 "tool_call_id": tr.tool_call_id,
                 "content": tr.content,
@@ -160,7 +162,7 @@ fn build_openai_messages(request: &ToolChatCompletionRequest) -> Vec<serde_json:
         }
     }
 
-    messages
+    wire
 }
 
 /// Parse the `arguments` string from an OpenAI-compatible tool call. Returns
@@ -336,18 +338,9 @@ impl LlmClient for OpenAiClient {
         } = request;
         let (reasoning_effort, reasoning) = self.map_reasoning(reasoning_effort);
 
-        let request = ToolChatCompletionRequest {
-            model,
-            messages,
-            tools,
-            reasoning_effort: None,
-            prior_rounds,
-        };
+        let wire_messages = build_openai_messages(&messages, &prior_rounds);
 
-        let messages = build_openai_messages(&request);
-
-        let tools: Vec<ApiTool> = request
-            .tools
+        let api_tools: Vec<ApiTool> = tools
             .iter()
             .map(|t| ApiTool {
                 r#type: "function".to_string(),
@@ -360,9 +353,9 @@ impl LlmClient for OpenAiClient {
             .collect();
 
         let api_request = ApiToolRequest {
-            model: request.model,
-            messages,
-            tools,
+            model,
+            messages: wire_messages,
+            tools: api_tools,
             reasoning_effort,
             reasoning,
         };
@@ -480,7 +473,8 @@ mod tests {
 
     #[test]
     fn build_messages_empty_rounds_passes_through_base_messages() {
-        let msgs = build_openai_messages(&req_with_rounds(vec![]));
+        let req = req_with_rounds(vec![]);
+        let msgs = build_openai_messages(&req.messages, &req.prior_rounds);
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0]["role"], "system");
         assert_eq!(msgs[1]["role"], "user");
@@ -517,7 +511,8 @@ mod tests {
             reasoning_content: None,
         };
 
-        let msgs = build_openai_messages(&req_with_rounds(vec![round1, round2]));
+        let req = req_with_rounds(vec![round1, round2]);
+        let msgs = build_openai_messages(&req.messages, &req.prior_rounds);
 
         // Expected layout:
         // [0] system, [1] user,
@@ -571,7 +566,8 @@ mod tests {
             reasoning_content: Some("I should save this fact.".to_string()),
         };
 
-        let msgs = build_openai_messages(&req_with_rounds(vec![round]));
+        let req = req_with_rounds(vec![round]);
+        let msgs = build_openai_messages(&req.messages, &req.prior_rounds);
 
         // [0] system, [1] user, [2] assistant, [3] tool
         assert_eq!(msgs[2]["role"], "assistant");
@@ -598,7 +594,8 @@ mod tests {
             reasoning_content: None,
         };
 
-        let msgs = build_openai_messages(&req_with_rounds(vec![round]));
+        let req = req_with_rounds(vec![round]);
+        let msgs = build_openai_messages(&req.messages, &req.prior_rounds);
 
         assert!(
             msgs[2].get("reasoning_content").is_none(),

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -422,7 +422,7 @@ impl LlmClient for OpenAiClient {
             });
         }
 
-        let content = choice.message.content.unwrap_or_default();
+        let content = choice.message.content.ok_or(LlmError::EmptyResponse)?;
         Ok(ToolChatCompletionResponse::Message(content))
     }
 }
@@ -435,6 +435,20 @@ mod tests {
     use crate::types::{
         Message, ToolCall, ToolCallRound, ToolChatCompletionRequest, ToolResultMessage,
     };
+
+    #[test]
+    fn empty_message_content_is_error_not_empty_string() {
+        // Source-level regression: the tool path must surface an
+        // EmptyResponse error rather than handing back Message("").
+        // Assemble the needle at runtime so this assertion does not
+        // self-match the literal it is looking for.
+        let s = include_str!("openai.rs");
+        let needle = format!("{}.{}()", "content", "unwrap_or_default");
+        assert!(
+            !s.contains(&needle),
+            "tool path must error on empty content, not return Message(\"\")"
+        );
+    }
 
     static CRYPTO: Once = Once::new();
 

--- a/crates/twitch-1337/src/llm_factory.rs
+++ b/crates/twitch-1337/src/llm_factory.rs
@@ -29,16 +29,13 @@ pub fn build_llm_client(ai_config: Option<&AiConfig>) -> Result<Option<Arc<dyn L
                 .expect("validated: openai backend has api_key");
             OpenAiClient::new(
                 api_key.expose_secret(),
-                &ai_cfg.model,
                 ai_cfg.base_url.as_deref(),
                 APP_USER_AGENT,
             )
             .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
         }
-        AiBackend::Ollama => {
-            OllamaClient::new(&ai_cfg.model, ai_cfg.base_url.as_deref(), APP_USER_AGENT)
-                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
-        }
+        AiBackend::Ollama => OllamaClient::new(ai_cfg.base_url.as_deref(), APP_USER_AGENT)
+            .map(|c| Arc::new(c) as Arc<dyn LlmClient>),
     };
 
     match result {


### PR DESCRIPTION
## Summary

Section 4 of the [LLM agent API spec](docs/superpowers/specs/2026-04-30-llm-agent-api-design.md). Three small, independent cleanups now that the agent runner and consumer migration have landed:

- Drop dead struct rebuild in `OpenAiClient::chat_completion_with_tools`. `build_openai_messages` now takes `(&[Message], &[ToolCallRound])` directly instead of a synthetic request rebuilt with `reasoning_effort: None`.
- Drop stored `model` field on `OpenAiClient` and `OllamaClient`. Each request carries its own `model`, and consumers vary it (extraction / consolidation / chat use different models). Tracing events log the per-request model. `model` argument removed from both `new` constructors.
- `chat_completion_with_tools` now returns `Err(LlmError::EmptyResponse)` on empty content instead of `Ok(Message(""))`. Source-level regression tests in each provider guard against re-introducing `unwrap_or_default`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (285 tests pass)
- [ ] CI green (7 required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)