### PR TITLE
feat(1337): add !pb command and clarify PB stats wording

### DIFF
--- a/crates/twitch-1337/src/commands/mod.rs
+++ b/crates/twitch-1337/src/commands/mod.rs
@@ -9,6 +9,7 @@ use twitch_irc::{
 pub mod feedback;
 pub mod leaderboard;
 pub mod news;
+pub mod pb;
 pub mod ping_admin;
 pub mod ping_trigger;
 pub mod suspend;
@@ -34,6 +35,13 @@ pub fn is_admin(privmsg: &PrivmsgMessage, hidden_admin_ids: &[String]) -> bool {
 /// dispatcher's suspension lookup — they MUST agree.
 pub fn normalize_command_name(raw: &str) -> String {
     raw.trim_start_matches('!').to_ascii_lowercase()
+}
+
+/// Normalize a username argument: strip a leading `@` and ASCII-lowercase.
+/// Twitch logins are ASCII-only and always lowercase, so this matches the
+/// keys stored by handlers (`privmsg.sender.login`).
+pub fn normalize_username(raw: &str) -> String {
+    raw.trim_start_matches('@').to_ascii_lowercase()
 }
 
 /// Context passed to every command execution.

--- a/crates/twitch-1337/src/commands/pb.rs
+++ b/crates/twitch-1337/src/commands/pb.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use tokio::sync::RwLock;
+use tracing::error;
+use twitch_irc::{login::LoginCredentials, transport::Transport};
+
+use super::{Command, CommandContext, normalize_username};
+use crate::twitch::handlers::tracker_1337::PersonalBest;
+
+pub struct PbCommand {
+    leaderboard: Arc<RwLock<HashMap<String, PersonalBest>>>,
+}
+
+impl PbCommand {
+    pub fn new(leaderboard: Arc<RwLock<HashMap<String, PersonalBest>>>) -> Self {
+        Self { leaderboard }
+    }
+}
+
+#[async_trait]
+impl<T, L> Command<T, L> for PbCommand
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    fn name(&self) -> &str {
+        "!pb"
+    }
+
+    async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()> {
+        let target = ctx
+            .args
+            .first()
+            .map(|arg| normalize_username(arg))
+            .unwrap_or_else(|| ctx.privmsg.sender.login.clone());
+        let is_self = target == ctx.privmsg.sender.login;
+
+        let pb = self.leaderboard.read().await.get(&target).cloned();
+
+        let response = match (pb, is_self) {
+            (Some(pb), true) => {
+                format!("Dein PB ist {}ms am {}", pb.ms, pb.date.format("%d.%m.%Y"))
+            }
+            (Some(pb), false) => format!(
+                "PB von {target}: {}ms am {}",
+                pb.ms,
+                pb.date.format("%d.%m.%Y")
+            ),
+            (None, true) => "Du hast noch keinen PB".to_string(),
+            (None, false) => format!("{target} hat noch keinen PB"),
+        };
+
+        if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, response).await {
+            error!(error = ?e, "Failed to send !pb response");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/twitch-1337/src/commands/ping_admin.rs
+++ b/crates/twitch-1337/src/commands/ping_admin.rs
@@ -7,7 +7,7 @@ use twitch_irc::{login::LoginCredentials, transport::Transport};
 
 use crate::ping::PingManager;
 
-use super::{ADMIN_DENIED_MSG, Command, CommandContext, is_admin};
+use super::{ADMIN_DENIED_MSG, Command, CommandContext, is_admin, normalize_username};
 
 /// Normalize a ping name from user input to the canonical lowercase form.
 fn normalize_ping_name(name: &str) -> String {
@@ -194,7 +194,7 @@ impl PingAdminCommand {
         }
 
         let name = normalize_ping_name(ctx.args[1]);
-        let user = ctx.args[2].trim_start_matches('@').to_lowercase();
+        let user = normalize_username(ctx.args[2]);
 
         let mut manager = self.ping_manager.write().await;
         let result = match op {

--- a/crates/twitch-1337/src/twitch/handlers/commands.rs
+++ b/crates/twitch-1337/src/twitch/handlers/commands.rs
@@ -162,7 +162,10 @@ where
             aviation_client,
             Duration::from_secs(cooldowns.up),
         )),
-        Box::new(commands::leaderboard::LeaderboardCommand::new(leaderboard)),
+        Box::new(commands::leaderboard::LeaderboardCommand::new(
+            leaderboard.clone(),
+        )),
+        Box::new(commands::pb::PbCommand::new(leaderboard)),
         Box::new(commands::feedback::FeedbackCommand::new(
             data_dir.clone(),
             Duration::from_secs(cooldowns.feedback),

--- a/crates/twitch-1337/src/twitch/handlers/tracker_1337.rs
+++ b/crates/twitch-1337/src/twitch/handlers/tracker_1337.rs
@@ -470,7 +470,7 @@ pub async fn run_1337_handler<T, L>(
                 drop(leaderboard_guard);
 
                 if is_record {
-                    message.push_str(" - neuer Rekord!");
+                    message.push_str(" - neue PB!");
                 }
             }
         }

--- a/crates/twitch-1337/tests/pb.rs
+++ b/crates/twitch-1337/tests/pb.rs
@@ -1,0 +1,107 @@
+mod common;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::NaiveDate;
+use common::TestBotBuilder;
+use serial_test::serial;
+use twitch_1337::PersonalBest;
+
+fn seeded_alice() -> HashMap<String, PersonalBest> {
+    let mut seeded = HashMap::new();
+    seeded.insert(
+        "alice".into(),
+        PersonalBest {
+            ms: 234,
+            date: NaiveDate::from_ymd_opt(2026, 4, 17).unwrap(),
+        },
+    );
+    seeded
+}
+
+#[tokio::test]
+#[serial]
+async fn pb_returns_callers_own_pb() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_alice())
+        .spawn()
+        .await;
+
+    bot.send("alice", "!pb").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(out.contains("Dein PB"), "missing self phrasing: {out}");
+    assert!(out.contains("234"), "missing ms: {out}");
+    assert!(out.contains("17.04.2026"), "missing date: {out}");
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn pb_returns_other_user_pb() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_alice())
+        .spawn()
+        .await;
+
+    bot.send("bob", "!pb alice").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        out.contains("PB von alice"),
+        "missing other phrasing: {out}"
+    );
+    assert!(out.contains("234"), "missing ms: {out}");
+    assert!(out.contains("17.04.2026"), "missing date: {out}");
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn pb_handles_at_prefix_and_case() {
+    let mut bot = TestBotBuilder::new()
+        .with_seeded_leaderboard(seeded_alice())
+        .spawn()
+        .await;
+
+    bot.send("bob", "!pb @ALICE").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        out.contains("PB von alice"),
+        "missing other phrasing: {out}"
+    );
+    assert!(out.contains("234"), "missing ms: {out}");
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn pb_empty_state_self() {
+    let mut bot = TestBotBuilder::new().spawn().await;
+
+    bot.send("alice", "!pb").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        out.contains("Du hast noch keinen PB"),
+        "expected empty self message, got: {out}"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn pb_empty_state_other() {
+    let mut bot = TestBotBuilder::new().spawn().await;
+
+    bot.send("alice", "!pb bob").await;
+    let out = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        out.contains("bob hat noch keinen PB"),
+        "expected empty other message, got: {out}"
+    );
+
+    bot.shutdown().await;
+}


### PR DESCRIPTION
## Summary

- Replace `" - neuer Rekord!"` in the daily 1337 stats with `" - neue PB!"` — the check only compares against the user's own previous PB, so the old wording misled chat into thinking it was a global record.
- Add `!pb` command: shows the caller's PB (`!pb`) or another user's (`!pb <user>`, optional `@`, case-insensitive). Output mirrors `!lb` style with ms + Berlin `dd.mm.yyyy` date.
- Extract shared `normalize_username()` helper in `commands/mod.rs` and migrate `ping_admin`'s inline strip+lowercase to use it.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 293 pass, 1 skipped
- [x] New integration tests in `tests/pb.rs`: self lookup, other lookup, `@`/case handling, empty-state self, empty-state other

🤖 Generated with [Claude Code](https://claude.com/claude-code)