### PR TITLE
fix(ai): log web_search/fetch_url failures + surface full eyre chain

### DIFF
--- a/crates/twitch-1337/src/ai/web_search/executor.rs
+++ b/crates/twitch-1337/src/ai/web_search/executor.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::Mutex;
+use tracing::{error, warn};
 
 use llm::{ToolCall, ToolResultMessage};
 
@@ -127,13 +128,15 @@ impl WebToolExecutor {
                     .chain()
                     .any(|cause| cause.to_string().to_ascii_lowercase().contains("timed out"))
                 {
+                    warn!(error = ?err, query, "web_search timed out");
                     "search_timeout"
                 } else {
+                    error!(error = ?err, query, "web_search failed");
                     "search_failed"
                 };
                 json!({
                     "error": error_code,
-                    "details": err.to_string(),
+                    "details": format!("{err:#}"),
                 })
                 .to_string()
             }
@@ -166,15 +169,18 @@ impl WebToolExecutor {
             Err(err) => {
                 let msg = err.to_string().to_ascii_lowercase();
                 let error_code = if msg.contains("blocked") {
+                    warn!(error = ?err, url, "fetch_url blocked");
                     "fetch_blocked"
                 } else if msg.contains("timed out") {
+                    warn!(error = ?err, url, "fetch_url timed out");
                     "fetch_timeout"
                 } else {
+                    error!(error = ?err, url, "fetch_url failed");
                     "fetch_failed"
                 };
                 json!({
                     "error": error_code,
-                    "details": err.to_string(),
+                    "details": format!("{err:#}"),
                 })
                 .to_string()
             }


### PR DESCRIPTION
## Summary

- `web_search` tool returned `Failed to call SearXNG search endpoint` to the model with **no matching log line**: `crates/twitch-1337/src/ai/web_search/` had zero `tracing` calls.
- Compounding bug: `details` field used `err.to_string()`, which on `eyre::Report` only formats the topmost wrap message — the actual reqwest cause (DNS / connect / TLS / timeout) was dropped from log AND JSON.
- Add `error!`/`warn!` (with `?error` for full Debug chain) on every `Err` arm of `execute_web_search` and `execute_fetch_url`. Switch JSON `details` to `format!("{err:#}")` so the model sees the real cause too.
- Log level: `warn` for timeout/blocked, `error` for everything else.

## Test plan

- [x] `cargo clippy -p twitch-1337 --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p twitch-1337 web_search` — 10 passed
- [x] `cargo fmt --all -- --check` clean
- [ ] After deploy: next `web_search` failure should emit a structured `error!` line at target `twitch_1337::ai::web_search::executor` with the full eyre chain visible in `error=` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)