### PR TITLE
fix(ci): resolve open code scanning alerts (#81 #82 #83)

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -29,7 +29,7 @@ jobs:
           output-file: hadolint.sarif
           no-fail: true
 
-      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         if: always()
         with:
           sarif_file: hadolint.sarif
@@ -57,7 +57,7 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: '0'
 
-      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         if: always()
         with:
           sarif_file: trivy-config.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1@sha256:00c3c07c51d092325d
 WORKDIR /app
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=clang
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install --no-install-recommends --assume-yes musl-tools mold clang ca-certificates \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- `sast.yml`: bump `# v4` → `# v4.35.2` on the two `codeql-action/upload-sarif` pins (resolves zizmor `ref-version-mismatch`, alerts #82 + #83). SHA unchanged.
- `Dockerfile`: add `# hadolint ignore=DL3008` above the apt-get install RUN; Debian apt version pinning is high-churn and not worth the noise (resolves alert #81).

## Notes
- Trivy alert #35 (no `HEALTHCHECK`, LOW) will be dismissed as won't-fix after merge — `FROM scratch` image with no shell and no network endpoint, so the check is not meaningful.
- Trivy alert #34 (root user, HIGH) remains open pending volume-perms verification on the deploy host.

## Test plan
- [x] CI green on all 7 required checks
- [ ] zizmor + hadolint alerts auto-close after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)