### PR TITLE
Batch: security + reliability fixes (#21 #22 #39 #40 #100 #129 #130)

### DIFF
--- a/crates/twitch-1337/config.toml.example
+++ b/crates/twitch-1337/config.toml.example
@@ -146,6 +146,9 @@ client_secret = "your_client_secret"
 # reasoning_effort = "high"        # fallback → [ai].reasoning_effort
 # run_at           = "04:00"       # HH:MM in Europe/Berlin
 # timeout_secs     = 120
+# max_rounds       = 20            # Max tool-call rounds per ritual (1..=200, default: 20).
+                                  # Independent from ai.max_turn_rounds since the ritual
+                                  # touches every memory file plus the day's transcript.
 
 # Optional: Scheduled messages configuration
 # Add [[schedules]] sections to define scheduled messages.

--- a/crates/twitch-1337/src/ai/command.rs
+++ b/crates/twitch-1337/src/ai/command.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, instrument, warn};
 use twitch_irc::{login::LoginCredentials, transport::Transport};
 
 use llm::{
-    AgentOpts, AgentOutcome, LlmClient, Message, ToolCall, ToolCallRound,
+    AgentOpts, AgentOutcome, LlmClient, LlmError, Message, ToolCall, ToolCallRound,
     ToolChatCompletionRequest, ToolExecutor, ToolResultMessage, run_agent,
 };
 
@@ -423,6 +423,14 @@ where
             }
             Err(e) => {
                 warn!(error = ?e, "AI llm error");
+                if let Some(reply) = user_facing_provider_message(&e)
+                    && let Err(send_err) = ctx
+                        .client
+                        .say_in_reply_to(ctx.privmsg, reply.to_string())
+                        .await
+                {
+                    error!(error = ?send_err, "Failed to send AI provider-error reply");
+                }
                 None
             }
         };
@@ -455,6 +463,24 @@ where
         }
 
         Ok(())
