### PR TITLE
build: add just recipes to mount prod data via sshfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ ai_memory.ron
 
 # Caveman compression backups
 *.original.md
+
+# sshfs mount of prod data (root@docker.homelab:/opt/dockhand/stacks/twitch/data)
+/prod-data/

--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,15 @@ logs:
 # Deploy image and restart pod
 deploy: build push restart
 
+# Mount prod data dir from docker host via sshfs at ./prod-data
+mount-prod-data:
+  mkdir -p prod-data
+  sshfs root@docker.homelab:/opt/dockhand/stacks/twitch/data prod-data
+
+# Unmount prod data dir
+unmount-prod-data:
+  fusermount -u prod-data
+
 # Run locally with data dir in current directory and debug logging
 dev:
   DATA_DIR=./crates/twitch-1337/data RUST_LOG=info,twitch_1337=debug cargo run -p twitch-1337


### PR DESCRIPTION
## Summary
- Add `just mount-prod-data` / `just unmount-prod-data` recipes that sshfs-mount `root@docker.homelab:/opt/dockhand/stacks/twitch/data` at `./prod-data`.
- Gitignore `/prod-data/` so the mount point cannot be committed.

## Test plan
- [ ] `just mount-prod-data` mounts and lists prod runtime files
- [ ] `just unmount-prod-data` cleanly unmounts
- [ ] `git status` clean while mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)