+    }
+}
+
+/// Map a provider-side LLM failure to a short German chat reply.
+///
+/// 5xx and decode/transport errors stay silent — they are already logged at
+/// warn! and are usually transient. Authentication, payment, and rate-limit
+/// problems get a hint in chat so the bot doesn't appear to silently swallow
+/// `!ai` requests when, e.g., the OpenRouter wallet is empty.
+fn user_facing_provider_message(err: &LlmError) -> Option<&'static str> {
+    match err {
+        LlmError::Provider { status, .. } => match *status {
+            402 => Some("KI-Konto leer FeelsBadMan"),
+            429 => Some("KI gerade rate-limited Stare"),
+            401 | 403 => Some("KI-Konfiguration kaputt FeelsBadMan"),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/crates/twitch-1337/src/ai/memory/ritual.rs
+++ b/crates/twitch-1337/src/ai/memory/ritual.rs
@@ -5,8 +5,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{NaiveDate, NaiveTime, TimeZone as _};
+use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone as _};
 use chrono_tz::Europe::Berlin;
+use chrono_tz::Tz;
 use eyre::Result;
 use llm::{AgentOpts, AgentOutcome, LlmClient, Message, ToolChatCompletionRequest, run_agent};
 use tokio::sync::Notify;
@@ -31,6 +32,21 @@ pub struct RitualConfig {
     pub channel: String,
 }
 
+/// Resolve `run_at` on `date` to a Berlin `DateTime`, bumping forward across the
+/// spring-forward DST gap (02:00–03:00 on the last Sunday in March) when the
+/// requested local time does not exist. Returns `None` only if even the
+/// post-gap candidate fails to resolve, which should not happen for any real
+/// Berlin date.
+fn resolve_berlin_run_at(date: NaiveDate, time: NaiveTime) -> Option<DateTime<Tz>> {
+    let dt = date.and_time(time);
+    if let Some(resolved) = Berlin.from_local_datetime(&dt).single() {
+        return Some(resolved);
+    }
+    // DST gap: bump forward an hour to land past the missing window.
+    let bumped = dt + chrono::Duration::hours(1);
+    Berlin.from_local_datetime(&bumped).single()
+}
+
 pub fn spawn_ritual(
     llm: Arc<dyn LlmClient>,
     store: MemoryStore,
@@ -41,15 +57,11 @@ pub fn spawn_ritual(
     tokio::spawn(async move {
         loop {
             let now = chrono::Utc::now().with_timezone(&Berlin);
-            let target = Berlin
-                .from_local_datetime(&now.date_naive().and_time(cfg.run_at))
-                .single();
+            let target = resolve_berlin_run_at(now.date_naive(), cfg.run_at);
             let next = target.filter(|t| *t > now).unwrap_or_else(|| {
-                let tomorrow = now.date_naive().succ_opt().unwrap();
-                Berlin
-                    .from_local_datetime(&tomorrow.and_time(cfg.run_at))
-                    .single()
-                    .expect("valid")
+                let tomorrow = now.date_naive().succ_opt().expect("valid next day");
+                resolve_berlin_run_at(tomorrow, cfg.run_at)
+                    .expect("post-gap fallback resolves on the next day")
             });
             let wait = (next - now).to_std().unwrap_or_default();
             tokio::select! {
@@ -136,4 +148,28 @@ pub async fn run_ritual(
         Err(e) => warn!(error = ?e, "dreamer llm error"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Timelike as _;
+
+    use super::*;
+
+    #[test]
+    fn resolve_berlin_run_at_handles_dst_gap() {
+        // 2026 spring-forward in Berlin is Sunday 2026-03-29; 02:00–03:00 local does not exist.
+        let date = NaiveDate::from_ymd_opt(2026, 3, 29).unwrap();
+        let in_gap = NaiveTime::from_hms_opt(2, 30, 0).unwrap();
+        let resolved = resolve_berlin_run_at(date, in_gap).expect("falls through past gap");
+        assert_eq!(resolved.hour(), 3, "should bump into the post-DST hour");
+    }
+
+    #[test]
+    fn resolve_berlin_run_at_default_safe() {
+        let date = NaiveDate::from_ymd_opt(2026, 3, 29).unwrap();
+        let four_am = NaiveTime::from_hms_opt(4, 0, 0).unwrap();
+        let resolved = resolve_berlin_run_at(date, four_am).expect("04:00 always resolves");
+        assert_eq!(resolved.hour(), 4);
+    }
 }

--- a/crates/twitch-1337/src/aviation/client.rs
+++ b/crates/twitch-1337/src/aviation/client.rs
@@ -135,6 +135,8 @@ impl AviationClient {
     pub fn new() -> Result<Self> {
         let http = reqwest::Client::builder()
             .user_agent(APP_USER_AGENT)
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(15))
             .build()
             .wrap_err("Failed to build aviation HTTP client")?;
         Ok(Self::new_with_adsb_aggregators(

--- a/crates/twitch-1337/src/aviation/commands/track.rs
+++ b/crates/twitch-1337/src/aviation/commands/track.rs
@@ -43,7 +43,19 @@ where
             return Ok(());
         }
 
-        let identifier = FlightIdentifier::parse(&input);
+        let identifier = match FlightIdentifier::parse(&input) {
+            Ok(id) => id,
+            Err(e) => {
+                if let Err(send_err) = ctx
+                    .client
+                    .say_in_reply_to(ctx.privmsg, format!("{e} FDM"))
+                    .await
+                {
+                    error!(error = ?send_err, "Failed to send invalid-identifier message");
+                }
+                return Ok(());
+            }
+        };
         let cmd = TrackerCommand::Track {
             identifier,
             requested_by: ctx.privmsg.sender.login.clone(),

--- a/crates/twitch-1337/src/aviation/tracker.rs
+++ b/crates/twitch-1337/src/aviation/tracker.rs
@@ -76,14 +76,22 @@ impl FlightIdentifier {
     /// Parse user input into a FlightIdentifier.
     ///
     /// 6-character all-hex-digit strings are treated as ICAO24 hex codes.
-    /// Everything else is treated as a callsign.
-    pub fn parse(input: &str) -> Self {
+    /// Everything else is treated as a callsign and must be ASCII alphanumeric
+    /// with length 1..=8 (ICAO callsigns are at most 8 chars). Rejects path
+    /// separators and other characters that would let user input forge URL
+    /// segments when interpolated into ADS-B aggregator endpoints.
+    pub fn parse(input: &str) -> eyre::Result<Self> {
         let input = input.trim().to_uppercase();
-        if input.len() == 6 && input.chars().all(|c| c.is_ascii_hexdigit()) {
-            FlightIdentifier::Hex(input)
-        } else {
-            FlightIdentifier::Callsign(input)
+        if input.is_empty() {
+            eyre::bail!("Identifier darf nicht leer sein");
         }
+        if input.len() == 6 && input.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Ok(FlightIdentifier::Hex(input));
+        }
+        if input.len() > 8 || !input.chars().all(|c| c.is_ascii_alphanumeric()) {
+            eyre::bail!("Ungültiges callsign/hex");
+        }
+        Ok(FlightIdentifier::Callsign(input))
     }
 
     /// Returns the display string (the callsign or hex value).
@@ -1452,5 +1460,45 @@ mod tests {
         let ac = aircraft_at(34_000, 0);
 
         assert_eq!(detect_phase(&flight, &ac), FlightPhase::Cruise);
+    }
+
+    #[test]
+    fn parse_accepts_six_char_hex() {
+        let id = FlightIdentifier::parse("4ca87d").unwrap();
+        assert_eq!(id, FlightIdentifier::Hex("4CA87D".to_string()));
+    }
+
+    #[test]
+    fn parse_accepts_alphanumeric_callsign() {
+        let id = FlightIdentifier::parse("DLH1234").unwrap();
+        assert_eq!(id, FlightIdentifier::Callsign("DLH1234".to_string()));
+    }
+
+    #[test]
+    fn parse_accepts_eight_char_callsign() {
+        let id = FlightIdentifier::parse("RYR1234A").unwrap();
+        assert_eq!(id, FlightIdentifier::Callsign("RYR1234A".to_string()));
+    }
+
+    #[test]
+    fn parse_rejects_path_traversal() {
+        assert!(FlightIdentifier::parse("../foo").is_err());
+        assert!(FlightIdentifier::parse("a/b").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_too_long_callsign() {
+        assert!(FlightIdentifier::parse("ABCDEFGHI").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_non_ascii() {
+        assert!(FlightIdentifier::parse("DLH1ä34").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_empty() {
+        assert!(FlightIdentifier::parse("").is_err());
+        assert!(FlightIdentifier::parse("   ").is_err());
     }
 }

--- a/crates/twitch-1337/src/config.rs
+++ b/crates/twitch-1337/src/config.rs
@@ -107,6 +107,10 @@ fn default_dreamer_timeout() -> u64 {
     120
 }
 
+fn default_dreamer_max_rounds() -> usize {
+    20
+}
+
 fn default_max_rounds() -> usize {
     3
 }
@@ -195,6 +199,11 @@ pub struct DreamerConfigSection {
     pub run_at: String,
     #[serde(default = "default_dreamer_timeout")]
     pub timeout_secs: u64,
+    /// Max tool-call rounds the ritual is allowed. The dreamer touches every
+    /// memory file plus the day's transcript, so this is intentionally larger
+    /// than `ai.max_turn_rounds` (which caps a single chat turn).
+    #[serde(default = "default_dreamer_max_rounds")]
+    pub max_rounds: usize,
 }
 
 impl Default for DreamerConfigSection {
@@ -205,6 +214,7 @@ impl Default for DreamerConfigSection {
             reasoning_effort: None,
             run_at: default_dreamer_run_at(),
             timeout_secs: default_dreamer_timeout(),
+            max_rounds: default_dreamer_max_rounds(),
         }
     }
 }
@@ -640,6 +650,12 @@ pub fn validate_config(config: &Configuration) -> Result<()> {
             bail!(
                 "ai.max_writes_per_turn must be 1..=64 (got {})",
                 ai.max_writes_per_turn
+            );
+        }
+        if !(1..=200).contains(&ai.dreamer.max_rounds) {
+            bail!(
+                "ai.dreamer.max_rounds must be 1..=200 (got {})",
+                ai.dreamer.max_rounds
             );
         }
         validate_reasoning_effort(

--- a/crates/twitch-1337/src/database.rs
+++ b/crates/twitch-1337/src/database.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::util::resolve_berlin_time;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Schedule {
     pub name: String,
     pub start_date: Option<NaiveDateTime>,

--- a/crates/twitch-1337/src/lib.rs
+++ b/crates/twitch-1337/src/lib.rs
@@ -164,7 +164,7 @@ where
                     .or_else(|| ai.reasoning_effort.clone()),
                 run_at,
                 timeout_secs: ai.dreamer.timeout_secs,
-                max_rounds: ai.max_turn_rounds,
+                max_rounds: ai.dreamer.max_rounds,
                 max_writes_per_turn: ai.max_writes_per_turn,
                 inject_byte_budget: ai.memory.inject_byte_budget,
                 channel: channel_for_ritual,

--- a/crates/twitch-1337/src/ping.rs
+++ b/crates/twitch-1337/src/ping.rs
@@ -54,9 +54,15 @@ pub struct PingManager {
 
 impl PingManager {
     /// Load pings from disk. Creates empty store if file doesn't exist.
+    ///
+    /// Templates are re-validated against `validate_template` after
+    /// deserialization so that entries that were written before the validator
+    /// existed, hand-edited on disk, or survived a partial atomic write cannot
+    /// smuggle CR/LF/NUL into outgoing PRIVMSGs. Failing entries are dropped
+    /// with a warning.
     pub fn load(data_dir: &Path) -> Result<Self> {
         let path = data_dir.join(PINGS_FILENAME);
-        let store = if path.exists() {
+        let mut store: PingStore = if path.exists() {
             let data = std::fs::read_to_string(&path).wrap_err("Failed to read pings.ron")?;
             ron::from_str(&data).wrap_err("Failed to parse pings.ron")?
         } else {
@@ -65,6 +71,20 @@ impl PingManager {
                 pings: HashMap::new(),
             }
         };
+
+        store
+            .pings
+            .retain(|name, ping| match validate_template(&ping.template) {
+                Ok(()) => true,
+                Err(e) => {
+                    tracing::warn!(
+                        ping = %name,
+                        error = %e,
+                        "Dropping ping with invalid template on load",
+                    );
+                    false
+                }
+            });
 
         info!(count = store.pings.len(), "Loaded pings");
 
@@ -358,6 +378,24 @@ mod tests {
         assert!(result.is_err());
         let ping = mgr.store.pings.get("test").unwrap();
         assert_eq!(ping.template, "Hey {mentions}!");
+    }
+
+    #[test]
+    fn load_drops_pings_with_invalid_template_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(PINGS_FILENAME);
+        // Hand-write a pings.ron containing one good and one CR/LF-bearing entry,
+        // simulating a file written before validate_template existed or
+        // hand-edited on disk.
+        let raw = "(pings: {\n  \"good\": (template: \"Hey {mentions}!\", members: [], cooldown: None, created_by: \"admin\"),\n  \"bad\": (template: \"Hey {mentions}\\r\\nPRIVMSG #other :pwned\", members: [], cooldown: None, created_by: \"admin\"),\n})\n";
+        std::fs::write(&path, raw).unwrap();
+
+        let mgr = PingManager::load(dir.path()).unwrap();
+        assert!(mgr.store.pings.contains_key("good"));
+        assert!(
+            !mgr.store.pings.contains_key("bad"),
+            "ping with control chars must be dropped on load",
+        );
     }
 
     #[test]

--- a/crates/twitch-1337/src/twitch/handlers/schedules.rs
+++ b/crates/twitch-1337/src/twitch/handlers/schedules.rs
@@ -345,8 +345,12 @@ pub async fn run_scheduled_message_handler<T, L>(
 
     info!("Dynamic scheduled message handler started");
 
-    // Track running tasks by schedule name
-    let mut running_tasks: HashMap<String, JoinHandle<()>> = HashMap::new();
+    // Track running tasks by schedule name. We keep a cloned `Schedule`
+    // alongside the handle so a hot-reload that edits an existing schedule's
+    // content (without renaming) still aborts the stale task and respawns.
+    // Without this, `retain` keyed only on name silently dropped content
+    // changes — see issue #39.
+    let mut running_tasks: HashMap<String, (JoinHandle<()>, database::Schedule)> = HashMap::new();
     let mut current_version = 0u64;
 
     // Monitor cache for changes every 30 seconds
@@ -357,7 +361,7 @@ pub async fn run_scheduled_message_handler<T, L>(
             _ = check_interval.tick() => {}
             () = shutdown.notified() => {
                 info!("Scheduled message handler: shutdown received, awaiting children");
-                for (name, handle) in running_tasks.drain() {
+                for (name, (handle, _)) in running_tasks.drain() {
                     handle.abort();
                     if let Err(e) = handle.await
                         && !e.is_cancelled()
@@ -389,33 +393,44 @@ pub async fn run_scheduled_message_handler<T, L>(
             let desired_schedules: HashMap<String, database::Schedule> =
                 schedules.into_iter().map(|s| (s.name.clone(), s)).collect();
 
-            // Stop tasks for schedules that no longer exist or have changed
-            running_tasks.retain(|name, handle| {
-                if !desired_schedules.contains_key(name) {
-                    info!(schedule = %name, "Stopping task for removed/changed schedule");
-                    handle.abort();
-                    false
-                } else {
-                    true
-                }
-            });
+            // Stop tasks for schedules that no longer exist OR whose content
+            // changed. Comparing the captured `Schedule` against the desired
+            // one catches in-place edits to message/interval/active window
+            // that share a name — `or_insert_with` below would otherwise be a
+            // no-op for the changed entry and the stale task keeps firing.
+            running_tasks.retain(
+                |name, (handle, captured)| match desired_schedules.get(name) {
+                    None => {
+                        info!(schedule = %name, "Stopping task for removed schedule");
+                        handle.abort();
+                        false
+                    }
+                    Some(desired) if desired != captured => {
+                        info!(schedule = %name, "Restarting task for changed schedule");
+                        handle.abort();
+                        false
+                    }
+                    Some(_) => true,
+                },
+            );
 
-            // Start tasks for new schedules
+            // Start tasks for new (or just-aborted) schedules.
             for (name, schedule) in desired_schedules {
                 let channel = channel.clone();
                 let shutdown = shutdown.clone();
                 let clock = clock.clone();
                 running_tasks.entry(name.clone()).or_insert_with(|| {
                     info!(schedule = %name, "Starting task for new schedule");
-
-                    tokio::spawn(run_schedule_task(
+                    let captured = schedule.clone();
+                    let handle = tokio::spawn(run_schedule_task(
                         schedule,
                         client.clone(),
                         cache.clone(),
                         channel,
                         shutdown,
                         clock,
-                    ))
+                    ));
+                    (handle, captured)
                 });
             }
 


### PR DESCRIPTION
## Summary

Seven small, independent fixes batched into one PR — each as its own commit. All security/correctness or reliability tightenings; no feature work.

| # | Commit | Area |
|---|---|---|
| #22 | `fix(aviation): add connect_timeout to HTTP client` | Aviation client hangs on DNS/TCP stalls |
| #21 | `fix(aviation): validate callsign in FlightIdentifier::parse` | URL path-segment injection guard |
| #130 | `fix(ritual): handle Berlin DST gap when resolving run_at` | Once-a-year panic in dreamer |
| #40 | `fix(ping): re-validate templates on PingManager::load` | CR/LF defense-in-depth on disk entries |
| #129 | `feat(ai): separate dreamer max_rounds from chat-turn cap` | Ritual no longer starves at the chat-turn cap |
| #39 | `fix(schedule): restart task on schedule content change` | Hot-reload edits without rename now apply |
| #100 | `feat(ai): surface provider auth/billing errors to chat` | OpenRouter 401/402/403/429 visible in chat |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 287 passed, 1 skipped
- [ ] Manual: `!track ../foo` rejected with German error
- [ ] Manual: edit existing schedule message in-place, verify next post uses new text
- [ ] Manual: simulate provider 402 (revoked OpenRouter key) and confirm chat reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)