### PR TITLE
Improve AI emote timing

### DIFF
--- a/crates/twitch-1337/data/7tv_emotes.toml
+++ b/crates/twitch-1337/data/7tv_emotes.toml
@@ -8,4906 +8,4911 @@
 # only the first [ai.emotes].max_prompt_emotes non-empty meanings into the prompt.
 
 [[emotes]]
-name = "KEKW"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
+name = ":d"
+meaning = "Kleines, einfaches Lachen oder Grinsen."
+usage = "Für kurze, lockere Reaktionen, wenn etwas eher niedlich oder leicht witzig ist."
 
 [[emotes]]
-name = "OMEGALUL"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
+name = ":DDDDDDDDDD"
+meaning = "Übertriebenes breites Lachen."
+usage = "Als stark überzeichnete Lachreaktion auf absurden Humor oder komplettes Chaos."
 
 [[emotes]]
-name = "MEGALUL"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
+name = "????"
+meaning = "Verwirrte Tieraufnahme mit Fragezeichen-Anmutung."
+usage = "Wenn der Chat sichtbar ratlos ist oder etwas gar keinen Sinn ergibt."
 
 [[emotes]]
-name = "LULE"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
+name = "$f1"
+meaning = "Formel-1-/Racing-Bild mit dramatischer Szene."
+usage = "Für F1-Rennen, Crashes, Strategiechaos oder Motorsport-Drama."
 
 [[emotes]]
-name = "LUUL"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
+name = "3DPrinting"
+meaning = "Bild eines 3D-Druckers bzw. einer Druckszene."
+usage = "Für Basteln, Prototyping, Maker-Talk oder wenn etwas langsam Schicht für Schicht entsteht."
 
 [[emotes]]
-name = "XD"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "xdd"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "NODDERS"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "HYPERNODDERS"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "Okayge"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "OK"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "YEPPERS"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "YESIDOTHINKSO"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "NOIDONTTHINKSO"
-meaning = "Ablehnung; eher nein oder das stimmt nicht."
-usage = "wenn man einer Aussage widerspricht"
-
-[[emotes]]
-name = "HUH"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "Aware"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "Clueless"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "WeirdChamp"
-meaning = "Missbilligung oder sarkastische Enttaeuschung."
-usage = "wenn etwas cringe, unpassend oder boomerhaft wirkt"
-
-[[emotes]]
-name = "PauseChamp"
-meaning = "Spannung oder erwartungsvolles Warten."
-usage = "wenn gleich etwas Wichtiges passiert oder ein Ausgang offen ist"
-
-[[emotes]]
-name = "AINTNOWAY"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "BRUH"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "cmonBRUH"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "monkaW"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "Sadeg"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "PeepoSad"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "Madge"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "PogU"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "Pag"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "LETSGO"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "COOKING"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "LETHIMCOOK"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "GOTTEM"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = "Yoink"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = "5Head"
-meaning = "Big-brain oder nerdige Korrektur."
-usage = "bei schlauen, uebergenauen oder nerdigen Aussagen"
-
-[[emotes]]
-name = "NOTED"
-meaning = "Notiert; Information wurde zur Kenntnis genommen."
-usage = "wenn etwas gemerkt, protokolliert oder trocken bestaetigt wird"
-
-[[emotes]]
-name = "Thinking"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "Prayge"
-meaning = "Respekt, Gebet oder Salut."
-usage = "bei Dank, Abschied, Respekt oder hoffnungsvollen Momenten"
-
-[[emotes]]
-name = "o7"
-meaning = "Respekt, Gebet oder Salut."
-usage = "bei Dank, Abschied, Respekt oder hoffnungsvollen Momenten"
-
-[[emotes]]
-name = "Waiting"
-meaning = "Warten; etwas laesst auf sich warten."
-usage = "wenn alle auf jemanden, ein Ergebnis oder einen Start warten"
-
-[[emotes]]
-name = "peepoHey"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "TriKool"
-meaning = "Cooler, gelassener oder zustimmender Vibe."
-usage = "wenn etwas entspannt, cool oder gelungen wirkt"
-
-[[emotes]]
-name = "gachiHacker"
-meaning = "Gachi-/Hacker-Meme; jemand wirkt uebertrieben technisch oder cracked."
-usage = "bei Tech-, Hackerman- oder Tryhard-Momenten"
-
-[[emotes]]
-name = "Thinking2"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "TRUEING"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "OkaygeL"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "snailWalk"
-meaning = "Langsames Vorankommen."
-usage = "wenn etwas sehr langsam passiert oder jemand troedelt"
-
-[[emotes]]
-name = "forsenInsane"
-meaning = "Wahnsinniger oder komplett chaotischer Forsen-Moment."
-usage = "bei absurdem Chaos oder Tilt"
-
-[[emotes]]
-name = "peepoArrive"
-meaning = "Ankunft; jemand kommt in den Chat oder zurueck."
-usage = "wenn jemand dazukommt"
-
-[[emotes]]
-name = "pepeMeltdown"
-meaning = "Meltdown; jemand bricht emotional oder rage-maessig zusammen."
-usage = "bei uebertriebener Frustration"
-
-[[emotes]]
-name = "forsenScoots"
-meaning = "Forsen-/Scoots-Meme; hektisches Wegbewegen oder Rumrutschen."
-usage = "bei hektischer Bewegung oder Ausweichmomenten"
-
-[[emotes]]
-name = "donowall"
-meaning = "DonoWall; eine Nachricht wird ignoriert oder prallt ab."
-usage = "wenn jemand nicht beachtet wird"
-
-[[emotes]]
-name = "Peace"
-meaning = "Frieden, Ruhe oder freundliches Peace-Zeichen."
-usage = "bei versoehnlicher oder entspannter Stimmung"
-
-[[emotes]]
-name = "pepeD"
-meaning = "Dance-/Party-Pepe."
-usage = "wenn Musik oder Bewegung passt"
-
-[[emotes]]
-name = "ppOverheat"
-meaning = "Ueberforderung oder Overheating."
-usage = "wenn etwas zu viel wird oder jemand ueberlastet ist"
-
-[[emotes]]
-name = "Painsge"
-meaning = "Schmerz, Leid oder unangenehmer Moment."
-usage = "bei kleinen Pain- oder Cringe-Momenten"
-
-[[emotes]]
-name = "ZULUL"
-meaning = "ZULUL-/ethnischer Twitch-Meme-Hype."
-usage = "bei klassischem Twitch-Meme-Kontext"
-
-[[emotes]]
-name = "ppAutismo"
-meaning = "Chaotische, ueberfokussierte Meme-Reaktion."
-usage = "bei sehr spezieller oder absurder Chat-Energie"
-
-[[emotes]]
-name = "Copeyeg"
-meaning = "Coping; jemand redet sich etwas schoen."
-usage = "bei Selbsttaeuschung, Ausreden oder uebertriebenem Optimismus"
-
-[[emotes]]
-name = "EgCheg"
-meaning = "Okayeg-/Cheg-Reaktion; leicht schraeges Zustimmen oder Beobachten."
-usage = "bei komischen, aber harmlosen Situationen"
-
-[[emotes]]
-name = "DankG"
-meaning = "Dankes oder danker Meme-Vibe."
-usage = "bei dankem Humor oder ironischem Meme-Kontext"
-
-[[emotes]]
-name = "wideFlop"
-meaning = "Breiter Floppa; alberner Floppa-Moment."
-usage = "bei goofy oder absurd breiten Meme-Reaktionen"
-
-[[emotes]]
-name = "WEEBSDETECTED"
-meaning = "Weebs erkannt."
-usage = "wenn Anime-/Weeb-Themen auftauchen"
-
-[[emotes]]
-name = "ABDUL"
-meaning = "Abdul-/nahostbezogener Meme-Charakter."
-usage = "bei etabliertem Abdul-Meme-Kontext im Chat"
-
-[[emotes]]
-name = "peepoFine"
-meaning = "Alles ist okay oder wird tapfer schoengeredet."
-usage = "wenn jemand so tut, als sei alles in Ordnung"
-
-[[emotes]]
-name = "KKooool"
-meaning = "Sehr cool oder laessig."
-usage = "wenn etwas besonders cool wirkt"
-
-[[emotes]]
-name = "FloppaL"
-meaning = "Floppa-Liebe oder Floppa-Herz."
-usage = "bei Floppa- oder liebevollem Meme-Kontext"
-
-[[emotes]]
-name = "Rainge"
-meaning = "Regen, graue Stimmung oder melancholischer Vibe."
-usage = "bei Regen, Traurigkeit oder ruhigen Momenten"
-
-[[emotes]]
-name = "PepeLa"
-meaning = "Pepe-la; lockere musikalische Reaktion."
-usage = "bei Sing-/La-la- oder Musikmomenten"
-
-[[emotes]]
-name = "EZWink"
-meaning = "Leichtes EZ mit zwinkerndem Unterton."
-usage = "bei spielerischem Triumph oder Necking"
-
-[[emotes]]
-name = "Trolleg"
-meaning = "Trolliger Okayeg-Moment."
-usage = "wenn jemand offensichtlich trollt"
-
-[[emotes]]
-name = "GuesNoEg"
-meaning = "Unsicheres Nein oder skeptisches Ablehnen."
-usage = "wenn etwas wahrscheinlich nicht stimmt"
-
-[[emotes]]
-name = "YOURMOM"
-meaning = "Your-mom-Witz."
-usage = "bei albernem, kindischem Roast-Humor"
-
-[[emotes]]
-name = "Wideg"
-meaning = "Breiter, goofy Okayeg-Moment."
-usage = "bei absurden oder gestreckten Meme-Reaktionen"
+name = "3Head"
+meaning = "Meme-Gesicht für einfaches, naives oder absichtlich dummes Denken."
+usage = "Wenn jemand sehr simpel argumentiert oder eine offensichtliche Lösung übersieht."
 
 [[emotes]]
 name = "3Heading"
-meaning = "3Head-/britischer Denk- oder Erklaermoment."
-usage = "bei britischem Humor oder einfachen Erklaerungen"
+meaning = "Animierte/aktive Variante von 3Head."
+usage = "Für laufende 3Head-Momente, bei denen jemand demonstrativ nicht mitdenkt."
 
 [[emotes]]
-name = "BASEDCIGAR"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
+name = "5Head"
+meaning = "Großhirn-/Genie-Meme für besonders kluge oder übertrieben schlaue Plays."
+usage = "Wenn jemand eine clevere Lösung findet oder ironisch als Superhirn dargestellt wird."
 
 [[emotes]]
-name = "meow"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
+name = "60TonnenEinigkeitRechtUndFreiheit"
+meaning = "Überladener deutscher Militär-/Hymnen-Insider mit schwerer Maschine im Bild."
+usage = "Wenn ein Deutschland-Moment absichtlich martialisch, schwerfällig oder übertrieben pathetisch gerahmt wird."
+
+[[emotes]]
+name = "AAAA"
+meaning = "Schrei- oder Panikreaktion."
+usage = "Wenn etwas plötzlich eskaliert, laut, stressig oder komplett überwältigend ist."
+
+[[emotes]]
+name = "ABDUL"
+meaning = "7TV-/Twitch-Meme-Figur, oft als Partystimmung oder Insider genutzt."
+usage = "Für ausgelassene, chaotische oder gemeinschaftliche Chat-Momente."
+
+[[emotes]]
+name = "AbdulFlop"
+meaning = "Abdul-Variante, die wie ein Fail, Flop oder erschöpfter Absturz wirkt."
+usage = "Wenn ein Plan scheitert, Stimmung kippt oder ein Abdul-Moment komplett daneben geht."
+
+[[emotes]]
+name = "ABDULpls"
+meaning = "Tanz-/Musikvariante von ABDUL."
+usage = "Wenn Musik läuft, der Chat jammt oder jemand einen Beat feiert."
+
+[[emotes]]
+name = "ABOBA"
+meaning = "Überraschtes, breites Meme-Gesicht."
+usage = "Wenn etwas unerwartet, suspekt oder stark überzeichnet überraschend wirkt."
+
+[[emotes]]
+name = "ADDICTED"
+meaning = "Süchtig-/Fixierungs-Meme."
+usage = "Wenn jemand von einem Spiel, Thema, Getränk oder Bit nicht loskommt."
+
+[[emotes]]
+name = "ADHDge"
+meaning = "Unruhiges, sprunghaftes Energie-Meme."
+usage = "Wenn der Chat oder Streamer ständig das Thema wechselt oder hyperaktiv wirkt."
+
+[[emotes]]
+name = "Adiosge"
+meaning = "Abschieds- oder Weggeh-Emote."
+usage = "Wenn jemand den Chat verlässt, etwas beendet wird oder ein Run vorbei ist."
+
+[[emotes]]
+name = "AINTNOCAT"
+meaning = "Unscharfes Tier-/Bildmotiv als „ain’t no cat“-Insider."
+usage = "Wenn diskutiert wird, ob etwas überhaupt eine Katze ist, oder als absurder Gegenruf."
+
+[[emotes]]
+name = "AINTNOWAY"
+meaning = "Ungläubige „aint no way“-Reaktion; sichtbar als gruselig/geschockt wirkendes Bild."
+usage = "Wenn etwas so absurd oder unglaublich ist, dass man es kaum fassen kann."
+
+[[emotes]]
+name = "AkiraDespair"
+meaning = "Dunkles, kontrastreiches Despair-Bild mit dramatischer Silhouette."
+usage = "Für überzeichnete Verzweiflung, Anime-Drama oder den Moment, in dem alles innerlich kollabiert."
+
+[[emotes]]
+name = "ALERT"
+meaning = "Alarmierendes Tierbild mit Warn-/Aufmerksamkeitsgefühl."
+usage = "Wenn der Chat sofort hinschauen soll oder etwas Wichtiges bemerkt wurde."
+
+[[emotes]]
+name = "AlienGathering"
+meaning = "Alien-/außerirdisches Meme-Emote."
+usage = "Für seltsame, außerirdische, technoide oder unerwartet fremde Momente im Stil von 'AlienGathering'."
+
+[[emotes]]
+name = "AlienPls"
+meaning = "Tanzendes Alien-Meme."
+usage = "Für Musik, Techno, rhythmische Szenen oder außerirdisch-weirde Stimmung."
+
+[[emotes]]
+name = "AlienWave"
+meaning = "Winkendes Alien."
+usage = "Als Begrüßung oder Abschied mit leicht seltsamem, außerirdischem Vibe."
+
+[[emotes]]
+name = "AlonsoHola"
+meaning = "Alonso-/Formel-1-Insider als Begrüßungs- oder „hola“-Moment."
+usage = "Für spanisch angehauchte Grüße, F1-Talk oder wenn ein Alonso-Insider freundlich in den Chat kommt."
+
+[[emotes]]
+name = "AlonsoLookingAtYou"
+meaning = "Alonso-/F1-Insider mit direktem, prüfendem Blick."
+usage = "Wenn jemand beobachtet, judged oder der Chat sich direkt angesprochen fühlt."
+
+[[emotes]]
+name = "AlonsoPls"
+meaning = "Alonso-/F1-Insider mit bittender oder tanzender „pls“-Energie."
+usage = "Wenn man auf ein gutes Rennen, Strategieglück oder einen Alonso-Moment hofft."
+
+[[emotes]]
+name = "AlonsoSigma"
+meaning = "Alonso-/F1-Insider als Sigma-/Boss-Variante."
+usage = "Wenn ein Fahrer- oder Racing-Moment besonders souverän, kalt oder selbstbewusst wirkt."
+
+[[emotes]]
+name = "AlonsoStare"
+meaning = "Alonso-/F1-Stare: intensiver Blick bzw. Helm-/Fahrer-Fokus."
+usage = "Für konzentriertes Beobachten, stille Spannung oder skeptisches Starren bei Racing-Drama."
+
+[[emotes]]
+name = "Aloo"
+meaning = "Lautes Aloo-/Hallo-Rufemote."
+usage = "Als auffällige Begrüßung, Ruf in den Chat oder wenn jemand akustisch Aufmerksamkeit will."
+
+[[emotes]]
+name = "ALOO"
+meaning = "Sehr laute Variante des Aloo-Rufs."
+usage = "Wenn die Begrüßung, der Callout oder die Reaktion absichtlich größer und lauter wirken soll."
+
+[[emotes]]
+name = "alooo"
+meaning = "Langgezogenes, albernes Aloo."
+usage = "Für verspielte Begrüßungen, Meme-Rufe oder wenn jemand extra dumm-lustig in den Chat kommt."
+
+[[emotes]]
+name = "AlwaysHasBeen"
+meaning = "Meme aus dem Astronauten-Format: 'War schon immer so'."
+usage = "Wenn eine Erkenntnis angeblich neu ist, aber eigentlich immer offensichtlich war."
+
+[[emotes]]
+name = "Amogus"
+meaning = "Among-Us-/Sus-Meme."
+usage = "Wenn jemand verdächtig wirkt oder der Chat 'sus' ruft."
+
+[[emotes]]
+name = "amongEg"
+meaning = "Among-Us-Anspielung mit Eg-/Egg-Meme-Flair."
+usage = "Für sus-Momente, besonders wenn Ei-/Eg-Insider im Chat laufen."
+
+[[emotes]]
+name = "AMOOOGUS"
+meaning = "Übertriebene Among-Us-Referenz."
+usage = "Wenn jede Form und jedes Geräusch zwanghaft als Amogus erkannt wird."
+
+[[emotes]]
+name = "angy"
+meaning = "Kleine wütende Reaktion."
+usage = "Wenn man spielerisch genervt ist oder sich über Kleinigkeiten aufregt."
+
+[[emotes]]
+name = "annehatschonwiedernichtszutunwährenddesazb"
+meaning = "Sehr spezifischer Arbeitszeitbetrug-/Anne-Insider."
+usage = "Wenn jemand während der Arbeit offensichtlich nichts Produktives macht oder Chat-Time statt Arbeitszeit hat."
+
+[[emotes]]
+name = "anotado"
+meaning = "Spanisch/Portugiesisch für 'notiert'."
+usage = "Wenn man sich etwas merkt, eine Drohung ironisch notiert oder Buch führt."
+
+[[emotes]]
+name = "ANTIFA"
+meaning = "Politisch aufgeladenes Antifa-Emote; eher Marker für politischen Kontext als normale Emotion."
+usage = "Nur bei ausdrücklich politischem Kontext oder als Erkennung solcher Referenzen nutzen; nicht als neutrale Standardantwort einsetzen."
+
+[[emotes]]
+name = "AntistasiExperience"
+meaning = "Ironischer Anti-Stasi-/Überwachungs-Insider."
+usage = "Wenn etwas nach Kontrolle, Schnüffelei oder übertriebener Regelwut klingt."
+
+[[emotes]]
+name = "Applecatrun"
+meaning = "Rennende Apfelkatze."
+usage = "Wenn etwas schnell wegflitzt, ein Run startet oder Katzenchaos passiert."
+
+[[emotes]]
+name = "Arbeitszeitbetrug"
+meaning = "Peepo/Person im Arbeits- oder Business-Kontext als Meme für bezahltes Nichtstun."
+usage = "Wenn jemand im Chat hängt, prokrastiniert oder während der Arbeitszeit Unsinn macht."
+
+[[emotes]]
+name = "ARDA"
+meaning = "Foto einer Person in einem rot-weißen Sporttrikot vor rotem Hintergrund."
+usage = "Für Sport-, Team- oder Fan-Momente, wenn jemand wie ein Spieler oder Vereinsanhänger ins Bild kommt."
+
+[[emotes]]
+name = "AREYOUAGIRL"
+meaning = "Direkte, oft unbeholfene Frage als Meme."
+usage = "Für unangenehme Chat-Fragen oder ironische Social-Awkwardness."
 
 [[emotes]]
 name = "ArnoldHalt"
-meaning = "Stopp/Halt im Arnold-Stil."
-usage = "wenn etwas unterbrochen oder gestoppt werden soll"
+meaning = "Arnold-/Stop-Meme."
+usage = "Wenn jemand sofort aufhören, warten oder sich beruhigen soll."
 
 [[emotes]]
-name = "EgBusiness"
-meaning = "Business-Okayeg; serioeser oder pseudo-professioneller Moment."
-usage = "bei Business, Planen oder Verhandlungen"
+name = "ArnoldShake"
+meaning = "Handshake-/Arnold-Meme."
+usage = "Für Zustimmung, Bündnisse oder zwei Seiten, die sich überraschend einig sind."
 
 [[emotes]]
-name = "pepeCD"
-meaning = "Cheating-/CD-Meme."
-usage = "bei verdächtigem oder schummelndem Verhalten"
+name = "ARSCHKRATZEN"
+meaning = "Derber Körperhumor: Tier/Figur kratzt oder putzt sich am Hinterteil."
+usage = "Für absichtlich kindischen, unangenehmen oder sehr stumpfen Chat-Humor."
 
 [[emotes]]
-name = "peepoIgnore"
-meaning = "Ignorieren oder bewusst wegschauen."
-usage = "wenn jemand etwas nicht beachten will"
+name = "ASSEMBLE"
+meaning = "Aufruf zum Sammeln oder Zusammenkommen."
+usage = "Wenn Chat, Team oder Gruppe sich versammeln oder gemeinsam reagieren soll."
 
 [[emotes]]
-name = "GoodOneBoomer"
-meaning = "Missbilligung oder sarkastische Enttaeuschung."
-usage = "wenn etwas cringe, unpassend oder boomerhaft wirkt"
+name = "AufFloWarten"
+meaning = "Warten-auf-Flo-Insider."
+usage = "Wenn alle bereit sind, aber Flo noch fehlt, lädt oder den Ablauf verzögert."
 
 [[emotes]]
-name = "JoeBiden"
-meaning = "Joe-Biden-/Politik-Meme."
-usage = "wenn Biden oder US-Politik Thema ist"
+name = "AufGnocc"
+meaning = "Gnocc-/Nagertier-Insider mit nach vorn gestreckter Bewegung."
+usage = "Für einen sehr lokalen Gnocc-Moment oder wenn etwas wie ein kleiner, hektischer Einsatz wirkt."
 
 [[emotes]]
-name = "peepoTalk"
-meaning = "Reden oder Diskutieren."
-usage = "wenn jemand spricht, erklaert oder diskutiert"
+name = "AufKok"
+meaning = "Überdrehter Kok-/Koks-Insider mit Sonnenbrillen-/Partyenergie."
+usage = "Wenn jemand extrem aufgekratzt, zu wach oder übertrieben motiviert wirkt; vorsichtig wegen Drogen-Anspielung."
 
 [[emotes]]
-name = "Omege"
-meaning = "Omega-/Omegalul-artige Reaktion."
-usage = "bei lustigen oder absurden Situationen"
+name = "auh"
+meaning = "Katzen-/Tier-Nahaufnahme mit kurzem Schmerz- oder Überraschungslaut."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser auh-Moment zur Stimmung passt."
 
 [[emotes]]
-name = "pepeW"
-meaning = "PepeW; intensives, breites Meme-Lachen."
-usage = "bei starken Lach- oder W-Momenten"
+name = "AUSTRIAN"
+meaning = "Österreich-/Austrian-Insider."
+usage = "Bei Österreich-Bezug, Akzentwitzen oder Alpen-Referenzen."
 
 [[emotes]]
-name = "tucked"
-meaning = "Eingekuschelt oder tucked-in."
-usage = "bei cozy, Schlaf- oder Rueckzugsstimmung"
+name = "averageFan"
+meaning = "'Average fan'-Vergleichsmeme."
+usage = "Wenn eine Gruppe als typischer Fan karikiert wird."
 
 [[emotes]]
-name = "Yepge"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
+name = "averageSauerlaender"
+meaning = "Wütendes oder salziges Reaktionsmeme."
+usage = "Wenn Frust, Tilt oder Ärger eskaliert und 'averageSauerlaender' als Ausdruck passt."
 
 [[emotes]]
-name = "tomatoTime"
-meaning = "Tomaten-/Boo-Moment; jemand wird ausgebuht."
-usage = "bei spielerischem Ausbuhen oder Tomatenwerfen"
+name = "AverageTurkishMan"
+meaning = "Überzeichnetes Nationalitäten-/„Average X man“-Meme."
+usage = "Nur vorsichtig bei klar ironischem Meme-Kontext nutzen; nicht für abwertende Aussagen über reale Gruppen."
 
 [[emotes]]
-name = "dogTrip"
-meaning = "Trip oder verwirrter Hundemoment."
-usage = "bei surrealer oder verwirrter Stimmung"
+name = "awakebutatwhatcost"
+meaning = "Wach, aber erschöpft oder traumatisiert."
+usage = "Wenn man zwar da ist, aber mental noch nicht bereit."
 
 [[emotes]]
-name = "okge"
-meaning = "Okayge-artige neutrale Zustimmung."
-usage = "bei ruhiger Zustimmung oder Akzeptanz"
+name = "Awakege"
+meaning = "Wachgewordenes Meme-Gesicht."
+usage = "Für Morgenstimmung, plötzliche Aufmerksamkeit oder müdes Erwachen."
 
 [[emotes]]
-name = "PETTHEDOGEGE"
-meaning = "Hund streicheln."
-usage = "bei niedlichen Hundemomenten oder Trost"
+name = "Aware"
+meaning = "Bewusstes, melancholisches Erkenntnis-Meme."
+usage = "Wenn jemand eine bittere Wahrheit erkennt oder zu real wird."
 
 [[emotes]]
-name = "egDealer"
-meaning = "Dealer-/zwielichtiger Okayeg-Moment."
-usage = "bei scherzhaft suspekten Angeboten"
+name = "Awareg"
+meaning = "Aware-Variante mit trockenem Realisationsgefühl."
+usage = "Wenn man plötzlich versteht, wie schlecht, wahr oder unangenehm eine Situation wirklich ist."
 
 [[emotes]]
-name = "PepeGiggle"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
+name = "AWOKEGE"
+meaning = "Awake/Woke-Variante von Pepe: plötzlich wach, aufmerksam oder erleuchtet."
+usage = "Wenn eine Erkenntnis kickt, jemand aus dem Halbschlaf kommt oder eine Lage bewusst wahrnimmt."
 
 [[emotes]]
-name = "FloppaDespair"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
+name = "AYOOOOO"
+meaning = "Überraschte oder anzügliche Reaktion."
+usage = "Wenn jemand etwas Suspektes, Wildes oder Doppeldeutiges sagt."
 
 [[emotes]]
-name = "peepoTalkR"
-meaning = "Reden nach rechts; Dialog oder Antwort."
-usage = "wenn jemand spricht oder antwortet"
+name = "azb"
+meaning = "Nahaufnahme eines hellen kleinen Tiers, das über eine Tischkante oder an einem Arbeitsplatz vorbeischaut."
+usage = "Für Situationen, in denen jemand im Arbeits-/Alltagskontext nur kurz auftaucht, neugierig schaut oder still beobachtet."
 
 [[emotes]]
-name = "egsqzL"
-meaning = "Linksgerichtetes Squeeze-/Okayeg-Meme."
-usage = "bei engem, gedruecktem oder seitlichem Meme-Kontext"
+name = "BADEMEISTER"
+meaning = "Bademeister-/Poolaufsicht-Meme."
+usage = "Für Wasser-, Sommer-, Schwimmbad- oder strenge Aufsichtsmomente."
 
 [[emotes]]
-name = "WideEgg"
-meaning = "Breites Egg-/Okayeg-Meme."
-usage = "bei goofy oder breitgezogenen Reaktionen"
+name = "Barack"
+meaning = "Barack-Obama-bezogene Reaktion."
+usage = "Wenn ein politischer, präsidialer oder trocken charismatischer Moment im Chat passiert."
 
 [[emotes]]
-name = "Okayge7"
-meaning = "Okayge-Salut."
-usage = "bei Respekt, Zustimmung oder Abschied"
+name = "BASADO"
+meaning = "Spanisch wirkende Variante von 'based'."
+usage = "Für dieselbe Zustimmung wie BASED, aber mit extra Meme-Geschmack."
 
 [[emotes]]
-name = "Paaag"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
+name = "BASED"
+meaning = "Zustimmung für eine mutige oder starke Meinung."
+usage = "Wenn jemand etwas sagt, das der Chat feiert oder ironisch für 'korrekt' hält."
 
 [[emotes]]
-name = "EgHug"
-meaning = "Umarmung, Trost oder Zuneigung."
-usage = "bei freundlichen, warmen oder troestenden Momenten"
+name = "BASEDCIGAR"
+meaning = "Based-Reaktion mit Zigarren-/Boss-Vibe."
+usage = "Wenn jemand besonders souverän oder lässig recht hat."
+
+[[emotes]]
+name = "BASEDFARMING"
+meaning = "Based plus Landwirtschafts-/Farming-Insider."
+usage = "Wenn harte Arbeit, Farmen oder bodenständige Takes gefeiert werden."
+
+[[emotes]]
+name = "Baseg"
+meaning = "Kleine 7TV-Variante von 'based'."
+usage = "Als schnelle Zustimmung bei guten Aussagen oder ironisch starken Takes."
+
+[[emotes]]
+name = "Bayern"
+meaning = "Bayern-/München- oder Bundesland-Insider."
+usage = "Für Bayern-Witze, Dialektmomente, Fußball oder süddeutsche Lokalreferenzen."
+
+[[emotes]]
+name = "BBoomer"
+meaning = "Boomer-Meme."
+usage = "Wenn jemand altmodisch wirkt, Technik nicht versteht oder nostalgisch wird."
+
+[[emotes]]
+name = "bebop"
+meaning = "Bebop-/Cowboy-Bebop-artiges Stil-Emote."
+usage = "Wenn etwas cool, jazzig, retrofuturistisch oder lässig inszeniert wirkt."
+
+[[emotes]]
+name = "bebopstyle"
+meaning = "Bebop-Stilvariante mit extra Style-Fokus."
+usage = "Für stylische Bewegungen, Musikvibes oder Momente mit Anime-/Jazz-Ästhetik."
+
+[[emotes]]
+name = "Bedge"
+meaning = "Schlaf-/Bett-Meme."
+usage = "Wenn der Stream müde macht, jemand schlafen geht oder Content gemütlich langsam ist."
+
+[[emotes]]
+name = "BeeHappy"
+meaning = "Fröhliches Bienen-Meme."
+usage = "Für süße, positive oder wholesome Momente."
+
+[[emotes]]
+name = "BeerTime"
+meaning = "Bierzeit-Meme."
+usage = "Wenn Feierabend, Fußball, Wochenende oder Trinkstimmung angesagt ist."
+
+[[emotes]]
+name = "bejj"
+meaning = "Verniedlichte Bedge-/Cozy-Variante."
+usage = "Wenn der Chat schläfrig, weich, gemütlich oder leicht benommen wirkt."
+
+[[emotes]]
+name = "bejjtogeth"
+meaning = "Gemeinsames Cozy-/Bedge-Meme."
+usage = "Wenn alle zusammen chillen, schlafen wollen oder eine warme Gruppenstimmung entsteht."
+
+[[emotes]]
+name = "BENZER"
+meaning = "Auto-/Mercedes-Benz-Insider mit dunklem Sportwagen im Bild."
+usage = "Für Car-Talk, Luxusauto-Witze, deutsche Auto-Momente oder ironisches Fahrer-Prestige."
+
+[[emotes]]
+name = "Berge"
+meaning = "Kleines Berg-/Geröll- oder Steinmotiv."
+usage = "Für Alpen-, Fels-, Wander- oder Geröllmomente, auch als trockener Natur-Insider."
+
+[[emotes]]
+name = "bidenBlast"
+meaning = "Joe-Biden-Explosion-/Blast-Meme."
+usage = "Wenn ein politischer Moment plötzlich eskaliert oder jemand mit absurder Energie antwortet."
+
+[[emotes]]
+name = "bieberbutzemanPepe"
+meaning = "Pepe-Variante mit Bieberbutzemann-/lokalem Insider-Flair."
+usage = "Wenn ein Pepe-Reaktionsbild mit absichtlich spezifischem Community-Insider statt generischem Pepe gemeint ist."
+
+[[emotes]]
+name = "Bierge"
+meaning = "Bierbezogenes Meme-Gesicht."
+usage = "Für Prost-Momente, Kneipenstimmung oder ironisches Feierabendgefühl."
+
+[[emotes]]
+name = "BiggusDickus"
+meaning = "Monty-Python-Referenz."
+usage = "Wenn ein absurder Name, kindischer Humor oder Klassiker-Zitat passt."
+
+[[emotes]]
+name = "billyReady"
+meaning = "Billy-/Gachi-Ready-Emote."
+usage = "Wenn jemand bereit ist, etwas durchzuziehen, oft mit ironisch übermotivierter Energie."
+
+[[emotes]]
+name = "BillySmoke"
+meaning = "Rauchendes Billy-/Meme-Emote."
+usage = "Für lässige, dunkle oder 'erstmal rauchen'-Momente."
+
+[[emotes]]
+name = "BINGCHILLING"
+meaning = "John-Cena-/Social-Credit-Meme mit Eiscreme-Bezug."
+usage = "Für China-/Social-Credit-Witze, Eiscreme-Referenzen oder ironisches Chillen."
+
+[[emotes]]
+name = "binrusselL"
+meaning = "George-Russell-/Racing-L-Meme."
+usage = "Wenn ein Formel-1-Moment für Russell, Mercedes oder einen klaren L steht."
+
+[[emotes]]
+name = "BirdgeArrive"
+meaning = "Birdge kommt in die Szene; auf dem Standbild sehr dunkel/kaum sichtbar."
+usage = "Wenn jemand im Chat auftaucht oder ein Vogel-/Birdge-Charakter hereinkommt."
+
+[[emotes]]
+name = "BirdgeLeave"
+meaning = "Vogel verlässt die Szene."
+usage = "Wenn jemand geht, ein Thema endet oder man sich verabschiedet."
+
+[[emotes]]
+name = "BirdgeStare"
+meaning = "Starrender Vogel."
+usage = "Wenn etwas beobachtet, geprüft oder misstrauisch beäugt wird."
+
+[[emotes]]
+name = "birdgeWhatIsGoingOn"
+meaning = "Birdge-Reaktion für Verwirrung: der Vogel wirkt ratlos oder beobachtet Chaos."
+usage = "Wenn etwas im Stream so seltsam wird, dass man nur noch „was passiert hier?“ denkt."
+
+[[emotes]]
+name = "Bitti"
+meaning = "Kleines graues Tier mit rosa Schleife und gelben Füßen, das bittend nach vorne schaut."
+usage = "Für niedliche Bitten, vorsichtiges Nachfragen oder einen harmlosen 'bitte'-Moment im Chat."
+
+[[emotes]]
+name = "bla"
+meaning = "Katzen-Nahaufnahme als kurzer Bla-/Blabla-Laut."
+usage = "Für Blabla, leises Maunzen oder belanglose Kommentare, die wie ein kleiner Katzenlaut wirken."
+
+[[emotes]]
+name = "BLANKIES"
+meaning = "Decken-/Kuschelemote."
+usage = "Für gemütliche, müde oder schutzsuchende Stimmung."
+
+[[emotes]]
+name = "BLEHHHH"
+meaning = "Ekel- oder Zungenrausstreck-Reaktion."
+usage = "Wenn etwas unangenehm, cringe oder eklig wirkt."
+
+[[emotes]]
+name = "Blindge"
+meaning = "Blind-/Übersehen-Reaktionsmeme."
+usage = "Wenn jemand etwas Offensichtliches nicht sieht oder komplett am Punkt vorbeischaut."
+
+[[emotes]]
+name = "BLUBBER"
+meaning = "Blubber-, Wasser- oder Unterwassergeräusch-Meme."
+usage = "Für absurde Geräusche, Ertrinken-in-Content-Vibes oder Wasserchaos."
+
+[[emotes]]
+name = "Blusheg"
+meaning = "Errötetes/verlegenes Meme-Gesicht."
+usage = "Wenn etwas süß, peinlich oder charmant unangenehm ist."
+
+[[emotes]]
+name = "Bobbers"
+meaning = "Wippendes, kleines Reaktions-Emote."
+usage = "Wenn man im Chat ruhig mitgeht, nickt oder einen Moment beiläufig begleitet."
+
+[[emotes]]
+name = "Boink"
+meaning = "Kleiner Treffer-/Anstups-Moment, im Bild ein Tier oder Objekt beim Anstoßen."
+usage = "Wenn jemand harmlos getroffen, angetippt, geprankt oder cartoonhaft „geboinkt“ wird."
+
+[[emotes]]
+name = "BOOBA"
+meaning = "Twitch-Meme für auffällige Oberweite/Attraktion."
+usage = "Als Thirst-/Attraction-Reaktion erkennen; in sachlichen oder moderierten Bot-Antworten besser vermeiden."
+
+[[emotes]]
+name = "BOOMIES"
+meaning = "Boomer-/Explosion-/lauter alter Meme-Moment mit überzeichneter Optik."
+usage = "Für altbackene Takes, laute Eskalation oder wenn etwas maximal boomerhaft wirkt."
 
 [[emotes]]
 name = "BORGIR"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
+meaning = "Burger-Meme."
+usage = "Wenn Essen, Fast Food oder absurde Aussprache von Burgern Thema ist."
+
+[[emotes]]
+name = "borpaSpin"
+meaning = "Drehendes Borpa-/Tanz-Meme."
+usage = "Für Musik, Rotation, Hype oder stumpfes Mitwippen."
+
+[[emotes]]
+name = "BOXBOX"
+meaning = "Gaming-/Streamer-Referenz, oft als Energie- oder Hypeemote."
+usage = "Wenn mechanisch etwas stark gespielt wird oder der Chat einen Clutch feiert."
+
+[[emotes]]
+name = "brainrot"
+meaning = "Internet-Brainrot-Meme."
+usage = "Wenn Content absurd, dauerhaft online oder komplett degeneriert wirkt."
+
+[[emotes]]
+name = "Breadge"
+meaning = "Brot- oder Loaf-artiges Meme-Emote."
+usage = "Für Brot, Essen, weiche Loaf-Energie oder komplett harmlose Cozy-Momente."
+
+[[emotes]]
+name = "BRICK"
+meaning = "Backstein-/Ziegel-Meme."
+usage = "Wenn etwas hart, stumpf, schwer oder absolut blockig ist."
+
+[[emotes]]
+name = "BrickTime"
+meaning = "Zeit für Backstein/Brick."
+usage = "Wenn der Backstein-Insider passend wird oder etwas schwer einschlägt."
+
+[[emotes]]
+name = "BRRRRRRRRRRRRRT"
+meaning = "Maschinengewehr-/A-10-Geräuschmeme."
+usage = "Für laute Dauerfeuer-, Motor- oder Spam-Momente."
+
+[[emotes]]
+name = "bruh"
+meaning = "Kleine Bruh-Reaktion."
+usage = "Für milde Enttäuschung, trockenen Unglauben oder Alltagsversagen."
+
+[[emotes]]
+name = "BRUH"
+meaning = "Klassische Bruh-Reaktion für Enttäuschung oder Fassungslosigkeit."
+usage = "Wenn jemand etwas Dummes tut oder ein Moment peinlich kippt."
+
+[[emotes]]
+name = "BRUHDespair"
+meaning = "Bruh plus Verzweiflung."
+usage = "Wenn ein Fehler so schlimm ist, dass normales Bruh nicht reicht."
+
+[[emotes]]
+name = "Bruhge"
+meaning = "7TV-Bruh-Variante."
+usage = "Als kompakte Reaktion auf Unfug, schlechte Plays oder dumme Aussagen."
+
+[[emotes]]
+name = "BruhhurB"
+meaning = "Bruh rückwärts/gespiegelt: absichtlich verdrehte Bruh-Reaktion."
+usage = "Wenn etwas nicht nur bruh ist, sondern so absurd, dass selbst die Reaktion verdreht wird."
+
+[[emotes]]
+name = "BRUHSIT"
+meaning = "Sitzende Bruh-Reaktion."
+usage = "Wenn man enttäuscht sitzen bleibt und das Geschehen verarbeitet."
+
+[[emotes]]
+name = "bruhSlide"
+meaning = "Kleine Bruh-Figur, die rutscht oder wegslidet."
+usage = "Wenn jemand aus der Situation herausrutscht, sich leise verabschiedet oder ein Fail wegdriftet."
+
+[[emotes]]
+name = "bruuuuuuuuuuuuuuuuuuuuuuuuh"
+meaning = "Extrem langgezogene Bruh-Reaktion mit maximaler Fassungslosigkeit."
+usage = "Für sehr dumme Fails, peinliche Aussagen oder Momente, die ein normales „bruh“ nicht mehr abdeckt."
+
+[[emotes]]
+name = "Bruvge"
+meaning = "Britisch angehauchte Bruder-/Bruv-Reaktion."
+usage = "Wenn man jemanden kumpelhaft, ironisch oder leicht enttäuscht als 'bruv' anspricht."
+
+[[emotes]]
+name = "BuffDoge"
+meaning = "Starker Doge."
+usage = "Wenn etwas muskulös, überlegen oder ironisch alpha wirkt."
+
+[[emotes]]
+name = "buh"
+meaning = "Buh aus Busted: das Bild zeigt das kleine braune Buh-Tier/Maskottchen; es ist kein Ausbuhen und kein Boo-Ruf."
+usage = "Für Busted-/Buh-Insider, niedliche kurze Reaktionen oder wenn der Chat genau diesen Buh-Charakter meint."
+
+[[emotes]]
+name = "buhL"
+meaning = "Busted-Buh-Variante mit Herz-/Love-Anmutung; das Motiv wirkt wie ein verliebtes oder weiches Buh."
+usage = "Wenn ein Buh-Moment liebevoll, süß oder extra weich gemeint ist; nicht als Ausbuhen interpretieren."
+
+[[emotes]]
+name = "buhRave"
+meaning = "Busted-Buh in Rave-/Partyform, mit überdrehter Feier- oder Tanzenergie."
+usage = "Für Musik, Party, Rave, Spam oder wenn der Buh-Insider komplett aufdreht."
+
+[[emotes]]
+name = "buhroar"
+meaning = "Busted-Buh als brüllende oder schreiende Variante."
+usage = "Wenn der Buh-Charakter laut eskaliert, schreit oder ein Meme-Moment sehr intensiv wird."
+
+[[emotes]]
+name = "buhShakey"
+meaning = "Busted-Buh als wackelnde/zitternde Variante."
+usage = "Für nervöse, vibrierende, chaotische oder überforderte Buh-Momente."
+
+[[emotes]]
+name = "buhssin"
+meaning = "Busted-Buh mit „bussin“-/genießender Insider-Anmutung; im Bild wirkt Buh begeistert oder zufrieden."
+usage = "Wenn etwas im Busted-/Buh-Kontext gut schmeckt, gut läuft oder absichtlich albern gefeiert wird."
+
+[[emotes]]
+name = "BuntenbachLike"
+meaning = "Mann im Sessel mit zustimmender Präsentationshaltung."
+usage = "Wenn etwas abgesegnet, geliked oder trocken als guter Punkt markiert wird."
+
+[[emotes]]
+name = "bup"
+meaning = "Nahaufnahme eines Tiers als kurzer „bup“-Laut oder Mini-Reaktion."
+usage = "Für kleine, niedliche, abrupte Reaktionen ohne große Aussage."
+
+[[emotes]]
+name = "Businessge"
+meaning = "Business-/Anzug-Meme."
+usage = "Wenn etwas professionell, geldorientiert oder pseudo-seriös wirkt."
+
+[[emotes]]
+name = "Buyegg"
+meaning = "Ei-kaufen-/Egg-Commerce-Meme."
+usage = "Wenn jemand absurde Konsumentscheidungen trifft oder der Chat zu Eiern zurückkehrt."
+
+[[emotes]]
+name = "Byege"
+meaning = "Abschieds-Meme."
+usage = "Wenn jemand geht, ein Gegner rausfliegt oder ein Thema beendet ist."
+
+[[emotes]]
+name = "Camoningerland"
+meaning = "Verballhornter 'Come on England'-Ruf."
+usage = "Für Fußball, England-Witze oder ironischen Support mit maximal falscher Aussprache."
+
+[[emotes]]
+name = "CantinaJAM"
+meaning = "Star-Wars-Cantina-Musik-Meme."
+usage = "Für Musik, Sci-Fi-Stimmung oder nerdiges Mitjammen."
+
+[[emotes]]
+name = "Capybara"
+meaning = "Wasserschwein-Meme."
+usage = "Für ruhige, chillige oder sozial verträgliche Stimmung."
+
+[[emotes]]
+name = "CapybaraStare"
+meaning = "Starrendes Capybara."
+usage = "Wenn man kommentarlos beobachtet oder skeptisch schaut."
+
+[[emotes]]
+name = "Carlos"
+meaning = "Foto einer orangefarbenen Katze, die ruhig und leicht seitlich in die Kamera schaut."
+usage = "Für gelassene Katzenreaktionen, trockenes Beobachten oder einen unbeeindruckten Blick."
 
 [[emotes]]
 name = "catArrive"
 meaning = "Katze kommt an."
-usage = "wenn jemand oder etwas ankommt"
-
-[[emotes]]
-name = "Copege"
-meaning = "Coping; jemand redet sich etwas schoen."
-usage = "bei Selbsttaeuschung, Ausreden oder uebertriebenem Optimismus"
-
-[[emotes]]
-name = "peepoRant"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "Fishinge"
-meaning = "Angeln oder Bait."
-usage = "wenn jemand baitet oder nach Reaktionen fischt"
-
-[[emotes]]
-name = "Dedge"
-meaning = "Tot/Deadge; etwas ist vorbei."
-usage = "bei Fail, Ende oder komplettem Stillstand"
-
-[[emotes]]
-name = "Bruhge"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "dogBOOP"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "DankL"
-meaning = "Dank-L; Meme-Niederlage."
-usage = "bei ironischem Verlust oder L-Moment"
-
-[[emotes]]
-name = "BRICK"
-meaning = "Brick; etwas ist dumm, schwerfaellig oder komplett daneben."
-usage = "bei stumpfen Fehlern oder Brick-Momenten"
-
-[[emotes]]
-name = "INSANECAT"
-meaning = "Verrueckte Katze."
-usage = "bei chaotischer Cat-Energie"
-
-[[emotes]]
-name = "monakChrist"
-meaning = "Monak/Christus-Meme."
-usage = "bei ueberdramatischen heiligen oder christlichen Meme-Momenten"
-
-[[emotes]]
-name = "BruhhurB"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "Suseg"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "EZeg"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "stopbeingEg"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "BRUHSIT"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "Wankge"
-meaning = "Derber Wankge-Meme-Moment."
-usage = "bei bewusst derbem oder NSFW-nahem Humor"
-
-[[emotes]]
-name = "DogLookingWickedAndCool"
-meaning = "Hund sieht wicked und cool aus."
-usage = "bei sehr coolem Hund- oder Style-Moment"
-
-[[emotes]]
-name = "DEUTSCHLAND"
-meaning = "Deutschland-Bezug."
-usage = "wenn Deutschland, Deutsch oder deutsche Themen direkt relevant sind"
-
-[[emotes]]
-name = "Richeg"
-meaning = "Based; starke Zustimmung."
-usage = "bei klarer Zustimmung oder Respekt"
-
-[[emotes]]
-name = "WeeWoo"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "PauseChamps"
-meaning = "Spannung oder erwartungsvolles Warten."
-usage = "wenn gleich etwas Wichtiges passiert oder ein Ausgang offen ist"
-
-[[emotes]]
-name = "bruhSlide"
-meaning = "Bruh-Moment; unglaeubige oder trocken genervte Reaktion."
-usage = "wenn etwas dumm, frustrierend oder kaum zu glauben ist"
-
-[[emotes]]
-name = "AYOOOOO"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "monakHmm"
-meaning = "Nachdenken oder Frage."
-usage = "bei Analyse, Unsicherheit oder Spekulation"
-
-[[emotes]]
-name = "Muhammeg"
-meaning = "Okayeg-/Name-Insider mit ruhiger Zustimmung."
-usage = "bei trockenem Mohammed/Muhammed- oder Name-Meme-Kontext"
-
-[[emotes]]
-name = "FeelsGladMan"
-meaning = "Freundliche Erleichterung oder gute Laune."
-usage = "wenn sich etwas positiv aufloest oder angenehm wirkt"
-
-[[emotes]]
-name = "MaxRebo"
-meaning = "Musik- oder Star-Wars-Referenz."
-usage = "wenn gejammt wird oder ein Star-Wars-Musikmoment passt"
-
-[[emotes]]
-name = "Moodwokege"
-meaning = "Kuh-Meme."
-usage = "bei Kuh-, Farm- oder Muh-Momenten"
-
-[[emotes]]
-name = "BuffDoge"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "FloppaBing"
-meaning = "Floppa-Meme."
-usage = "wenn ein Floppa- oder Chad-Floppa-Moment passt"
-
-[[emotes]]
-name = "Berge"
-meaning = "Berg- oder Okayeg-Insider."
-usage = "bei Hoehen-, Wander- oder Berg-Momenten"
-
-[[emotes]]
-name = "modCheck"
-meaning = "Mod-Check; fragt nach Moderatoren oder Aufmerksamkeit."
-usage = "wenn Mods oder Moderation scherzhaft angesprochen werden"
-
-[[emotes]]
-name = "BOOBA"
-meaning = "Booba-/Horny-Twitch-Meme."
-usage = "bei bewusst horny oder Booba-Meme-Kontext"
-
-[[emotes]]
-name = "StaregeZoom"
-meaning = "Starren oder Beobachten."
-usage = "wenn jemand beobachtet, schaut oder suspekt fixiert"
-
-[[emotes]]
-name = "pepeP"
-meaning = "PepeP; neugierige oder leicht angespannte Pepe-Reaktion."
-usage = "wenn man aufmerksam schaut oder auf etwas wartet"
-
-[[emotes]]
-name = "AlienPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "PogTasty"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "Awakege"
-meaning = "Wachgewordene Okayeg-Reaktion."
-usage = "wenn jemand aufmerksam wird oder aufwacht"
-
-[[emotes]]
-name = "ABDULpls"
-meaning = "Musik, Tanz oder Vibe."
-usage = "wenn Musik laeuft oder die Stimmung groovt"
-
-[[emotes]]
-name = "pepeAgony"
-meaning = "Pepe in Qual; Schmerz, Cringe oder Verzweiflung."
-usage = "wenn etwas weh tut, unangenehm oder kaum ertragbar ist"
-
-[[emotes]]
-name = "Cheems"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "Waving"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "GachiPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "dankWave"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "Dogey"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "pepeJAM"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "NoBitches"
-meaning = "No-bitches-Meme; jemand ist allein oder erfolglos beim Flirten."
-usage = "nur scherzhaft bei klarer Meme-Stimmung"
-
-[[emotes]]
-name = "zyzzPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "BeerTime"
-meaning = "Bier oder Feierabendgetraenk."
-usage = "wenn es um Bier, Feierabend oder Anstossen geht"
-
-[[emotes]]
-name = "ppHop"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "UNLUCKY"
-meaning = "Pech gehabt."
-usage = "bei Pech, schlechten Rolls oder knappen Fails"
-
-[[emotes]]
-name = "forsenExplainingHow"
-meaning = "Lange Erklaerung oder Essay."
-usage = "wenn jemand ausfuehrlich erklaert oder yappt"
-
-[[emotes]]
-name = "Saved"
-meaning = "Gerettet; knapp nochmal gut gegangen."
-usage = "wenn etwas gerade noch klappt"
-
-[[emotes]]
-name = "HELLAWICKED"
-meaning = "Krasse, wilde oder boese starke Reaktion."
-usage = "wenn etwas extrem, edgy oder uebertrieben stark wirkt"
-
-[[emotes]]
-name = "Dogege"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "SusegGun"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "headBang"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "DinkDonk"
-meaning = "Hinweis, Reminder oder Glocken-Moment."
-usage = "bei Ankuendigungen, Timern oder kurzen Erinnerungen"
-
-[[emotes]]
-name = "WICKED"
-meaning = "Krasse, wilde oder boese starke Reaktion."
-usage = "wenn etwas extrem, edgy oder uebertrieben stark wirkt"
-
-[[emotes]]
-name = "peepoLeave"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "FotzenFaschoFritzVonPapen"
-meaning = "Derber politischer Simpsons-/Faschismus-Diss."
-usage = "bei klar satirischem politischen Spott"
-
-[[emotes]]
-name = "TrollDespair"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "FeelsOldMan"
-meaning = "Alt, nostalgisch oder gealtert."
-usage = "bei Nostalgie oder wenn etwas alt wirkt"
-
-[[emotes]]
-name = "ppBounce"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "KKonaW"
-meaning = "KKona-/Country-Amerika-Meme."
-usage = "bei US-, Country- oder Redneck-Anspielungen"
-
-[[emotes]]
-name = "Amogus"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "Nerdge"
-meaning = "Big-brain oder nerdige Korrektur."
-usage = "bei schlauen, uebergenauen oder nerdigen Aussagen"
-
-[[emotes]]
-name = "peepoShy"
-meaning = "Schuechternheit oder Verlegenheit."
-usage = "bei suessen, awkward oder leicht verlegenen Momenten"
-
-[[emotes]]
-name = "borpaSpin"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "MONKE"
-meaning = "Monke-Meme."
-usage = "bei primitiver, alberner oder monke-artiger Reaktion"
-
-[[emotes]]
-name = "sumSmash"
-meaning = "Smash; etwas wird hart getroffen oder zerstoert."
-usage = "bei Smash-/Impact-Momenten"
-
-[[emotes]]
-name = "TOOBASED"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
-
-[[emotes]]
-name = "MONKEPUTIN"
-meaning = "Monke-Meme."
-usage = "bei primitiver, alberner oder monke-artiger Reaktion"
-
-[[emotes]]
-name = "bruh"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "Voidge"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "Bierge"
-meaning = "Bier oder Feierabendgetraenk."
-usage = "wenn es um Bier, Feierabend oder Anstossen geht"
-
-[[emotes]]
-name = "Latege"
-meaning = "Zu spaet."
-usage = "wenn jemand oder etwas verspaetet ist"
-
-[[emotes]]
-name = "MADeg"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "BASED"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
-
-[[emotes]]
-name = "OMEGALULiguess"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "CatChomp"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
-
-[[emotes]]
-name = "Fatge"
-meaning = "Dicker/traeger Sadge-Moment."
-usage = "bei scherzhaftem Fatge-Meme-Kontext"
-
-[[emotes]]
-name = "MadgeJuice"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "MadgeLate"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "Prayers"
-meaning = "Respekt, Gebet oder Salut."
-usage = "bei Dank, Abschied, Respekt oder hoffnungsvollen Momenten"
-
-[[emotes]]
-name = "catSmash"
-meaning = "Katze haut drauf."
-usage = "bei Smash- oder Wutmomenten mit Cat-Vibe"
-
-[[emotes]]
-name = "Blusheg"
-meaning = "Schuechternheit oder Verlegenheit."
-usage = "bei suessen, awkward oder leicht verlegenen Momenten"
-
-[[emotes]]
-name = "doggoArrive"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "hmmMeeting"
-meaning = "Nachdenken oder Frage."
-usage = "bei Analyse, Unsicherheit oder Spekulation"
-
-[[emotes]]
-name = "OkayChamp"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "ppConga"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "flushE"
-meaning = "Flush/wegspuelen."
-usage = "wenn etwas weg, erledigt oder im Klo ist"
-
-[[emotes]]
-name = "zyzzBass"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "STRONGERS"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "tintinJesus"
-meaning = "Tintin-/Jesus-Meme."
-usage = "bei absurd heiligem oder Tintin-bezogenem Kontext"
-
-[[emotes]]
-name = "SNIFFA"
-meaning = "Schnueffeln oder verdächtiges Riechen."
-usage = "bei suspekter Suche oder Schnueffel-Momenten"
-
-[[emotes]]
-name = "BASADO"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
-
-[[emotes]]
-name = "gullScream"
-meaning = "Vogel-Meme."
-usage = "bei Bird-, Flug- oder Schrei-Momenten"
-
-[[emotes]]
-name = "TheVoices"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "catsittingverycomfortablearoundacampfirewithitsfriends"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "deviW"
-meaning = "Devi-W-Moment."
-usage = "bei lokalem Devi-Insider oder W-Reaktion"
-
-[[emotes]]
-name = "Concerned"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "ChatTime"
-meaning = "Chatten oder Schreib-Moment."
-usage = "wenn der Chat aktiv schreibt oder etwas diskutiert"
-
-[[emotes]]
-name = "Zimb3l"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "Erm"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "bruuuuuuuuuuuuuuuuuuuuuuuuh"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "catNuke"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "Lookinge"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "AbdulFlop"
-meaning = "Floppa-Meme."
-usage = "bei Floppa, Chad-Floppa oder goofy Cat-Momenten"
-
-[[emotes]]
-name = "Shruge"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "BrickTime"
-meaning = "Ausbuhen oder Backstein-Moment."
-usage = "wenn etwas verworfen, ausgebuht oder hart abgelehnt wird"
-
-[[emotes]]
-name = "MoomTime"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "MADDIES"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "SMH"
-meaning = "Kopfschuetteln; Enttaeuschung oder Unglaube."
-usage = "bei kleinen Fehltritten oder absurden Aussagen"
-
-[[emotes]]
-name = "wikked"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "VIBE"
-meaning = "Vibe, entspannte Stimmung oder wohliger Moment."
-usage = "bei chilligen, ruhigen oder stimmigen Momenten"
-
-[[emotes]]
-name = "danse"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "AWOKEGE"
-meaning = "Awoke-/Woke-Okayeg."
-usage = "wenn etwas uebertrieben bewusst, woke oder meta wirkt"
-
-[[emotes]]
-name = "Coldge"
-meaning = "Kalte Okayeg-Reaktion."
-usage = "wenn etwas kalt, frostig oder emotionsarm wirkt"
-
-[[emotes]]
-name = "Aloo"
-meaning = "Kartoffel- oder Food-Referenz."
-usage = "bei Essensmomenten oder albernem Food-Talk"
-
-[[emotes]]
-name = "teaa"
-meaning = "Getraenk oder Trinkmoment."
-usage = "wenn es um Trinken, Kaffee, Bier oder Hydration geht"
-
-[[emotes]]
-name = "luvv"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "letsgo"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "sadd"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "NukeMoscow"
-meaning = "Kuh-Meme."
-usage = "bei Kuh-, Farm- oder Muh-Momenten"
-
-[[emotes]]
-name = "fricc"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "wikk"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "Chatting"
-meaning = "Chatten oder Schreib-Moment."
-usage = "wenn der Chat aktiv schreibt oder etwas diskutiert"
-
-[[emotes]]
-name = "essaying"
-meaning = "Lange Erklaerung oder Essay."
-usage = "wenn jemand ausfuehrlich erklaert oder yappt"
-
-[[emotes]]
-name = "CowDance"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "JosefScheisser"
-meaning = "Derber Josef-Insider-Diss."
-usage = "bei spottischer Ablehnung eines Josef- oder Insider-Moments"
-
-[[emotes]]
-name = "pepeJAMMER"
-meaning = "Musik, Tanz oder Vibe."
-usage = "wenn Musik laeuft oder die Stimmung groovt"
-
-[[emotes]]
-name = "SmokeTime"
-meaning = "Rauch-/Smoke-Meme."
-usage = "bei Smoke- oder Kiffer-Meme-Kontext"
-
-[[emotes]]
-name = "pugPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "GUMO"
-meaning = "Guten Morgen."
-usage = "als morgendliche Begruessung"
-
-[[emotes]]
-name = "SCHIZO"
-meaning = "Schizo-/Voices-Meme."
-usage = "bei uebertrieben paranoidem oder wirrem Meme-Kontext"
-
-[[emotes]]
-name = "peepoPooRocket"
-meaning = "Poo-Rocket; sehr derber, absurder Peepo-Moment."
-usage = "bei Fäkal- oder Rocket-Humor"
-
-[[emotes]]
-name = "sajj"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "Applecatrun"
-meaning = "Applecat rennt."
-usage = "bei schnellem Weglaufen oder Cat-Run-Momenten"
-
-[[emotes]]
-name = "widepeepoHappy"
-meaning = "Breites glueckliches Peepo."
-usage = "bei grosser Freude"
-
-[[emotes]]
-name = "pogg"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "CMONLETSGO"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "MyHonestReaction"
-meaning = "Meine ehrliche Reaktion."
-usage = "bei trockener Reaktions-Meme-Antwort"
-
-[[emotes]]
-name = "billyReady"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "XiPls"
-meaning = "Xi-/China-Meme tanzt."
-usage = "bei China-/Xi- oder Musik-Meme-Kontext"
-
-[[emotes]]
-name = "lookUp"
-meaning = "Nach oben schauen."
-usage = "wenn jemand nach oben schaut oder etwas oben passiert"
-
-[[emotes]]
-name = "PokiKiss"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "EARTHQUAKE"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "BirdgeLeave"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "HmmNotes"
-meaning = "Notiert; Information wurde zur Kenntnis genommen."
-usage = "wenn etwas gemerkt, protokolliert oder trocken bestaetigt wird"
-
-[[emotes]]
-name = "CluelessCouncil"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "sStrat"
-meaning = "Ratten-Meme."
-usage = "bei Rat-, Shake- oder hektischem Meme-Kontext"
-
-[[emotes]]
-name = "BRRRRRRRRRRRRRT"
-meaning = "Flugzeug- oder Aviation-Meme."
-usage = "wenn Flugzeuge, Jets oder Fliegen Thema sind"
-
-[[emotes]]
-name = "BENZER"
-meaning = "Benzer-Insider/Reaktionsmeme."
-usage = "bei lokalem Benzer-Kontext"
-
-[[emotes]]
-name = "SUSSY"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "Deadge"
-meaning = "Deadge; tot, vorbei oder komplett erledigt."
-usage = "bei Ende, Fail oder Stille"
-
-[[emotes]]
-name = "hmjj"
-meaning = "Nachdenklicher hmjj-Moment."
-usage = "bei unsicherem Nachdenken"
-
-[[emotes]]
-name = "Uhm"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "WINK"
-meaning = "Zwinkern."
-usage = "bei spielerischem Hinweis oder Scherz"
-
-[[emotes]]
-name = "BirdgeArrive"
-meaning = "Vogel-Meme."
-usage = "bei Bird-, Flug- oder Schrei-Momenten"
-
-[[emotes]]
-name = "VOICES"
-meaning = "Die Stimmen; innere Stimmen oder Schizo-Meme."
-usage = "bei uebertrieben wirrem Gedankenchaos"
-
-[[emotes]]
-name = "IveGonePastThePointOfInsanity"
-meaning = "Jenseits des Wahnsinns."
-usage = "bei komplett eskaliertem Unsinn"
-
-[[emotes]]
-name = "danseparty"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "REEEE"
-meaning = "Kreischen oder uebertriebene Rage."
-usage = "bei lauter, ueberzeichneter Frustration"
-
-[[emotes]]
-name = "Hydrationge"
-meaning = "Trinken nicht vergessen; Hydration Reminder."
-usage = "als freundliche Erinnerung, Wasser zu trinken"
-
-[[emotes]]
-name = "Awareg"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "Copeless"
-meaning = "Coping; jemand redet sich etwas schoen."
-usage = "bei Selbsttaeuschung, Ausreden oder uebertriebenem Optimismus"
-
-[[emotes]]
-name = "Capybara"
-meaning = "Capybara-Moment."
-usage = "bei ruhiger, stare-artiger oder capybara-bezogener Stimmung"
-
-[[emotes]]
-name = "FORSEN"
-meaning = "Forsen-Meme."
-usage = "bei Forsen- oder klassischem Twitch-Meme-Kontext"
-
-[[emotes]]
-name = "plonk"
-meaning = "Cat-Stare/Plonk."
-usage = "bei stummem, komischem Anstarren"
-
-[[emotes]]
-name = "catSleep"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
-
-[[emotes]]
-name = "kiwiDance"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "ThumbsUpSadCat"
-meaning = "Traurige Zustimmung mit Daumen hoch."
-usage = "bei bittersuesser Akzeptanz"
-
-[[emotes]]
-name = "GIGALONSO"
-meaning = "Giga-Alonso."
-usage = "bei starken Fernando-Alonso- oder F1-Momenten"
-
-[[emotes]]
-name = "PLEASE"
-meaning = "Bitten oder Flehen."
-usage = "wenn jemand lieb oder verzweifelt bittet"
-
-[[emotes]]
-name = "Sisi"
-meaning = "Ja ja; Zustimmung."
-usage = "bei lockerer Zustimmung"
-
-[[emotes]]
-name = "SquidJAM"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "Maracagers"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "WIDEGIGALONSO"
-meaning = "Breiter Giga-Alonso."
-usage = "bei besonders starkem Alonso-/F1-Meme"
-
-[[emotes]]
-name = "MarkusLanz"
-meaning = "Markus-Lanz-/Talkshow-Meme."
-usage = "bei Talkshow, Diskussion oder deutschem TV-Kontext"
-
-[[emotes]]
-name = "DIEGRÜNEN"
-meaning = "Die Gruenen als Politik-Meme."
-usage = "wenn deutsche Gruenen-Politik Thema ist"
-
-[[emotes]]
-name = "peepoExplosion"
-meaning = "Explosion oder kompletter Boom."
-usage = "bei explosiven Ereignissen oder Ueberraschung"
-
-[[emotes]]
-name = "Mexicaneg"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "PTSDge"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "Maggus"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "Coffeege"
-meaning = "Kaffee oder Koffein."
-usage = "wenn es um Kaffee, Wachwerden oder Koffeinbedarf geht"
-
-[[emotes]]
-name = "peepoCoffee"
-meaning = "Kaffee oder Koffein."
-usage = "wenn es um Kaffee, Wachwerden oder Koffeinbedarf geht"
-
-[[emotes]]
-name = "HmmmOK"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "TOPXI"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "peepoRun"
-meaning = "Peepo rennt."
-usage = "wenn jemand schnell weg oder loslaeuft"
-
-[[emotes]]
-name = "MmmHmm"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "spongePls"
-meaning = "Musik, Tanz oder Vibe."
-usage = "wenn Musik laeuft oder die Stimmung groovt"
-
-[[emotes]]
-name = "literallyme"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn Training, Muskeln oder Chad-Energie passt"
-
-[[emotes]]
-name = "birdgeWhatIsGoingOn"
-meaning = "Vogel-Meme."
-usage = "bei Bird-, Flug- oder Schrei-Momenten"
-
-[[emotes]]
-name = "MEGALULING"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "AlonsoLookingAtYou"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "pigPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "HmmPhone"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "HmmYAPPP"
-meaning = "Lange Erklaerung oder Essay."
-usage = "wenn jemand ausfuehrlich erklaert oder yappt"
-
-[[emotes]]
-name = "WaitingAngry"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "averageFan"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "AverageTurkishMan"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "StarwarsTime"
-meaning = "Star-Wars-Zeit."
-usage = "wenn Star Wars Thema wird"
-
-[[emotes]]
-name = "WtF"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "Heyge"
-meaning = "Freundliches Heyge-Hallo."
-usage = "bei Begruessungen"
-
-[[emotes]]
-name = "notListening"
-meaning = "Nicht zuhoeren."
-usage = "wenn jemand bewusst ausblendet"
-
-[[emotes]]
-name = "Camoningerland"
-meaning = "England- oder Fussball-Chant."
-usage = "zum Anfeuern oder ironischen Hypen von England/Fussball"
-
-[[emotes]]
-name = "wideduckass"
-meaning = "Enten-Meme."
-usage = "bei Duck-, Quack- oder alberner Tierstimmung"
-
-[[emotes]]
-name = "Bruvge"
-meaning = "Britischer Bruv-Okayeg."
-usage = "bei UK-, Bro- oder Mate-Vibe"
-
-[[emotes]]
-name = "angy"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "3Head"
-meaning = "3Head-/britischer Meme-Moment."
-usage = "bei britischem oder simpel-denkendem Humor"
-
-[[emotes]]
-name = "JarJarSwole"
-meaning = "Swole Jar Jar."
-usage = "bei Star-Wars- oder Muskel-Meme"
-
-[[emotes]]
-name = "MaN"
-meaning = "Unglaeubiges Mann/Man-Meme."
-usage = "bei genervtem oder erstauntem Ausruf"
-
-[[emotes]]
-name = "Exquisite"
-meaning = "Exquisit; stilvoll oder gehoben."
-usage = "bei elegantem, feinem oder ironisch edlem Moment"
-
-[[emotes]]
-name = "HolUp"
-meaning = "Moment mal; kurz stoppen und nachdenken."
-usage = "wenn etwas suspekt oder unerwartet ist"
-
-[[emotes]]
-name = "LOLE"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "pepePalpatine"
-meaning = "Star-Wars-Meme."
-usage = "wenn Star Wars oder Sci-Fi-Kontext passt"
-
-[[emotes]]
-name = "catBombing"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "peepoStrong"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "Serene"
-meaning = "Vibe, entspannte Stimmung oder wohliger Moment."
-usage = "bei chilligen, ruhigen oder stimmigen Momenten"
-
-[[emotes]]
-name = "YODA"
-meaning = "Yoda-/Star-Wars-Meme."
-usage = "bei Star-Wars- oder weisem Spruch"
-
-[[emotes]]
-name = "HelloThere"
-meaning = "Hello there."
-usage = "bei Star-Wars-Gruessen oder ikonischem Hallo"
-
-[[emotes]]
-name = "VaderListening"
-meaning = "Star-Wars-Meme."
-usage = "wenn Star Wars oder Sci-Fi-Kontext passt"
-
-[[emotes]]
-name = "speziTime"
-meaning = "Spezi-Getraenk oder Spezi-Moment."
-usage = "wenn es um Spezi oder Getraenke geht"
-
-[[emotes]]
-name = "BRUHDespair"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "WHAT"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "WIRES"
-meaning = "Verkabelt oder technisch chaotisch."
-usage = "bei Kabel-, Technik- oder Setup-Chaos"
-
-[[emotes]]
-name = "Ferrarieg"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "peepoYELLING"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "FeelsLagMan"
-meaning = "Lag, Verzoegerung oder technische Traegheit."
-usage = "wenn etwas haengt, verzögert reagiert oder laggt"
-
-[[emotes]]
-name = "juh"
-meaning = "Kurzer Cat-/Meme-Ausdruck."
-usage = "bei kleiner, alberner Reaktion"
-
-[[emotes]]
-name = "peepoUK"
-meaning = "Laenderbezug."
-usage = "wenn das konkrete Land Thema ist"
-
-[[emotes]]
-name = "WannDayZ"
-meaning = "Gaming- oder Spielmoment."
-usage = "bei Gameplay, Queue, Skill oder Game-Talk"
-
-[[emotes]]
-name = "DEVI"
-meaning = "Devi-Channel-Insider."
-usage = "wenn ein Devi-Running-Gag oder Devi-Moment angesprochen wird"
-
-[[emotes]]
-name = "catFU"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "WatchingForsen"
-meaning = "Forsen beobachten."
-usage = "wenn jemand beobachtet oder Forsen-Kontext da ist"
-
-[[emotes]]
-name = "plinkbedge"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
-
-[[emotes]]
-name = "peepoCookie"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
-
-[[emotes]]
-name = "HyperSwoleMEGAdoggersOnPreWorkoutOnLegDayWithAChestPumpGoing"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "alooo"
-meaning = "Aloo-Hallo."
-usage = "bei freundlichem Auftauchen"
-
-[[emotes]]
-name = "joever"
-meaning = "It is Joever; etwas ist vorbei."
-usage = "bei Niederlage oder Ende mit Biden-Meme"
-
-[[emotes]]
-name = "AlonsoStare"
-meaning = "Alonso starrt."
-usage = "bei intensivem Alonso-/F1-Blick"
-
-[[emotes]]
-name = "donkRun"
-meaning = "Donk rennt."
-usage = "bei schnellem Losrennen"
-
-[[emotes]]
-name = "MOURINHO"
-meaning = "Mourinho-Shush."
-usage = "wenn jemand schweigen oder nichts sagen soll"
-
-[[emotes]]
-name = "CLANKERS"
-meaning = "Star-Wars-Meme."
-usage = "wenn Star Wars oder Sci-Fi-Kontext passt"
-
-[[emotes]]
-name = "ICANT"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "buh"
-meaning = "Buh/Guh-Reaktion."
-usage = "bei kleinem Schock, Ratlosigkeit oder Albernheit"
-
-[[emotes]]
-name = "THONKERS"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "DogHello"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "vibee"
-meaning = "Vibe, entspannte Stimmung oder wohliger Moment."
-usage = "bei chilligen, ruhigen oder stimmigen Momenten"
-
-[[emotes]]
-name = "Okayegg"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "peepoSpit"
-meaning = "Ausspucken vor Schock oder Lachen."
-usage = "bei ueberraschenden Aussagen"
-
-[[emotes]]
-name = "GOTTEM2"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = "NotLikeDuck"
-meaning = "NotLikeDuck; Unbehagen oder Abneigung."
-usage = "wenn etwas unangenehm wirkt"
-
-[[emotes]]
-name = "peepoVanish"
-meaning = "Peepo verschwindet."
-usage = "wenn jemand abhaut oder aus der Situation raus will"
-
-[[emotes]]
-name = "Platypus"
-meaning = "Perry-/Schnabeltier-Referenz."
-usage = "bei random Tier-, Agenten- oder Perry-Momenten"
-
-[[emotes]]
-name = "grass"
-meaning = "Touch-grass- oder Pflanzen-Typ-Referenz."
-usage = "wenn jemand rausgehen soll oder Natur/Pokemon-Gras passt"
-
-[[emotes]]
-name = "LukashenkaExplainingHow"
-meaning = "Lange Erklaerung oder Essay."
-usage = "wenn jemand ausfuehrlich erklaert oder yappt"
-
-[[emotes]]
-name = "Blindge"
-meaning = "Blind oder nichts gesehen."
-usage = "bei uebersehenen Dingen oder Blindheit im Spiel"
-
-[[emotes]]
-name = "DonkHunter"
-meaning = "Donk-Jagd; jemanden beim Donk-Verhalten erwischen."
-usage = "wenn ein clowniger oder dummer Moment aufgedeckt wird"
-
-[[emotes]]
-name = "HUHBibi"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "mexicat"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "BOXBOX"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "DIESOFPAIN"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "ALOO"
-meaning = "Aloo-Call oder freundlicher Ruf."
-usage = "bei Hallo-/Call-Momenten"
-
-[[emotes]]
-name = "PHEW"
-meaning = "Erleichterung nach einem knappen Moment."
-usage = "wenn etwas gerade noch gut gegangen ist"
-
-[[emotes]]
-name = "WHERE"
-meaning = "Wo? Frage nach Ort oder Sache."
-usage = "wenn jemand fragt, wo etwas ist"
-
-[[emotes]]
-name = "monkaX"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "FDM"
-meaning = "FeelsDankMan; danker Meme-Vibe."
-usage = "bei trockenem oder dankem Humor"
-
-[[emotes]]
-name = "peepoFrance"
-meaning = "Laenderbezug."
-usage = "wenn das konkrete Land Thema ist"
-
-[[emotes]]
-name = "donkWalk"
-meaning = "Donk laeuft."
-usage = "bei Lauf- oder Weggeh-Momenten"
-
-[[emotes]]
-name = "peepoPride"
-meaning = "Pride oder stolzer Peepo."
-usage = "bei Stolz, Support oder Pride-Bezug"
-
-[[emotes]]
-name = "Oldge"
-meaning = "Alt, nostalgisch oder gealtert."
-usage = "bei Nostalgie oder wenn etwas alt wirkt"
-
-[[emotes]]
-name = "WOAH"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "KLASSIKER"
-meaning = "Klassiker; das passiert wieder typisch."
-usage = "bei wiederkehrenden, bekannten Situationen"
-
-[[emotes]]
-name = "NOPERS"
-meaning = "Ablehnung; eher nein oder das stimmt nicht."
-usage = "wenn man einer Aussage widerspricht"
-
-[[emotes]]
-name = "dobro"
-meaning = "Hund/Doge-Meme."
-usage = "wenn Hund, Doge oder niedlicher Hundemoment passt"
-
-[[emotes]]
-name = "BLEHHHH"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
+usage = "Als Begrüßung oder wenn Katzencontent beginnt."
 
 [[emotes]]
 name = "CatBedge"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
+meaning = "Müde Katze im Bett."
+usage = "Für Schlafenszeit, cozy Vibes oder Content zum Eindösen."
 
 [[emotes]]
-name = "stopbeingmean"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
+name = "catBombing"
+meaning = "Katze in einer chaotischen Bombing-/Überraschungssituation."
+usage = "Wenn ein Cat-Moment plötzlich eskaliert oder jemand unerwartet in eine Szene platzt."
 
 [[emotes]]
-name = "Pidser"
-meaning = "Pizza-/Apu-Meme."
-usage = "bei Pizza oder Essensmomenten"
+name = "CatChomp"
+meaning = "Beißende Katze."
+usage = "Wenn jemand snackt, zubeißt oder frech attackiert."
+
+[[emotes]]
+name = "CatCozy"
+meaning = "Gemütliche Katze."
+usage = "Für warme, entspannte, kuschelige Chat-Stimmung."
+
+[[emotes]]
+name = "CatDriving"
+meaning = "Katze fährt Auto."
+usage = "Bei Fahr-, Racing- oder Kontrollverlust-Momenten."
+
+[[emotes]]
+name = "catFU"
+meaning = "Katze mit Daumen- oder Finger-Geste als freche Ablehnung."
+usage = "Wenn man etwas grob abwinkt, neckisch provoziert oder „lass mich“ ausdrücken will."
+
+[[emotes]]
+name = "CatHug"
+meaning = "Umarmende Katze."
+usage = "Für Trost, Zuneigung oder wholesome Chat-Reaktionen."
+
+[[emotes]]
+name = "catJAM"
+meaning = "Jammende Katze."
+usage = "Wenn Musik läuft oder der Chat rhythmisch mitgeht."
+
+[[emotes]]
+name = "catLeave"
+meaning = "Katze geht weg."
+usage = "Als Abschied oder wenn man sich aus einer Situation zurückzieht."
+
+[[emotes]]
+name = "catmakingpizza"
+meaning = "Katze bei Pizza-/Küchenaktivität."
+usage = "Für Koch-, Pizza-, Snack- oder absurde Katzenarbeit-Momente."
+
+[[emotes]]
+name = "catNuke"
+meaning = "Katze mit nuklearem Chaos."
+usage = "Wenn ein Moment maximal eskaliert oder alles explodiert."
+
+[[emotes]]
+name = "catPunch"
+meaning = "Schlagende Katze."
+usage = "Für spielerische Attacken, Bonks oder kleine Wutausbrüche."
+
+[[emotes]]
+name = "catRAVE"
+meaning = "Rave-Katze."
+usage = "Bei Techno, Party, hoher BPM oder Chat-Hype."
+
+[[emotes]]
+name = "catRose"
+meaning = "Katze mit Rose/romantischer Geste."
+usage = "Für charmante, liebevolle oder dramatisch flirtige Momente."
+
+[[emotes]]
+name = "catSigh"
+meaning = "Seufzende Katze."
+usage = "Wenn man enttäuscht, müde oder resigniert reagiert."
+
+[[emotes]]
+name = "catsittingverycomfortablearoundacampfirewithitsfriends"
+meaning = "Mehrere Katzen sitzen gemütlich am Lagerfeuer."
+usage = "Für Cozy-Abende, Lagerfeuerstimmung, gemeinsames Chillen oder friedliche Gruppenmomente."
+
+[[emotes]]
+name = "catSleep"
+meaning = "Schlafende Katze."
+usage = "Wenn es spät ist, etwas langweilig wird oder jemand offline geht."
+
+[[emotes]]
+name = "catSmash"
+meaning = "Katze schlägt/smasht."
+usage = "Wenn etwas aggressiv zerstört, gewonnen oder gedrückt wird."
+
+[[emotes]]
+name = "CatTime"
+meaning = "Zeit für Katzen."
+usage = "Wenn Katzenemotes gespammt werden oder Cat-Content kommt."
+
+[[emotes]]
+name = "CatType"
+meaning = "Tippende Katze."
+usage = "Wenn jemand schreibt, Code tippt oder der Chat schnell hämmert."
+
+[[emotes]]
+name = "catVibe"
+meaning = "Vibende Katze."
+usage = "Für entspannte Musik, gute Stimmung oder gemeinsames Grooven."
+
+[[emotes]]
+name = "ccpL"
+meaning = "Politik-/China-/CCP-Meme mit L-/Niederlagenvibe."
+usage = "Bei politischen China- oder Social-Credit-Witzen; kontextsensibel und nicht hetzend verwenden."
+
+[[emotes]]
+name = "ChatTime"
+meaning = "Zeit zum Chatten."
+usage = "Wenn Diskussion, Smalltalk oder Chat-Fokus beginnt."
+
+[[emotes]]
+name = "Chatting"
+meaning = "Chat-/Rede-Meme."
+usage = "Wenn geredet, erklärt oder diskutiert wird."
+
+[[emotes]]
+name = "Cheems"
+meaning = "Doge/Cheems-Meme."
+usage = "Für schüchterne, falsch geschriebene oder weichgespülte Doge-Momente."
+
+[[emotes]]
+name = "Cinema"
+meaning = "Kino-/Peak-Fiction-Meme."
+usage = "Wenn etwas dramatisch, gut inszeniert oder absurd filmreif ist."
+
+[[emotes]]
+name = "CLANKERS"
+meaning = "Roboter-/Droiden-Insider; im Bild eine mechanische/armartige Form."
+usage = "Für Bots, Maschinen, Droiden oder Sci-Fi-Momente; als Meme-Begriff vorsichtig und nicht abwertend gegen Personen nutzen."
+
+[[emotes]]
+name = "ClassicDuck"
+meaning = "Klassische Ente."
+usage = "Für Enten-Insider, klassische Gags oder leichte Albernheit."
+
+[[emotes]]
+name = "CLEAN"
+meaning = "Sauberer/geleckter Cat-Moment; visuell eine Katzen-Nahaufnahme."
+usage = "Wenn etwas sehr sauber ausgeführt, glatt gelöst oder optisch „clean“ ist."
+
+[[emotes]]
+name = "Clowneg"
+meaning = "Clown-Meme."
+usage = "Wenn jemand sich lächerlich macht oder eine dumme Hoffnung hatte."
+
+[[emotes]]
+name = "Clueless"
+meaning = "Ahnungslosigkeits-Meme."
+usage = "Wenn jemand nichts merkt, eine offensichtliche Sache nicht versteht oder blind vertraut."
+
+[[emotes]]
+name = "CluelessCouncil"
+meaning = "Rat der Ahnungslosen."
+usage = "Wenn mehrere Leute gemeinsam komplett lost sind."
+
+[[emotes]]
+name = "cmonBRUH"
+meaning = "Ungeduldiges 'come on, bruh'."
+usage = "Wenn etwas Offensichtliches trotzdem schiefgeht."
+
+[[emotes]]
+name = "CMONLETSGO"
+meaning = "Motivierender Los-geht's-Ruf."
+usage = "Für Startsignale, Hype und Aufforderung zum Handeln."
+
+[[emotes]]
+name = "COCKBedge"
+meaning = "Derbe Bedge-Variante mit Hahn-/Cock-Wortspiel im Bildkontext."
+usage = "Bei sehr stumpfem Wortwitz oder müdem derbem Humor; für neutrale Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "CoffeeAddict"
+meaning = "Kaffeeabhängigkeits-Meme."
+usage = "Wenn jemand ohne Koffein nicht funktioniert oder Kaffee dringend braucht."
+
+[[emotes]]
+name = "Coffeege"
+meaning = "Kaffee-Meme-Gesicht."
+usage = "Für Morgenkaffee, Pausen oder konzentriertes Zuschauen."
+
+[[emotes]]
+name = "Coffeegers"
+meaning = "Kaffee-/gers-Variante."
+usage = "Wenn Kaffee als ritualisierte Chat-Stimmung gefeiert wird."
+
+[[emotes]]
+name = "cokebert"
+meaning = "Edgy Kokain-/Pulverlinien-Insider mit Bert-/Meme-Bezug."
+usage = "Für überdrehte, viel zu wache Energie oder Drogenwitz-Kontext; wegen Drogen-Anspielung vorsichtig verwenden."
+
+[[emotes]]
+name = "Coldge"
+meaning = "Kälte-/Frieren-Meme."
+usage = "Wenn etwas kalt, frostig oder emotional distanziert wirkt."
+
+[[emotes]]
+name = "Concerned"
+meaning = "Besorgter Gesichtsausdruck."
+usage = "Wenn eine Situation fragwürdig, riskant oder leicht beunruhigend ist."
+
+[[emotes]]
+name = "COOKED"
+meaning = "Jemand ist fertig, erledigt oder hat sich verrannt."
+usage = "Wenn ein Plan scheitert oder jemand mental/gegnerisch gekocht wurde."
+
+[[emotes]]
+name = "COOKING"
+meaning = "Jemand kocht gerade, also bereitet etwas Starkes vor."
+usage = "Wenn ein guter Take, Plan oder Play entsteht und man abwartet."
+
+[[emotes]]
+name = "COOL"
+meaning = "Coole, gelassene Reaktion."
+usage = "Wenn etwas lässig, souverän oder trocken beeindruckend ist."
+
+[[emotes]]
+name = "CoolChamp"
+meaning = "Lässige Zustimmung."
+usage = "Wenn ein Moment cool ist, aber nicht komplett ausrastet."
+
+[[emotes]]
+name = "Copege"
+meaning = "Coping-Meme."
+usage = "Wenn jemand sich etwas schönredet oder eine Niederlage rationalisiert."
+
+[[emotes]]
+name = "Copeless"
+meaning = "Kein Copium mehr übrig."
+usage = "Wenn selbst Ausreden nicht mehr helfen."
+
+[[emotes]]
+name = "Copeyeg"
+meaning = "Copium-/Selbsttäuschungs-Meme."
+usage = "Wenn jemand eine Niederlage, Hoffnung oder Ausrede mit 'Copeyeg' schönredet."
 
 [[emotes]]
 name = "COPIUMSHUTTLE"
-meaning = "Coping; jemand redet sich etwas schoen."
-usage = "bei Selbsttaeuschung, Ausreden oder uebertriebenem Optimismus"
+meaning = "Übertriebener Copium-Flucht-/Raketenwitz."
+usage = "Wenn der Chat maximal unrealistische Hoffnung startet."
 
 [[emotes]]
-name = "hugg"
-meaning = "Umarmung, Trost oder Zuneigung."
-usage = "bei freundlichen, warmen oder troestenden Momenten"
+name = "CountMeIn"
+meaning = "'Ich bin dabei'-Reaktion."
+usage = "Wenn man sich einer Idee, Aktion oder einem Meme anschließt."
 
 [[emotes]]
-name = "YoCat"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
+name = "CowBelling"
+meaning = "Kuh mit Glocken-/Musik- oder Bimmel-Anspielung."
+usage = "Für Farm-, Kuh-, Glocken- oder rhythmische Albernheit."
 
 [[emotes]]
-name = "uwuu"
-meaning = "Uwu; suess oder verspielt."
-usage = "bei niedlicher, softer Stimmung"
-
-[[emotes]]
-name = "forsenLaughingAtYou"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "peepoAustralia"
-meaning = "Laenderbezug."
-usage = "wenn das konkrete Land Thema ist"
-
-[[emotes]]
-name = "RatgeStratge"
-meaning = "Ratten-Meme."
-usage = "bei Rat-, Shake- oder hektischem Meme-Kontext"
-
-[[emotes]]
-name = "peepoSpeziSpin"
-meaning = "Getraenk oder Trinkmoment."
-usage = "wenn es um Trinken, Kaffee, Bier oder Hydration geht"
-
-[[emotes]]
-name = "DankLook"
-meaning = "Derber oder horny Meme-Humor."
-usage = "nur bei eindeutig scherzhaftem derbem Chat-Kontext"
-
-[[emotes]]
-name = "IHaveAQuestion"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "notee"
-meaning = "Notiert; Information wurde zur Kenntnis genommen."
-usage = "wenn etwas gemerkt, protokolliert oder trocken bestaetigt wird"
-
-[[emotes]]
-name = "Nowoted"
-meaning = "Notiert; Information wurde zur Kenntnis genommen."
-usage = "wenn etwas gemerkt, protokolliert oder trocken bestaetigt wird"
-
-[[emotes]]
-name = "uwu7"
-meaning = "Respekt, Gebet oder Salut."
-usage = "bei Dank, Abschied, Respekt oder hoffnungsvollen Momenten"
-
-[[emotes]]
-name = "owo7"
-meaning = "Respekt, Gebet oder Salut."
-usage = "bei Dank, Abschied, Respekt oder hoffnungsvollen Momenten"
-
-[[emotes]]
-name = "Pointless"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "Arbeitszeitbetrug"
-meaning = "Scherz ueber Chatten statt Arbeiten."
-usage = "wenn jemand waehrend der Arbeit im Chat ist"
+name = "CowDance"
+meaning = "Tanzende Kuh."
+usage = "Für Musik, Farm-Vibes oder albernes Mitfeiern."
 
 [[emotes]]
 name = "Cowge"
 meaning = "Kuh-Meme."
-usage = "bei Kuh-, Farm- oder Muh-Momenten"
-
-[[emotes]]
-name = "WAYTOOBUH"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
+usage = "Wenn Bauernhof, Milch, Gras oder Kuh-Insider passen."
 
 [[emotes]]
 name = "CowRoll"
-meaning = "Kuh rollt."
-usage = "bei alberner Bewegung oder Kuh-Meme"
+meaning = "Rollende Kuh."
+usage = "Für absurde Bewegung, Rotation oder Farm-Chaos."
 
 [[emotes]]
-name = "Suffering"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
+name = "CrazyIWasCrazyOnceTheyPutMeInARoomARubberroomARubberroomFilledWithRatsRatsMakeMeGoCrazy"
+meaning = "„Crazy? I was crazy once...“-Copypasta als Ratten-/Wahnsinns-Meme."
+usage = "Wenn der Chat in eine endlose Copypasta, Wiederholung oder absurde Verrücktheit kippt."
 
 [[emotes]]
-name = "MoomTime2"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "HUHFarmer"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "BASEDFARMING"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
-
-[[emotes]]
-name = "Barack"
-meaning = "Obama-/Barack-Meme."
-usage = "bei Barack Obama oder US-Politik"
-
-[[emotes]]
-name = "PIASTRI"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "GotCaughtTrolling"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = "Saddies"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "WhereMonkey"
-meaning = "Monke-Meme."
-usage = "bei primitiver, alberner oder monke-artiger Reaktion"
-
-[[emotes]]
-name = "MONKA"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "catmakingpizza"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
-
-[[emotes]]
-name = "plink"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "ccpL"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "peepoNATO"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "HmmScoots"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "howdy"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "Carlos"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "doot"
-meaning = "Skeleton-Trumpet/Doot."
-usage = "bei Spooky-, Trompeten- oder Halloween-Momenten"
-
-[[emotes]]
-name = "NotSure"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "DisneyDance"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "Purge"
-meaning = "Purge; wegraeumen oder ausmisten."
-usage = "wenn etwas entfernt werden soll"
-
-[[emotes]]
-name = "JAN"
-meaning = "Jan-/Duck-Spin-Insider."
-usage = "bei lokalem Jan- oder Spin-Kontext"
-
-[[emotes]]
-name = "DIESOFCRINGE"
-meaning = "Cringe oder Fremdschaemen."
-usage = "bei unangenehmen oder peinlichen Momenten"
-
-[[emotes]]
-name = "AlwaysHasBeen"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "unkok"
-meaning = "Unkok; Gegenstueck zu kok."
-usage = "bei nicht-kok oder Anti-kok-Momenten"
-
-[[emotes]]
-name = "SKILLISSUE"
-meaning = "Skill issue; scherzhafter Hinweis auf fehlende Spiel-Faehigkeit."
-usage = "bei kleinen Gameplay-Fehlern oder scherzhaftem Necking"
-
-[[emotes]]
-name = "CowBelling"
-meaning = "Kuh-Meme."
-usage = "bei Kuh-, Farm- oder Muh-Momenten"
-
-[[emotes]]
-name = "okjj"
-meaning = "okjj; kurze trockene Bestaetigung."
-usage = "bei sehr knapper Zustimmung"
-
-[[emotes]]
-name = "owoshy"
-meaning = "Schuechternheit oder Verlegenheit."
-usage = "bei suessen, awkward oder leicht verlegenen Momenten"
-
-[[emotes]]
-name = "owoslay"
-meaning = "Uwu/Owo mit Slay-Vibe."
-usage = "bei cute und selbstbewusster Stimmung"
-
-[[emotes]]
-name = "CatCozy"
-meaning = "Vibe, entspannte Stimmung oder wohliger Moment."
-usage = "bei chilligen, ruhigen oder stimmigen Momenten"
-
-[[emotes]]
-name = "HetIsVoorbij"
-meaning = "Es ist vorbei."
-usage = "bei Ende oder Niederlage"
-
-[[emotes]]
-name = "3DPrinting"
-meaning = "3D-Druck."
-usage = "wenn es um 3D-Druck oder Drucken geht"
-
-[[emotes]]
-name = "wideNessie"
-meaning = "Breite Nessie-Reaktion."
-usage = "bei niedlichen, albernen oder mascotartigen Momenten"
-
-[[emotes]]
-name = "ratJAM"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "Wokege"
-meaning = "Muedigkeit oder Ruhebeduerfnis."
-usage = "bei sleepy, spaeter oder erschoepfter Stimmung"
-
-[[emotes]]
-name = "ELCLASSICO"
-meaning = "Klassiker; das passiert wieder typisch."
-usage = "bei wiederkehrenden, bekannten Situationen"
-
-[[emotes]]
-name = "TRRRRRRRRRRR"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "Bedge"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
-
-[[emotes]]
-name = "Kapp"
-meaning = "Kappa-artiger Sarkasmus."
-usage = "wenn etwas offensichtlich ironisch gemeint ist"
-
-[[emotes]]
-name = "owoWiggle"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "Handshakege"
-meaning = "Handshake-Zustimmung; Einigkeit oder Deal."
-usage = "wenn zwei Seiten sich einig sind"
-
-[[emotes]]
-name = "bidenBlast"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "Hmmge"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "Evilge"
-meaning = "Nachdenken oder Frage."
-usage = "bei Analyse, Unsicherheit oder Spekulation"
-
-[[emotes]]
-name = "veryPog"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "hUh"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "NoseTime"
-meaning = "Nasen-Moment."
-usage = "bei Nase, Schnueffeln oder Fokus auf Gesicht"
-
-[[emotes]]
-name = "peepoLost"
-meaning = "Peepo ist verloren; Orientierungslosigkeit."
-usage = "wenn jemand nicht weiter weiss oder sich verlaufen hat"
-
-[[emotes]]
-name = "YEK"
-meaning = "Yek/Kek-artiges Lachen."
-usage = "bei kurzem Meme-Lachen"
-
-[[emotes]]
-name = "RIPBOZO"
-meaning = "Spöttisches RIP nach einem Fail."
-usage = "bei scherzhaften Niederlagen oder Fails"
-
-[[emotes]]
-name = "binrusselL"
-meaning = "Formel-1- oder Motorsport-Meme."
-usage = "wenn F1, Fahrer oder Rennen Thema sind"
-
-[[emotes]]
-name = "yodance"
-meaning = "Musik, Tanz oder Vibe."
-usage = "wenn Musik laeuft oder die Stimmung groovt"
-
-[[emotes]]
-name = "GoslingDrive"
-meaning = "Bewegung, Ankommen oder Fahren."
-usage = "bei Lauf-, Fahr- oder Bewegungsmomenten"
-
-[[emotes]]
-name = "peepoSwim"
-meaning = "Bewegung, Ankommen oder Fahren."
-usage = "bei Lauf-, Fahr- oder Bewegungsmomenten"
-
-[[emotes]]
-name = "monkaTriggered"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "DankDrive"
-meaning = "Bewegung, Ankommen oder Fahren."
-usage = "bei Lauf-, Fahr- oder Bewegungsmomenten"
-
-[[emotes]]
-name = "Hmmm"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "Buyegg"
-meaning = "Essen, Kochen oder Snack-Moment."
-usage = "wenn Essen oder Kochen Thema ist"
-
-[[emotes]]
-name = "Thisisfine"
-meaning = "Alles ist angeblich okay, obwohl es brennt."
-usage = "bei Chaos, das jemand gelassen hinnimmt"
-
-[[emotes]]
-name = "SusgeSitCute"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "MadgeSit"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "ClassicDuck"
-meaning = "Enten-Meme."
-usage = "bei Duck-, Quack- oder alberner Tierstimmung"
-
-[[emotes]]
-name = "monkaSTEER"
-meaning = "Bewegung, Ankommen oder Fahren."
-usage = "bei Lauf-, Fahr- oder Bewegungsmomenten"
-
-[[emotes]]
-name = "GIGACHAD"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "bla"
-meaning = "Bla; Gerede oder unwichtiger Text."
-usage = "wenn jemand nur labert"
-
-[[emotes]]
-name = "uuh"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "DANKIES"
-meaning = "Dankies; Channel-/Dank-Meme."
-usage = "bei danker Zustimmung oder 1337-Kontext"
-
-[[emotes]]
-name = "catJAM"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "kok"
-meaning = "Kok; Channel-Insider-Emote."
-usage = "bei lokalem kok- oder Channel-Meme-Kontext"
-
-[[emotes]]
-name = "HalbeBibel"
-meaning = "Textwand oder sehr langer Vortrag."
-usage = "wenn jemand einen halben Roman schreibt oder zu viel erklaert"
-
-[[emotes]]
-name = "HabeckGrin"
-meaning = "Lachen oder Humor-Reaktion."
-usage = "bei lustigen oder absurden Momenten"
-
-[[emotes]]
-name = "SICHERLICH"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "DANKHACKERMANS"
-meaning = "Dank Hackerman."
-usage = "bei technischem oder hackerhaftem Dank-Meme"
-
-[[emotes]]
-name = "GotCaughtTrolling1"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = ":DDDDDDDDDD"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "PartyAnimals"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "PeepoFarmerRiot"
-meaning = "Peepo-Farmer-Riot; laendlicher Protestwitz."
-usage = "wenn Farmer-, Dorf- oder Aufstands-Humor passt"
-
-[[emotes]]
-name = "UltraMad"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "CatDriving"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "KEKL"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "zonedout"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "JUP"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "buhShakey"
-meaning = "Buh/Guh-artige kurze Meme-Reaktion."
-usage = "bei Verwirrung, Schock oder albernem Ausruf"
-
-[[emotes]]
-name = "AufGnocc"
-meaning = "Auf Gnocc warten/gehen; lokaler Gnocc-Insider."
-usage = "bei Gnocc- oder lokalen Insider-Momenten"
-
-[[emotes]]
-name = "peepoConfused"
-meaning = "Verwirrter Peepo."
-usage = "wenn etwas keinen Sinn ergibt"
-
-[[emotes]]
-name = "THERE"
-meaning = "Da ist es; genau dort."
-usage = "wenn auf etwas gezeigt oder hingewiesen wird"
-
-[[emotes]]
-name = "Houthis"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "ZUSTIMMUNGSVERWEIGERUNG"
-meaning = "Verweigerte Zustimmung."
-usage = "wenn jemand absichtlich nicht zustimmt"
-
-[[emotes]]
-name = "omgHi"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "KratosFall"
-meaning = "Ratten-Meme."
-usage = "bei Rat-, Shake- oder hektischem Meme-Kontext"
-
-[[emotes]]
-name = "PhonegeSleepy"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
-
-[[emotes]]
-name = "eeeh"
-meaning = "Eeeh; zoegernde Unsicherheit."
-usage = "bei awkward oder unsicherer Reaktion"
-
-[[emotes]]
-name = "HmmmLaptop"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "Uhmm"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "PhonegeAddict"
-meaning = "Abschied oder Weggehen."
-usage = "wenn jemand geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "AufFloWarten"
-meaning = "Warten; etwas laesst auf sich warten."
-usage = "wenn alle auf jemanden, ein Ergebnis oder einen Start warten"
-
-[[emotes]]
-name = "YEPL"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "HUHW"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "Overcope"
-meaning = "Coping; jemand redet sich etwas schoen."
-usage = "bei Selbsttaeuschung, Ausreden oder uebertriebenem Optimismus"
-
-[[emotes]]
-name = "monkaLaugh"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "monkaClock"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "Listening"
-meaning = "Gebet, heiliger oder religioeser Meme-Kontext."
-usage = "bei ueberdramatisch heiligen Momenten"
-
-[[emotes]]
-name = "FloppaDude"
-meaning = "Floppa-Meme."
-usage = "wenn ein Floppa- oder Chad-Floppa-Moment passt"
-
-[[emotes]]
-name = "AAAA"
-meaning = "Schrei oder Panik."
-usage = "bei lautem Chaos oder Schreck"
-
-[[emotes]]
-name = "MainzerFlu"
-meaning = "Deutschland- oder Ortsbezug."
-usage = "wenn der konkrete Ort oder Deutschland Thema ist"
-
-[[emotes]]
-name = "WeWaiting"
-meaning = "Warten; etwas laesst auf sich warten."
-usage = "wenn alle auf jemanden, ein Ergebnis oder einen Start warten"
-
-[[emotes]]
-name = "MeinMann"
-meaning = "Mein Mann; Zustimmung oder Anerkennung."
-usage = "bei Support fuer jemanden"
-
-[[emotes]]
-name = "PeepiBlush"
-meaning = "Schuechternheit oder Verlegenheit."
-usage = "bei suessen, awkward oder leicht verlegenen Momenten"
-
-[[emotes]]
-name = "peepoKaiserslautern"
-meaning = "Deutschland- oder Ortsbezug."
-usage = "wenn der konkrete Ort oder Deutschland Thema ist"
-
-[[emotes]]
-name = "widepeepoSad"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "slayyy"
-meaning = "Selbstbewusstes Feiern oder stylisher Erfolg."
-usage = "wenn jemand stark, elegant oder iconic wirkt"
-
-[[emotes]]
-name = "CapybaraStare"
-meaning = "Capybara-Moment."
-usage = "bei ruhiger, stare-artiger oder capybara-bezogener Stimmung"
-
-[[emotes]]
-name = "NilsWennErMorgenInDenChatKommtUndRealisiertDassSeineGanzenLieblingsEmotesRausSind"
-meaning = "Erkenntnis oder Aware-Moment."
-usage = "wenn jemand etwas merkt oder bitter realisiert"
-
-[[emotes]]
-name = "huhu"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "AufKok"
-meaning = "Auf Kok; lokaler Channel-Insider."
-usage = "bei kok- oder Channel-Kontext"
-
-[[emotes]]
-name = "DennisPlaybackSpeed"
-meaning = "Playback- oder Tempo-Witz."
-usage = "wenn etwas zu schnell, zu langsam oder verstellt klingt"
-
-[[emotes]]
-name = "Mainz"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "Susdog"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "DOGGING"
-meaning = "Derber Hund-/Dogging-Meme."
-usage = "bei bewusst derbem Chat-Humor"
-
-[[emotes]]
-name = "COOL"
-meaning = "Cool; Zustimmung oder Anerkennung."
-usage = "wenn etwas gut oder laessig ist"
-
-[[emotes]]
-name = "ScheiseErwischt"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = "mhm"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "ezz"
-meaning = "Easy; leichter Sieg."
-usage = "bei einfachen Erfolgen oder spielerischem Flex"
-
-[[emotes]]
-name = "FeelsStrongJAM"
-meaning = "Musik, Tanz oder Vibe."
-usage = "wenn Musik laeuft oder die Stimmung groovt"
-
-[[emotes]]
-name = "peepoStuttgart"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "CUM"
-meaning = "Derber NSFW-Meme."
-usage = "nur bei klarer derber Meme-Stimmung"
-
-[[emotes]]
-name = "catRose"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "AINTNOCAT"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "LIFE"
-meaning = "Life; Lebensmoment."
-usage = "bei allgemeinen Life- oder Real-Talk-Momenten"
-
-[[emotes]]
-name = "LifeTogether"
-meaning = "Gemeinsames Leben/Zusammenhalt."
-usage = "bei warmen Community- oder Together-Momenten"
-
-[[emotes]]
-name = "MaggusBased"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
-
-[[emotes]]
-name = "meowdy"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "frfr"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "Nerdga"
-meaning = "Big-brain oder nerdige Korrektur."
-usage = "bei schlauen, uebergenauen oder nerdigen Aussagen"
-
-[[emotes]]
-name = "peepoGiggle"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "Kuhtee"
-meaning = "Kuhtee/Cute-Kuh."
-usage = "bei niedlicher Kuh- oder Cute-Stimmung"
-
-[[emotes]]
-name = "ADDICTED"
-meaning = "Suechtig nach etwas im Meme-Sinn."
-usage = "bei wiederholtem Verlangen nach Spiel, Kaffee oder Thema"
-
-[[emotes]]
-name = "GAMING"
-meaning = "Gaming oder bestimmtes Spielthema."
-usage = "wenn es direkt um Gaming oder dieses Spiel geht"
-
-[[emotes]]
-name = "Gymgers"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "CatTime"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "Byege"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "happi"
-meaning = "Gluecklich."
-usage = "bei Freude oder niedlicher positiver Reaktion"
-
-[[emotes]]
-name = "JIPPIE"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "PETTHEPEEPO"
-meaning = "Peepo streicheln."
-usage = "bei Trost oder niedlicher Peepo-Stimmung"
-
-[[emotes]]
-name = "DiedOfHeat"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "peepotalkButPeepoIsNotTalkingButInsteadIsOkay"
-meaning = "Peepo ist okay statt zu reden."
-usage = "bei ruhiger, okay-artiger Antwort statt Diskussion"
-
-[[emotes]]
-name = "CoffeeAddict"
-meaning = "Kaffee oder Koffein."
-usage = "wenn es um Kaffee, Wachwerden oder Koffeinbedarf geht"
-
-[[emotes]]
-name = "xdding"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "SURE"
-meaning = "Sicher doch; oft skeptisch oder ironisch."
-usage = "bei zweifelnder Zustimmung"
-
-[[emotes]]
-name = "Poor"
-meaning = "Arm oder bedauerlich."
-usage = "bei Mitleid oder Geldmangel-Meme"
-
-[[emotes]]
-name = "DortmundRope"
-meaning = "BVB-/Dortmund-Frust."
-usage = "bei enttaeuschten oder ironisch dunklen Fussball-Reaktionen"
-
-[[emotes]]
-name = "nh"
-meaning = "Nice hand / nice hit / knappe Anerkennung."
-usage = "bei kurzer Anerkennung im Spielkontext"
-
-[[emotes]]
-name = "huhh"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "Sadding"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "PagChomp"
-meaning = "Pag mit Chomp; hungriger Hype."
-usage = "bei leckerem oder hype Moment"
-
-[[emotes]]
-name = "peepoSlam"
-meaning = "Peepo slammt auf den Tisch."
-usage = "wenn etwas hart betont oder dramatisch gesetzt wird"
-
-[[emotes]]
-name = "CoolChamp"
-meaning = "CoolChamp; laessige Spannung."
-usage = "bei coolem, erwartungsvollem Moment"
-
-[[emotes]]
-name = "monkaFly"
-meaning = "Flugzeug- oder Aviation-Meme."
-usage = "wenn Flugzeuge, Jets oder Fliegen Thema sind"
-
-[[emotes]]
-name = "peepoNetherlands"
-meaning = "Laenderbezug."
-usage = "wenn das konkrete Land Thema ist"
-
-[[emotes]]
-name = "HmmmBye"
-meaning = "Abschied oder Weggehen."
-usage = "wenn jemand geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "pepePoint"
-meaning = "Pepe zeigt auf ein Detail."
-usage = "um etwas hervorzuheben oder spottend darauf zu zeigen"
-
-[[emotes]]
-name = "peepoEngland"
-meaning = "Laenderbezug."
-usage = "wenn das konkrete Land Thema ist"
-
-[[emotes]]
-name = "HuggingButTheresAnEarthquake"
-meaning = "Umarmung, Trost oder Zuneigung."
-usage = "bei freundlichen, warmen oder troestenden Momenten"
-
-[[emotes]]
-name = "Hannover"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "PeepoBerlin"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "Bayern"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "CountMeIn"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "BeeHappy"
-meaning = "Glueckliche, freundliche Bienen-Reaktion."
-usage = "wenn etwas wholesome oder froehlich ist"
-
-[[emotes]]
-name = "AMOOOGUS"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "SUUUUUREEEE"
-meaning = "Sarkastisches Ja-klar; starke Skepsis."
-usage = "wenn man eine Aussage nicht wirklich glaubt"
-
-[[emotes]]
-name = "doog"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "HeimlichManeuver"
-meaning = "Heimlich-Manoever."
-usage = "bei Verschlucken, Retten oder absurd physischem Humor"
-
-[[emotes]]
-name = "speziCope"
-meaning = "Spezi-Getraenk oder Spezi-Moment."
-usage = "wenn es um Spezi oder Getraenke geht"
-
-[[emotes]]
-name = "Plaul"
-meaning = "Nerdige Korrektur oder Falsch-Reaktion."
-usage = "wenn jemand rechthaberisch korrigiert oder etwas falsch ist"
-
-[[emotes]]
-name = "PUUUH"
-meaning = "Puh; Erleichterung oder Anstrengung."
-usage = "wenn etwas knapp oder anstrengend war"
-
-[[emotes]]
-name = "Spezige"
-meaning = "Spezi-Getraenk oder Spezi-Moment."
-usage = "wenn es um Spezi oder Getraenke geht"
-
-[[emotes]]
-name = "BBoomer"
-meaning = "Missbilligung oder sarkastische Enttaeuschung."
-usage = "wenn etwas cringe, unpassend oder boomerhaft wirkt"
-
-[[emotes]]
-name = "Deutschge"
-meaning = "Deutschland-Bezug."
-usage = "wenn Deutschland, Deutsch oder deutsche Themen direkt relevant sind"
-
-[[emotes]]
-name = "ppPoof"
-meaning = "Poof; verschwindet ploetzlich."
-usage = "wenn etwas weg ist"
-
-[[emotes]]
-name = "peepoBike"
-meaning = "Peepo faehrt Rad."
-usage = "bei Bewegung, Reise oder Los-gehts-Momenten"
-
-[[emotes]]
-name = "waa"
-meaning = "Waa; kurzer Schrei oder Verwirrung."
-usage = "bei kleinem Schreck"
-
-[[emotes]]
-name = "BirdgeStare"
-meaning = "Vogel-Meme."
-usage = "bei Bird-, Flug- oder Schrei-Momenten"
-
-[[emotes]]
-name = "glorpNotL"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "ADHDge"
-meaning = "Unruhige ADHS-/Okayeg-Reaktion."
-usage = "bei sprunghafter Energie oder Konzentrationschaos"
-
-[[emotes]]
-name = "catPunch"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "MAYO"
-meaning = "Mayo."
-usage = "wenn Mayonnaise oder weisser Sauce-Humor passt"
-
-[[emotes]]
-name = "Mashallah"
-meaning = "Mashallah; positive Anerkennung."
-usage = "bei beeindruckenden oder segensreichen Momenten"
-
-[[emotes]]
-name = "Cinema"
-meaning = "Cinema; grosses Kino."
-usage = "bei dramatischen oder sehr unterhaltsamen Momenten"
-
-[[emotes]]
-name = "rooon"
-meaning = "Bewegung, Ankommen oder Fahren."
-usage = "bei Lauf-, Fahr- oder Bewegungsmomenten"
-
-[[emotes]]
-name = "ALERT"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "xqcL"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "glorpDude"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "Elglorpo"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "glorpBuisness"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "HMmm"
-meaning = "Nachdenken; ueberlegen oder etwas analysieren."
-usage = "bei Fragen, Spekulation oder vorsichtigem Abwaegen"
-
-[[emotes]]
-name = "Mannheim"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "zoomies"
-meaning = "Wirrer oder wahnsinniger Meme-Moment."
-usage = "bei uebertrieben chaotischen Gedanken oder Voices-Memes"
-
-[[emotes]]
-name = "SCATTER"
-meaning = "Auseinanderlaufen oder verstreuen."
-usage = "wenn alle schnell weg oder auseinander sollen"
-
-[[emotes]]
-name = "NerdRadar"
-meaning = "Big-brain oder nerdige Korrektur."
-usage = "bei schlauen, uebergenauen oder nerdigen Aussagen"
-
-[[emotes]]
-name = "yonose"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "kola"
-meaning = "Cola-/Getraenke-Moment."
-usage = "wenn Cola oder Softdrink passt"
-
-[[emotes]]
-name = "racist"
-meaning = "Problematischer Rassismus- oder CmonBruh-Moment."
-usage = "wenn etwas rassistisch, grenzwertig oder unangenehm wirkt"
-
-[[emotes]]
-name = "WickedSteer"
-meaning = "Formel-1- oder Motorsport-Meme."
-usage = "wenn F1, Fahrer oder Rennen Thema sind"
-
-[[emotes]]
-name = "buhroar"
-meaning = "Buh/Guh-artige kurze Meme-Reaktion."
-usage = "bei Verwirrung, Schock oder albernem Ausruf"
-
-[[emotes]]
-name = "anotado"
-meaning = "Notiert auf Spanisch/Portugiesisch."
-usage = "wenn etwas registriert wird"
-
-[[emotes]]
-name = "maloche"
-meaning = "Arbeit oder Malochen."
-usage = "wenn es um Arbeit geht"
-
-[[emotes]]
-name = "buhL"
-meaning = "Buh/Guh-artige kurze Meme-Reaktion."
-usage = "bei Verwirrung, Schock oder albernem Ausruf"
-
-[[emotes]]
-name = "MussEinfachNurSchmieden"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "VFBierchen"
-meaning = "Bier oder Feierabendgetraenk."
-usage = "wenn es um Bier, Feierabend oder Anstossen geht"
-
-[[emotes]]
-name = "DankSpin"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "monkaE"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "monkaTracklimits"
-meaning = "Formel-1- oder Motorsport-Meme."
-usage = "wenn F1, Fahrer oder Rennen Thema sind"
+name = "crunch"
+meaning = "Knusper-, Crash- oder Crunch-Geräuschmeme."
+usage = "Für harte Treffer, essbare Momente, kaputte Knochen im Meme-Sinn oder Crunch-Time."
 
 [[emotes]]
 name = "CrusadeHmm"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
+meaning = "Kreuzritter/Crusader mit skeptischem „Hmm“-Vibe."
+usage = "Wenn mittelalterliche, religiöse oder „Kreuzzug“-Witze mit Nachdenken/Skepsis kombiniert werden."
 
 [[emotes]]
-name = "HaltEinfachDeineFresseDuHurensohn"
-meaning = "Sehr derbe Rage-Ablehnung."
-usage = "wenn ein harter Meme-Diss den beleidigenden Ton markieren soll"
+name = "CS2"
+meaning = "Counter-Strike-2-Bezug."
+usage = "Für CS2-Runden, Aim, Tilt, Clutches oder Matchmaking-Leid."
 
 [[emotes]]
-name = "COCKBedge"
-meaning = "Muedigkeit oder Ruhebeduerfnis."
-usage = "bei sleepy, spaeter oder erschoepfter Stimmung"
+name = "CUM"
+meaning = "Derbes NSFW-Emote mit sexueller Anspielung."
+usage = "Für Bot-Ausgaben vermeiden; höchstens als zu moderierenden NSFW-Chat-Ausdruck erkennen."
 
 [[emotes]]
-name = "GUNA"
-meaning = "Gute Nacht oder Schlafenszeit."
-usage = "zur Verabschiedung spaet am Abend"
+name = "CURSED"
+meaning = "Verfluchter, unheimlicher Meme-Moment."
+usage = "Wenn etwas falsch, creepy oder unangenehm cursed wirkt."
 
 [[emotes]]
-name = "unzips"
-meaning = "Derber oder horny Meme-Humor."
-usage = "nur bei eindeutig scherzhaftem derbem Chat-Kontext"
-
-[[emotes]]
-name = "doubleCatRose"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "oleg"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn Training, Muskeln oder Chad-Energie passt"
-
-[[emotes]]
-name = "CatType"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "WHATAWEEK"
-meaning = "Was fuer eine Woche."
-usage = "bei anstrengender oder ereignisreicher Woche"
-
-[[emotes]]
-name = "MarkFelton"
-meaning = "Geschichts- oder Militaerdoku-Referenz."
-usage = "bei historischen, dokumentarischen oder WW2-nahen Themen"
-
-[[emotes]]
-name = "Haback"
-meaning = "Habeck-/Politik-Meme."
-usage = "bei Robert-Habeck- oder Politik-Kontext"
-
-[[emotes]]
-name = "DONDE"
-meaning = "Wo? auf Spanisch."
-usage = "wenn nach Ort oder Sache gefragt wird"
-
-[[emotes]]
-name = "makscookingskills"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "brainrot"
-meaning = "Brainrot; komplett Internet-vergifteter Unsinn."
-usage = "bei sehr absurdem Meme-Content"
-
-[[emotes]]
-name = "GIGHABECK"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "RobertThumbUp"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "BLUBBER"
-meaning = "Erkaeltung, Schniefen oder krankes Blubbern."
-usage = "wenn jemand krank, verschnupft oder verrotzt wirkt"
-
-[[emotes]]
-name = "hehe"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "IASKED"
-meaning = "Wer hat gefragt? / Ich habe gefragt."
-usage = "bei sarkastischem Reaktionshumor"
-
-[[emotes]]
-name = "NODFEST"
-meaning = "Massive Zustimmung."
-usage = "wenn sehr viele zustimmen"
-
-[[emotes]]
-name = "Gato"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "RealBenzer"
-meaning = "Benzer-Insider."
-usage = "wenn ein echter Benzer-Moment oder Name-Drop passt"
-
-[[emotes]]
-name = "Moodge"
-meaning = "Mood; relatable Stimmung."
-usage = "wenn etwas sehr nachvollziehbar ist"
-
-[[emotes]]
-name = "Lindnover"
-meaning = "Lindner-/Politik-Insider."
-usage = "bei FDP-, Lindner- oder liberalen Politik-Momenten"
-
-[[emotes]]
-name = "Businessge"
-meaning = "Geld, Business oder Handel."
-usage = "bei Money-, Business- oder Deal-Momenten"
-
-[[emotes]]
-name = "ExplainingHow"
-meaning = "Lange Erklaerung oder Essay."
-usage = "wenn jemand ausfuehrlich erklaert oder yappt"
-
-[[emotes]]
-name = "BuntenbachLike"
-meaning = "Buntenbach-Insider mit Like-Vibe."
-usage = "wenn ein Buntenbach-Running-Gag zustimmend passt"
-
-[[emotes]]
-name = "habeckO7"
-meaning = "Respekt, Gebet oder Salut."
-usage = "bei Dank, Abschied, Respekt oder hoffnungsvollen Momenten"
-
-[[emotes]]
-name = "Egeg"
-meaning = "Okayeg-artige Standardreaktion."
-usage = "bei neutralem Meme-Kommentar"
-
-[[emotes]]
-name = "HORSEN"
-meaning = "Pferde-/Forsen-Meme."
-usage = "bei albernen Horse-, Forsen- oder Stall-Momenten"
-
-[[emotes]]
-name = "JucktMichNicht"
-meaning = "Ist mir egal."
-usage = "wenn etwas ausdruecklich egal ist"
-
-[[emotes]]
-name = "peepoSick"
-meaning = "Kranker Peepo."
-usage = "wenn jemand sich schlecht, krank oder verschnupft fuehlt"
-
-[[emotes]]
-name = "Baseg"
-meaning = "Based; starke Zustimmung zu einer mutigen oder guten Aussage."
-usage = "bei klarer Zustimmung oder Respekt fuer eine Aussage"
-
-[[emotes]]
-name = "catVibe"
-meaning = "Vibe, entspannte Stimmung oder wohliger Moment."
-usage = "bei chilligen, ruhigen oder stimmigen Momenten"
-
-[[emotes]]
-name = "ewHOI"
-meaning = "Hearts-of-Iron- oder Mapgame-Reaktion."
-usage = "wenn Strategie, Karten oder HOI4 Thema sind"
-
-[[emotes]]
-name = "Whey"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "DonaldPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "COOKED"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "GOTEM"
-meaning = "Erwischt oder reingelegt; kleiner Gotcha-Moment."
-usage = "wenn jemand beim Troll, Fehler oder Trick erwischt wird"
-
-[[emotes]]
-name = "peepoAntifa"
-meaning = "Peepo-Antifa; niedlicher Protest-Moment."
-usage = "bei linken Politik- oder Protest-Bezuegen"
-
-[[emotes]]
-name = "AntistasiExperience"
-meaning = "Gaming- oder Spielmoment."
-usage = "bei Gameplay, Queue, Skill oder Game-Talk"
-
-[[emotes]]
-name = "peepoTinfoil"
-meaning = "Lachen oder Humor-Reaktion."
-usage = "bei lustigen oder absurden Momenten"
-
-[[emotes]]
-name = "LETHERCOOK"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "FTZNFRTZ"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "SNIPER"
-meaning = "Sniper."
-usage = "bei gezieltem Treffer oder Stream-Sniping-Kontext"
-
-[[emotes]]
-name = "yeeeeeeeeeeeeeeee"
-meaning = "Langgezogenes Yeah."
-usage = "bei Freude oder Zustimmung"
-
-[[emotes]]
-name = "plinkVibe"
-meaning = "Vibe, entspannte Stimmung oder wohliger Moment."
-usage = "bei chilligen, ruhigen oder stimmigen Momenten"
-
-[[emotes]]
-name = "kinkk"
-meaning = "Kink- oder zweideutiger Vorlieben-Witz."
-usage = "bei absurd zweideutigem oder degeneriertem Chat-Humor"
-
-[[emotes]]
-name = "Marx"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "nocap"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "ErmIDontThinkSo"
-meaning = "Ablehnung; eher nein oder das stimmt nicht."
-usage = "wenn man einer Aussage widerspricht"
-
-[[emotes]]
-name = "yeeeee"
-meaning = "Kurzes Yeah."
-usage = "bei Freude oder Zustimmung"
-
-[[emotes]]
-name = "HusoPepeDank"
-meaning = "Derber danker Pepe-Diss."
-usage = "bei hartem Meme-Spott oder sehr rauem Chat-Humor"
-
-[[emotes]]
-name = "ANTIFA"
-meaning = "Antifa- oder linkspolitischer Protest-Moment."
-usage = "bei linken Politik-, Protest- oder Anti-Faschismus-Bezuegen"
-
-[[emotes]]
-name = "Scared"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
-
-[[emotes]]
-name = "eww"
-meaning = "Ekel oder Ablehnung."
-usage = "wenn etwas widerlich oder unangenehm ist"
-
-[[emotes]]
-name = "peepoDJ"
-meaning = "Peepo-DJ; Musik und Party."
-usage = "wenn aufgelegt, gejammt oder gefeiert wird"
-
-[[emotes]]
-name = "BiggusDickus"
-meaning = "Derber oder horny Meme-Humor."
-usage = "nur bei eindeutig scherzhaftem derbem Chat-Kontext"
-
-[[emotes]]
-name = "nothingeverhappens"
-meaning = "Es passiert sowieso nichts."
-usage = "bei zynischem oder abgebruehtem Abwarten"
-
-[[emotes]]
-name = "Coffeegers"
-meaning = "Kaffee oder Koffein."
-usage = "wenn es um Kaffee, Wachwerden oder Koffeinbedarf geht"
-
-[[emotes]]
-name = "TEISCHENTE"
-meaning = "Teichenten- oder Duck-Meme."
-usage = "bei albernen Enten- oder Teich-Momenten"
-
-[[emotes]]
-name = "RacistModeEngaged"
-meaning = "Politik- oder Laender-Meme."
-usage = "wenn das konkrete politische Thema passt"
-
-[[emotes]]
-name = "AUSTRIAN"
-meaning = "Oesterreich-Referenz."
-usage = "wenn Oesterreich, oesterreichischer Akzent oder Austria-Memes passen"
-
-[[emotes]]
-name = "Ryanair"
-meaning = "Flugzeug- oder Aviation-Meme."
-usage = "wenn Flugzeuge, Jets oder Fliegen Thema sind"
-
-[[emotes]]
-name = "WAR"
-meaning = "Krieg/Kampf-Meme."
-usage = "bei Kampf-, Streit- oder War-Kontext"
-
-[[emotes]]
-name = "wideKok"
-meaning = "Breiter Kok-/Channel-Insider."
-usage = "bei ueberzogenen breiten Channel-Reaktionen"
-
-[[emotes]]
-name = "MadTyper"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "JDpwease"
-meaning = "Bettelnde Please-Reaktion mit JD-Vance-Insider."
-usage = "wenn jemand fleht, bittet oder puppy-eyes macht"
-
-[[emotes]]
-name = "guuh"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "okurwa"
-meaning = "Polnischer Ausruf der Ueberraschung."
-usage = "bei Schock oder Frust im Meme-Stil"
-
-[[emotes]]
-name = "Devi2"
-meaning = "Zweite Devi-Insider-Reaktion."
-usage = "wenn ein weiterer Devi-Moment oder Running Gag passt"
-
-[[emotes]]
-name = "Bitti"
-meaning = "Bitte/Bitte-Moment."
-usage = "bei Bitte oder Nachfrage"
-
-[[emotes]]
-name = "pastry"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
-
-[[emotes]]
-name = "DailyGettingPaidForShittingAppreciationPost"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "glorpCheer"
-meaning = "Glorp-Cheer; positives Anfeuern."
-usage = "wenn gejubelt, supported oder gehypt wird"
-
-[[emotes]]
-name = "dosehiii"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "azb"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "OlesWeeklyValorantMeltdownRant"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "WASHED"
-meaning = "Washed; nicht mehr in Form."
-usage = "bei scherzhaften Performance-Fails"
-
-[[emotes]]
-name = "REDFLAG"
-meaning = "Red Flag; Warnzeichen."
-usage = "wenn etwas offensichtlich problematisch wirkt"
-
-[[emotes]]
-name = "duckDisco"
-meaning = "Duck-Disco."
-usage = "bei Musik, Tanz oder Party"
-
-[[emotes]]
-name = "peepoEyeroll"
-meaning = "Augenrollen."
-usage = "bei Genervtheit oder Unglauben"
-
-[[emotes]]
-name = "zazaBinks"
-meaning = "Star-Wars-Meme."
-usage = "wenn Star Wars oder Sci-Fi-Kontext passt"
-
-[[emotes]]
-name = "SchizoYoda"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "waitingJAM"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "gurkenrichard"
-meaning = "Geld, Business oder Handel."
-usage = "bei Money-, Business- oder Deal-Momenten"
-
-[[emotes]]
-name = "P1"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "xddShrug"
-meaning = "Lachen oder Humor-Reaktion."
-usage = "bei lustigen oder absurden Momenten"
-
-[[emotes]]
-name = "tuh"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
-
-[[emotes]]
-name = "WHOLETHIMCOOK"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "oda"
-meaning = "Oda- oder One-Piece-Referenz."
-usage = "bei Autoren-, Story- oder One-Piece-Momenten"
-
-[[emotes]]
-name = "HULKW"
-meaning = "Formel-1- oder Motorsport-Meme."
-usage = "wenn F1, Fahrer oder Rennen Thema sind"
-
-[[emotes]]
-name = "averageSauerlaender"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "WennNilsMalWiederImChatDasWortMetaLesenMussZuEinerBubenGamingSession"
-meaning = "Essen, Kochen oder Snack-Moment."
-usage = "wenn Essen oder Kochen Thema ist"
-
-[[emotes]]
-name = "FeelsADHDMan"
-meaning = "ADHS-/Unruhe-Meme."
-usage = "bei Ablenkung oder Hyperfokus im Meme-Kontext"
-
-[[emotes]]
-name = "????"
-meaning = "Nachdenken oder Frage."
-usage = "bei Analyse, Unsicherheit oder Spekulation"
-
-[[emotes]]
-name = "ABOBA"
-meaning = "Aboba-Meme; absurde Reaktion."
-usage = "bei russisch/osteuropaeischem Meme-Humor"
-
-[[emotes]]
-name = "PERHAPS"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "ratgeRacer"
-meaning = "Ratten-Meme."
-usage = "bei rattenbezogenen oder hektischen Meme-Momenten"
-
-[[emotes]]
-name = "Breadge"
-meaning = "Brot- oder Food-Okayeg."
-usage = "bei Brot-, Essen- oder Bakery-Momenten"
-
-[[emotes]]
-name = "FeelsQueueMan"
-meaning = "Gaming- oder Spielmoment."
-usage = "bei Gameplay, Queue, Skill oder Game-Talk"
-
-[[emotes]]
-name = "MitNicoUndDirkZeltenAberInDerNachtStoßenDieGämseSteineVonDerSteilwand"
-meaning = "Wander-/Bergunfall-Insider mit absurdem Szenario."
-usage = "bei langen, spezifischen oder absurd dramatischen Berggeschichten"
-
-[[emotes]]
-name = "PausersHype"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "gadse"
-meaning = "Katze/Gadse."
-usage = "bei Katzenmomenten"
+name = "DaGoth"
+meaning = "Dagoth-Ur-/Elder-Scrolls-Insider in Goth-Schreibweise."
+usage = "Wenn eine dunkle, kultische oder Morrowind-artige Aura in den Chat kommt."
 
 [[emotes]]
 name = "DagothUr"
-meaning = "Morrowind-/Dagoth-Ur-Meme."
-usage = "bei dramatischem Boesewicht-, Kult- oder RPG-Vibe"
+meaning = "Dagoth-Ur-Meme aus The Elder Scrolls III: Morrowind."
+usage = "Für überdramatische Bösewichtreden, Kultvibes oder altmodische RPG-Referenzen."
 
 [[emotes]]
-name = "BADEMEISTER"
-meaning = "Bademeister."
-usage = "bei Schwimmen, Pool oder Aufsicht"
+name = "DailyGettingPaidForShittingAppreciationPost"
+meaning = "Täglicher bezahlter-Toilettenpausen-Insider."
+usage = "Wenn jemand während der Arbeit bezahlt prokrastiniert oder eine Toilettenpause feiert."
 
 [[emotes]]
-name = "Ratge"
-meaning = "Ratten-Meme."
-usage = "bei rattenbezogenen oder hektischen Meme-Momenten"
+name = "DAMN"
+meaning = "Starke 'Verdammt'-Reaktion."
+usage = "Bei Überraschung, Respekt, Schmerz oder krassen Momenten."
 
 [[emotes]]
-name = "RatgeNV"
-meaning = "Ratten-Meme."
-usage = "bei rattenbezogenen oder hektischen Meme-Momenten"
+name = "DankDrive"
+meaning = "Dank-Meme-Figur in Fahr-/Drive-Situation."
+usage = "Für Autofahrten, konzentriertes Fahren oder ironische „Drive“-Coolness."
 
 [[emotes]]
-name = "RatShake"
-meaning = "Ratten-Meme."
-usage = "bei rattenbezogenen oder hektischen Meme-Momenten"
+name = "DankG"
+meaning = "Dankes-/Dank-Meme oder danker Gesichtsausdruck."
+usage = "Für Meme-Humor, ironischen Dank oder absurde Qualität."
 
 [[emotes]]
-name = "buhRave"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
+name = "DANKHACKERMANS"
+meaning = "Hacker-Meme mit dankem Humor."
+usage = "Wenn jemand vermeintlich 200 IQ hackt oder technisch trickst."
 
 [[emotes]]
-name = "Pepege"
-meaning = "Pepege; goofy Pepe-Reaktion."
-usage = "bei alberner oder dummer Situation"
+name = "DANKIES"
+meaning = "Dankes-/Meme-Dank-Reaktion."
+usage = "Wenn etwas dank, absurd oder freundlich quittiert wird."
 
 [[emotes]]
-name = "peepoEggs"
-meaning = "Eier- oder Fruehstuecks-Peepo."
-usage = "bei Food-, Eier- oder Morgenmomenten"
+name = "DankL"
+meaning = "Dankes-/L-Variante."
+usage = "Wenn ein danker Moment gleichzeitig als Verlust wirkt."
 
 [[emotes]]
-name = "$f1"
-meaning = "Formel-1-Kommando/Shortcut."
-usage = "bei F1-Kontext"
+name = "DankLook"
+meaning = "Dank-Figur schaut seitlich oder prüfend."
+usage = "Wenn jemand misstrauisch beobachtet, einen Take abcheckt oder trocken starrt."
 
 [[emotes]]
-name = "Wowers"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
-
-[[emotes]]
-name = "FloppaBusiness"
-meaning = "Floppa-Meme."
-usage = "wenn ein Floppa- oder Chad-Floppa-Moment passt"
-
-[[emotes]]
-name = "DeusVult"
-meaning = "Gebet, heiliger oder religioeser Meme-Kontext."
-usage = "bei ueberdramatisch heiligen Momenten"
-
-[[emotes]]
-name = "fuh"
-meaning = "Fuh; kurzer verwirrter Ausruf."
-usage = "bei Ratlosigkeit"
-
-[[emotes]]
-name = "MAN"
-meaning = "Man/Mann-Ausruf."
-usage = "bei genervtem oder erstauntem Ausruf"
-
-[[emotes]]
-name = "dummarsch"
-meaning = "Derber Dummarsch-Insult."
-usage = "bei sehr derbem, scherzhaftem Chat-Humor"
-
-[[emotes]]
-name = "ehehe"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "WannSommer"
-meaning = "Ungeduld auf Sommer oder warme Tage."
-usage = "wenn Sommer vermisst oder Hitze herbeigesehnt wird"
-
-[[emotes]]
-name = "plinkge"
-meaning = "Plink-/Gitarren-Okayeg."
-usage = "bei sanftem Sound, Musik oder kleinen Pling-Momenten"
-
-[[emotes]]
-name = "DIESOFR2D2"
-meaning = "Cringe oder Fremdschaemen."
-usage = "bei unangenehmen oder peinlichen Momenten"
-
-[[emotes]]
-name = "VS"
-meaning = "Sus oder Among-Us-Reaktion."
-usage = "bei verdaechtigen oder zweideutigen Momenten"
-
-[[emotes]]
-name = "AlienWave"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "WannWinter"
-meaning = "Ungeduld auf Winter oder kalte Tage."
-usage = "wenn Winter, Kaelte oder Schnee vermisst wird"
-
-[[emotes]]
-name = "japierdole"
-meaning = "Polnischer Frust-/Schockausruf."
-usage = "bei starkem Schock oder Frust"
-
-[[emotes]]
-name = "YesYes"
-meaning = "Zustimmung; das stimmt oder klingt richtig."
-usage = "wenn man einer Aussage zustimmt oder sie bestaetigt"
-
-[[emotes]]
-name = "WannEUV"
-meaning = "Wann EUV? Insiderfrage."
-usage = "wenn nach EUV oder lang erwartetem Thema gefragt wird"
-
-[[emotes]]
-name = "Feels1444Man"
-meaning = "Europa-Universalis-4-/1444-Start-Meme."
-usage = "bei Geschichts-, Mapgame- oder EU4-Nostalgie"
-
-[[emotes]]
-name = "Susge"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "CantinaJAM"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
+name = "DankSpin"
+meaning = "Drehendes Dank-Meme."
+usage = "Bei Musik, Rotation oder hypnotischem Meme-Spam."
 
 [[emotes]]
 name = "DankStick"
-meaning = "Danker Twitch-Meme-Vibe."
-usage = "bei trockenem, ironischem oder dankem Humor"
+meaning = "Dank-Figur mit Stock/Stab oder steifer Haltung."
+usage = "Für simple, trockene Reaktionen oder wenn jemand bildlich mit einem Stock herumsteht."
 
 [[emotes]]
-name = "BLANKIES"
-meaning = "Decken- oder Comfort-Moment."
-usage = "wenn Einkuscheln, Schutz oder cozy Stimmung passt"
+name = "dankWave"
+meaning = "Dank-Figur winkt."
+usage = "Als Begrüßung, Abschied oder kleiner freundlicher Chat-Gruß."
 
 [[emotes]]
-name = "FloppaRave"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
+name = "danse"
+meaning = "Tanz-Emote in französisch/absurder Schreibweise."
+usage = "Wenn Musik läuft oder der Chat subtil in eine Tanzstimmung kippt."
 
 [[emotes]]
-name = "IntothemotherlandtheGermanarmymarchComradesstandsidebysidetostoptheNazichargePanzersonRussiansoil"
-meaning = "Sabaton-/Kriegslied-Referenz."
-usage = "bei dramatischem Mitsingen oder History-Metal-Momenten"
+name = "danseparty"
+meaning = "Party-Variante von danse."
+usage = "Wenn aus einem einzelnen Tanzmoment ein kompletter Chat-Rave wird."
 
 [[emotes]]
-name = "HORNY"
-meaning = "Horny-Meme."
-usage = "bei klarer horny Meme-Stimmung"
+name = "darthnotL"
+meaning = "Darth-Vader-/Star-Wars-Variante von „not L“ bzw. kein Verlust."
+usage = "Wenn man einem L widerspricht oder etwas nicht als Niederlage gelten lässt."
 
 [[emotes]]
-name = "CatHug"
-meaning = "Umarmung, Trost oder Zuneigung."
-usage = "bei freundlichen, warmen oder troestenden Momenten"
+name = "DAYZ"
+meaning = "DayZ-Spielbezug."
+usage = "Für Survival, Loot, Verrat, Zombies oder DayZ-Streamphasen."
 
 [[emotes]]
-name = "FloppaPong"
-meaning = "Floppa-Meme."
-usage = "wenn ein Floppa- oder Chad-Floppa-Moment passt"
+name = "Deadge"
+meaning = "Tot-/Dead-Meme."
+usage = "Wenn etwas stirbt, scheitert oder der Chat 'dead' ist."
 
 [[emotes]]
-name = "FLOPPACHAD"
-meaning = "Floppa-Meme."
-usage = "wenn ein Floppa- oder Chad-Floppa-Moment passt"
+name = "DEADLOCK"
+meaning = "Tod-, Explosion- oder Eskalationsmeme."
+usage = "Wenn ein Moment scheitert, stirbt, explodiert oder mit 'DEADLOCK' überdramatisiert wird."
 
 [[emotes]]
-name = "BINGCHILLING"
-meaning = "Bing Chilling/China-Meme."
-usage = "bei China- oder Eiscreme-Meme-Kontext"
+name = "DEATH"
+meaning = "Tod als starke Reaktion."
+usage = "Bei Ingame-Toden, Crashes oder dramatischem Scheitern."
 
 [[emotes]]
-name = "AkiraDespair"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
+name = "Dedge"
+meaning = "Kleine Deadge-Variante."
+usage = "Für trockenes, weniger dramatisches 'tot'-Gefühl."
 
 [[emotes]]
-name = "catRAVE"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
+name = "DennisPlaybackSpeed"
+meaning = "Dennis-Wiedergabegeschwindigkeit-Insider."
+usage = "Wenn jemand zu schnell redet, Videospeed auffällt oder Dennis als Speed-Referenz passt."
 
 [[emotes]]
-name = "startbeingNice"
-meaning = "Sei nett."
-usage = "wenn jemand freundlich sein soll"
+name = "DeusVult"
+meaning = "Kreuzzug-/Mittelalter-Meme."
+usage = "Für Crusader-, Ritter- oder übertriebene religiöse Kampfansagen."
 
 [[emotes]]
-name = "forsenCD"
-meaning = "ForsenCD; cheating/Doc-Meme."
-usage = "bei Cheat- oder ForsenCD-Kontext"
+name = "Deutschge"
+meaning = "Deutschland-/Deutsch-Meme-Gesicht."
+usage = "Bei deutscher Bürokratie, Sprache, Ordnung oder Nationen-Insidern."
 
 [[emotes]]
-name = "nymnCC"
-meaning = "NymnCC-Copyright/Meme."
-usage = "bei Nymn- oder CC-Kontext"
+name = "DEUTSCHLAND"
+meaning = "Deutschland-Bezug."
+usage = "Für patriotische, sportliche oder ironisch deutsche Momente."
 
 [[emotes]]
-name = "MEN"
-meaning = "Men-Meme."
-usage = "bei maennlicher, gym- oder gachiartiger Stimmung"
+name = "DEVI"
+meaning = "Devi-Personen- oder Channelinsider."
+usage = "Wenn der Chat auf Devi verweist oder eine Szene nach Devi-Energie aussieht."
 
 [[emotes]]
-name = "amongEg"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
+name = "Devi11SekundenNachdemErAusDemAutoSteigtAufSizilien"
+meaning = "Sehr spezifischer Devi-auf-Sizilien-Insider."
+usage = "Wenn ein Moment nach sofortiger Eskalation, Urlaubschaos oder maximaler Überforderung riecht."
 
 [[emotes]]
-name = "STONING"
-meaning = "Stoning; Steinigen als derbes Meme."
-usage = "bei sehr derbem Straf-/Mob-Humor"
+name = "Devi2"
+meaning = "Zweite Devi-Variante."
+usage = "Wenn die normale Devi-Reaktion nicht präzise genug ist und eine alternative Stimmung gebraucht wird."
 
 [[emotes]]
-name = "tintinHeadbang"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
+name = "devi3"
+meaning = "Dritte Devi-Variante mit noch stärkerem Insidercharakter."
+usage = "Für sehr konkrete Devi-Momente, die der Chat ohne weitere Erklärung erkennt."
 
 [[emotes]]
-name = "latinoHug"
-meaning = "Umarmung, Trost oder Zuneigung."
-usage = "bei freundlichen, warmen oder troestenden Momenten"
+name = "deviW"
+meaning = "Devi-Win- oder Devi-W-Variante."
+usage = "Wenn Devi gewinnt, etwas überraschend gut läuft oder ein Devi-Moment gefeiert wird."
 
 [[emotes]]
-name = ":d"
-meaning = "Kleines Grinsen."
-usage = "bei freundlichem, albernem Lachen"
+name = "DiedOfHeat"
+meaning = "An Hitze gestorben."
+usage = "Wenn es zu warm ist oder eine Situation metaphorisch überhitzt."
 
 [[emotes]]
-name = "GIRLDETECTED"
-meaning = "Girl detected."
-usage = "bei Girl-/Gender-Meme im Chat"
+name = "DIEGRÜNEN"
+meaning = "Die-Grünen-/Partei-Meme."
+usage = "Für deutsche Politik, grüne Themen, Ampel-Witze oder ironische Parteireferenzen."
 
 [[emotes]]
-name = "PepegaDriving"
-meaning = "Pepega faehrt Auto; schlechtes Fahren."
-usage = "bei Verkehrschaos oder dummen Fahrfehlern"
+name = "DIESOFCRINGE"
+meaning = "Stirbt an Fremdscham."
+usage = "Wenn etwas extrem peinlich oder unangenehm ist."
 
 [[emotes]]
-name = "peepoPonderingEternity"
-meaning = "Nachdenken oder Frage."
-usage = "bei Analyse, Unsicherheit oder Spekulation"
+name = "DIESOFPAIN"
+meaning = "Stirbt vor Schmerz."
+usage = "Bei schmerzhaften Plays, schlimmen Takes oder hartem Pech."
 
 [[emotes]]
-name = "koklick"
-meaning = "Kok-/Lick-Insider."
-usage = "bei frechen, spielerischen Channel-Momenten"
+name = "DIESOFR2D2"
+meaning = "Stirbt wie/wegen R2D2-Referenz."
+usage = "Für Star-Wars-/Roboterchaos oder piepsende Meme-Momente."
 
 [[emotes]]
-name = "sipp"
-meaning = "Sip; trinken oder beobachten."
-usage = "bei Tee/Kaffee-Sip oder abwartendem Zuschauen"
+name = "DinkDonk"
+meaning = "Ding-Dong-/Aufmerksamkeits-Meme."
+usage = "Wenn etwas angekündigt wird oder der Chat geweckt werden soll."
 
 [[emotes]]
-name = "majj"
-meaning = "Majj; freundlicher lokaler Meme-Vibe."
-usage = "bei positivem lokalen Insider-Kontext"
+name = "DisneyDance"
+meaning = "Tanzendes Disney-/Cartoon-Meme."
+usage = "Für fröhliche Musik, Nostalgie oder albernes Tanzen."
 
 [[emotes]]
-name = "bejjtogeth"
-meaning = "Bejj together; zusammen sein."
-usage = "bei Gemeinschaft oder Together-Vibe"
+name = "dlorp"
+meaning = "Hellgrünes alienartiges Wesen mit zwei Fühlern und leerem, verwirrtem Blick."
+usage = "Für seltsame, außerirdische oder schwer einzuordnende Momente, in denen der Chat nur glotzt."
 
 [[emotes]]
-name = "bejj"
-meaning = "Bejj; freundlicher lokaler Meme-Vibe."
-usage = "bei positivem lokalen Insider-Kontext"
+name = "dobro"
+meaning = "Slawisch angehauchte Zustimmung oder Begrüßung."
+usage = "Wenn etwas 'gut so', osteuropäisch gefärbt oder trocken bestätigend kommentiert wird."
 
 [[emotes]]
-name = "peepoCheer"
-meaning = "Peepo feuert an."
-usage = "bei Support oder Anfeuern"
+name = "dogBOOP"
+meaning = "Hund wird geboopt/angestupst."
+usage = "Für süße Hunde-Momente oder spielerisches Anstupsen."
 
 [[emotes]]
-name = "peepoGrüne"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
+name = "Dogege"
+meaning = "Doge-/ge-Meme."
+usage = "Für Hundereaktionen, Shiba-Humor oder leichte Meme-Zustimmung."
 
 [[emotes]]
-name = "lookDown"
-meaning = "Nach unten schauen."
-usage = "wenn etwas unten passiert oder jemand herabschaut"
+name = "Dogey"
+meaning = "Doge-Variante."
+usage = "Wenn Doge-typischer Humor oder Hundevibes passen."
 
 [[emotes]]
-name = "60TonnenEinigkeitRechtUndFreiheit"
-meaning = "Deutsches Panzer-/Patriotismus-Meme."
-usage = "bei deutschem Militär- oder Patriotismus-Kontext"
+name = "DOGGING"
+meaning = "Hund-/Tierclip mit edgy Doppelsinn im Namen."
+usage = "Für Hunde- oder Weird-Clip-Momente; wegen des Namens nur in passendem Meme-Kontext verwenden."
+
+[[emotes]]
+name = "doggoArrive"
+meaning = "Hund kommt an."
+usage = "Als freundliche Begrüßung oder Doggo-Entrance."
+
+[[emotes]]
+name = "DogHello"
+meaning = "Hallo-Hund."
+usage = "Für Begrüßungen mit besonders freundlichem Ton."
+
+[[emotes]]
+name = "dogkok"
+meaning = "Hundebild als Kok-/Koks-Insider; wirkt bewusst absurd und derb."
+usage = "Bei lokalen Kok-/Substanzwitzen oder extrem seltsamen Hundemomenten; vorsichtig verwenden."
+
+[[emotes]]
+name = "DogLookingWickedAndCool"
+meaning = "Hund sieht „wicked“ und cool aus."
+usage = "Für lässige Hundebilder, coole Tiermomente oder wenn jemand absurd souverän wirkt."
+
+[[emotes]]
+name = "dogMeditation"
+meaning = "Meditierender Hund."
+usage = "Wenn Ruhe, Fokus oder innerer Frieden gebraucht wird."
+
+[[emotes]]
+name = "dogTrip"
+meaning = "Reisender/unterwegs befindlicher Hund."
+usage = "Bei Roadtrip-, Reise- oder Wanderstimmung."
+
+[[emotes]]
+name = "DonaldPls"
+meaning = "Donald-/Tanz-/Bitte-Meme."
+usage = "Für Musik oder wenn jemand um etwas bettelt."
+
+[[emotes]]
+name = "DONDE"
+meaning = "Spanisch für 'wo'."
+usage = "Wenn etwas gesucht wird oder der Chat fragt, wo etwas ist."
+
+[[emotes]]
+name = "DonkHunter"
+meaning = "Donk-/Jagd-Meme."
+usage = "Wenn jemand Donks sucht, jagt oder gezielt einen Meme-Typ verfolgt."
+
+[[emotes]]
+name = "donkRun"
+meaning = "Rennender Donk."
+usage = "Wenn jemand losläuft, flieht oder schnell eskaliert."
+
+[[emotes]]
+name = "donkWalk"
+meaning = "Gehender Donk."
+usage = "Für gemächliche Bewegung oder Donk-Entrance."
+
+[[emotes]]
+name = "donowall"
+meaning = "Donation-Wall-/Ignoriertwerden-Meme."
+usage = "Wenn eine Nachricht übersehen wird oder in der Wand verschwindet."
+
+[[emotes]]
+name = "doog"
+meaning = "Verdrehte Dog-/Hund-Variante."
+usage = "Für dumme Hundemomente, Tippfehlerhumor oder Doggo-Energie mit extra Derp."
+
+[[emotes]]
+name = "doot"
+meaning = "Trompeten-/Skelett-Doot-Meme."
+usage = "Für musikalische Stinger, Oktober-/Spooky-Vibes oder kleine Fanfares."
+
+[[emotes]]
+name = "DortmundRope"
+meaning = "Dortmund-Insider mit problematisch dunkler Namensassoziation."
+usage = "Nicht als normale Reaktion ausgeben; nur als riskanten Fußball-/Insider-Ausdruck erkennen."
+
+[[emotes]]
+name = "dosehiii"
+meaning = "Dose-/Dosis-sagt-Hallo-Insider."
+usage = "Wenn jemand sehr süß, klein oder auffällig freundlich in den Chat hineinwinkt."
+
+[[emotes]]
+name = "doubleCatRose"
+meaning = "Zwei Katzen mit Rose bzw. romantischer Geste."
+usage = "Für Zuneigung, Duo-Momente, romantische Albernheit oder übertriebene Nettigkeit."
+
+[[emotes]]
+name = "DougDimmaDab"
+meaning = "Figur im Doug-Dimmadome-/Dab-Stil."
+usage = "Wenn jemand demonstrativ dabt, einen alten Meme-Move bringt oder cartoonhaft prahlt."
+
+[[emotes]]
+name = "duckass"
+meaning = "Enten-/absurder Körperteil-Insider."
+usage = "Für sehr alberne Entenwitze oder bewusst dumme Meme-Spams."
+
+[[emotes]]
+name = "duckDisco"
+meaning = "Disco-Ente."
+usage = "Wenn getanzt, gefeiert oder funky Musik läuft."
+
+[[emotes]]
+name = "Dudge"
+meaning = "Schlichter grüner Froschkopf mit blauem Oberteil und neutralem Blick."
+usage = "Für ruhige, leicht ratlose oder emotionsarme Reaktionen ohne große Aussage."
+
+[[emotes]]
+name = "dummarsch"
+meaning = "Vulgäre Beleidigungs-/Dummheitsreaktion."
+usage = "Wenn jemand absichtlich grob einen extrem dummen Move kommentieren will."
+
+[[emotes]]
+name = "EARTHQUAKE"
+meaning = "Erdbeben-/Wackel-Meme."
+usage = "Wenn der Stream, das Spiel oder ein Emote stark wackelt."
+
+[[emotes]]
+name = "eeeh"
+meaning = "Kurzes „eeeh“-Zögern mit Pepe/Ge-Figur."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser eeeh-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "eepy"
+meaning = "Sleepy/eepy-Meme."
+usage = "Wenn jemand müde, schläfrig oder weich eingekuschelt ist."
+
+[[emotes]]
+name = "EgBusiness"
+meaning = "Business-Egg-/Eg-Meme."
+usage = "Wenn ein Eg/egg seriös Geschäfte macht oder ein Deal läuft."
+
+[[emotes]]
+name = "EgCheg"
+meaning = "Eg-/Cheg-Insider."
+usage = "Für kleine Eg-Momente, oft ohne harte Bedeutung."
+
+[[emotes]]
+name = "egDealer"
+meaning = "Egg-/Dealer-Meme."
+usage = "Wenn jemand etwas verkauft, anbietet oder verdächtig handelt."
+
+[[emotes]]
+name = "Egeg"
+meaning = "Egg/Eg-Meme-Gesicht."
+usage = "Für absurde Ei-Insider oder generische Eg-Reaktionen."
+
+[[emotes]]
+name = "EgHug"
+meaning = "Egg/Eg-Umarmung."
+usage = "Für freundliche, tröstende oder ironisch süße Momente."
+
+[[emotes]]
+name = "Egium"
+meaning = "Eg-Meme als Substanz/Element."
+usage = "Wenn der Chat komplett in Eg-Logik abdriftet."
+
+[[emotes]]
+name = "EGIUM"
+meaning = "Großgeschriebene Egium-Variante."
+usage = "Für noch stärkeren Egium-Spam oder überzeichnete Eg-Energie."
+
+[[emotes]]
+name = "egsqzL"
+meaning = "Eg-/Pepe-Variante mit L- oder Quetsch-/Squish-Anmutung."
+usage = "Für kleine Niederlagen, gequetschte Reaktionen oder wenn ein Eg-Moment schiefgeht."
+
+[[emotes]]
+name = "ehehe"
+meaning = "Kichernde oder verschmitzte Tierreaktion."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser ehehe-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "eierschaukeln"
+meaning = "Derbes Nichtstun-/Faulenzer-Meme."
+usage = "Wenn jemand komplett unproduktiv herumhängt und das auch noch offensichtlich genießt."
+
+[[emotes]]
+name = "ELCLASSICO"
+meaning = "Der Klassiker/El Clásico."
+usage = "Wenn ein altbekannter Konflikt, Matchup oder Running Gag wiederkommt."
+
+[[emotes]]
+name = "Elefantastisch"
+meaning = "Elefanten-Wortspiel für positives Staunen."
+usage = "Wenn etwas überraschend gut, groß oder charmant-elefantös wirkt."
+
+[[emotes]]
+name = "Elglorpo"
+meaning = "Spanisch klingende Glorp-Alien-Variante."
+usage = "Wenn ein Glorp-/Alienmoment mit extra melodramatischem Namen markiert wird."
+
+[[emotes]]
+name = "ElNoSabe"
+meaning = "Spanisch: Er weiß es nicht."
+usage = "Wenn jemand ahnungslos ist oder eine offensichtliche Info fehlt."
+
+[[emotes]]
+name = "Erm"
+meaning = "Unsicheres Räusper-/Nerd-Intro."
+usage = "Wenn man korrigiert, zweifelt oder awkward einhakt."
+
+[[emotes]]
+name = "ErmActually"
+meaning = "'Ähm, eigentlich...' Nerd-Korrektur."
+usage = "Wenn jemand pedantisch oder technisch korrekt widerspricht."
+
+[[emotes]]
+name = "ErmIDontThinkSo"
+meaning = "Höflich-nerdiger Widerspruch."
+usage = "Wenn man sehr trocken sagt, dass etwas nicht stimmt."
+
+[[emotes]]
+name = "essaying"
+meaning = "Jemand schreibt einen langen Aufsatz."
+usage = "Wenn eine Antwort viel zu lang, analytisch oder textwandartig wird."
+
+[[emotes]]
+name = "Evilge"
+meaning = "Böses/verschmitztes Meme-Gesicht."
+usage = "Wenn jemand schadenfroh plant oder eine dunkle Idee hat."
+
+[[emotes]]
+name = "ewHOI"
+meaning = "Ekelreaktion auf Hearts of Iron."
+usage = "Wenn HOI4 oder Grand-Strategy-Leid thematisiert wird."
+
+[[emotes]]
+name = "ewLeague"
+meaning = "Ekelreaktion auf League of Legends."
+usage = "Wenn League erwähnt wird oder jemand wieder in die Queue geht."
+
+[[emotes]]
+name = "eww"
+meaning = "Ekel- oder Ablehnungsreaktion."
+usage = "Wenn etwas unangenehm, cringe oder schlicht widerlich ist."
+
+[[emotes]]
+name = "ExplainingHow"
+meaning = "Erklärt-wie-Meme."
+usage = "Wenn jemand eine Sache ausführlich und etwas belehrend erklärt."
+
+[[emotes]]
+name = "Exquisite"
+meaning = "Vornehm-zustimmendes Meme."
+usage = "Wenn etwas geschmackvoll, edel oder ironisch kultiviert wirkt."
+
+[[emotes]]
+name = "EZeg"
+meaning = "Easy/EZ als Eg-Meme."
+usage = "Wenn etwas leicht war oder ironisch als leicht verkauft wird."
 
 [[emotes]]
 name = "ezStrat"
 meaning = "Einfache Strategie."
-usage = "wenn ein Plan simpel oder offensichtlich ist"
+usage = "Wenn ein Plan simpel, effektiv oder lächerlich offensichtlich ist."
 
 [[emotes]]
-name = "GermanDank"
-meaning = "Deutschland- oder Ortsbezug."
-usage = "wenn der konkrete Ort oder Deutschland Thema ist"
+name = "EZWink"
+meaning = "Easy plus Zwinkern."
+usage = "Wenn ein Erfolg locker, frech oder ironisch selbstsicher wirkt."
 
 [[emotes]]
-name = "mlem"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "FeelsNukeMan"
-meaning = "Explosion, Tod oder kompletter Fail als Meme."
-usage = "bei ueberzeichnetem Chaos oder Ende"
-
-[[emotes]]
-name = "CLEAN"
-meaning = "Sauber; clean gespielt oder geloest."
-usage = "bei sauberer Ausfuehrung oder elegantem Move"
-
-[[emotes]]
-name = "catLeave"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "AlonsoSigma"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "Adiosge"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "AlonsoPls"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "AlonsoHola"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "ASSEMBLE"
-meaning = "Versammeln; alle zusammenkommen."
-usage = "wenn Chat, Gruppe oder Team zusammenkommen soll"
-
-[[emotes]]
-name = "veryCat"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "HECOOKED"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "BillySmoke"
-meaning = "Rauch-/Smoke-Meme."
-usage = "bei Smoke- oder Kiffer-Meme-Kontext"
-
-[[emotes]]
-name = "SpeziDank"
-meaning = "Spezi-Getraenk oder Spezi-Moment."
-usage = "wenn es um Spezi oder Getraenke geht"
-
-[[emotes]]
-name = "Fighter2"
-meaning = "Fighter-/Kampfjet-Kontext."
-usage = "bei Flugzeug oder Kampfjet-Momenten"
-
-[[emotes]]
-name = "SOCIALCREDITING"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "RightThere"
-meaning = "Da ist es; genau dort."
-usage = "wenn auf etwas gezeigt oder hingewiesen wird"
-
-[[emotes]]
-name = "MENNO"
-meaning = "Menno; kindlich genervt."
-usage = "bei kleiner Enttaeuschung"
-
-[[emotes]]
-name = "Madwokege"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
-
-[[emotes]]
-name = "hornerC"
-meaning = "Christian-Horner-/Formel-1-Meme."
-usage = "bei F1-Teamchef-Drama oder Red-Bull-Insidern"
-
-[[emotes]]
-name = "peepoPlant"
-meaning = "Peepo mit Pflanze; ruhiger Naturmoment."
-usage = "bei Garten, Wachstum oder cozy Plant-Vibe"
-
-[[emotes]]
-name = "TrumpetTime"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "sajjbutluvv"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "crunch"
-meaning = "Crunch; knusprig/zerquetscht."
-usage = "bei Crunch-, Snack- oder Druckmomenten"
-
-[[emotes]]
-name = "leavee"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "SERVUS"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "KKool"
-meaning = "Laessige Coolness mit KKona/K-Insider-Vibe."
-usage = "bei lockerer Zustimmung oder ironischem Coolsein"
-
-[[emotes]]
-name = "NotALOO"
-meaning = "Nicht ALOO."
-usage = "bei Aloo-Verneinung oder Gegenreaktion"
-
-[[emotes]]
-name = "PartyPls"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "CrazyIWasCrazyOnceTheyPutMeInARoomARubberroomARubberroomFilledWithRatsRatsMakeMeGoCrazy"
-meaning = "Lachen oder Humor-Reaktion."
-usage = "bei lustigen oder absurden Momenten"
-
-[[emotes]]
-name = "peepoMcLaren"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "glebeGlebe"
-meaning = "Glebe-Insider mit wiederholtem Meme-Ausruf."
-usage = "bei komischer Wiederholung oder Insider-Zustimmung"
-
-[[emotes]]
-name = "PeepoHappyLeave"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "peepoSpace"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "FCKAFD"
-meaning = "Anti-AfD-Politikstatement."
-usage = "bei klarer Ablehnung rechter Politik"
-
-[[emotes]]
-name = "peepoGoodNight"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "flowerr"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "FUKUYAMA"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "KKrikey"
-meaning = "Krikey-/australischer Ausruf."
-usage = "bei ueberraschtem australischem Meme"
-
-[[emotes]]
-name = "ArnoldShake"
-meaning = "Arnold-, Shake- oder Gym-Moment."
-usage = "bei Fitness, Muskeln oder Bodybuilding"
-
-[[emotes]]
-name = "HELLOWO"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "MyExistenceIsNothingButAGrainOfSandComparedToTheEntireScaleOfTheUniverse"
-meaning = "Musik, Tanz oder Vibe."
-usage = "wenn Musik laeuft oder die Stimmung groovt"
-
-[[emotes]]
-name = "peepoCCP"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man Hallo sagt"
-
-[[emotes]]
-name = "Geroellge"
-meaning = "Geroell- oder Steinlawinen-Okayeg."
-usage = "bei Berg-, Stein- oder Chaosmomenten"
-
-[[emotes]]
-name = "GNOCCI"
-meaning = "Alberner Donkey-/Gnocchi-Moment."
-usage = "bei goofy Food-, Donkey- oder Tierwitzen"
-
-[[emotes]]
-name = "popCat"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "TESTSIEGER"
-meaning = "Testsieger; etwas gewinnt den Vergleich."
-usage = "wenn etwas ironisch oder ernst als beste Option dargestellt wird"
-
-[[emotes]]
-name = "NessieParty"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
-
-[[emotes]]
-name = "DEATH"
-meaning = "Tod/Ende als Meme."
-usage = "bei kompletter Niederlage oder Deadge-Moment"
-
-[[emotes]]
-name = "RollCat"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "DougDimmaDab"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "howody"
-meaning = "Begruessung oder freundliches Winken."
-usage = "wenn jemand dazukommt oder man freundlich hallo sagt"
-
-[[emotes]]
-name = "plaisieren"
-meaning = "Bewegung, Ankommen oder Fahren."
-usage = "bei Lauf-, Fahr- oder Bewegungsmomenten"
-
-[[emotes]]
-name = "TriDance"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "HonestWork"
-meaning = "Arbeit oder Arbeitszeit-Meme."
-usage = "wenn Job, Schicht oder Arbeiten Thema ist"
-
-[[emotes]]
-name = "ewLeague"
-meaning = "Abschied oder Weggehen."
-usage = "wenn jemand geht oder gute Nacht sagt"
-
-[[emotes]]
-name = "Nessie"
-meaning = "Nessie-Meme."
-usage = "bei Nessie oder Monster-Momenten"
-
-[[emotes]]
-name = "duckass"
-meaning = "Duckass; Enten-/Albernheitsmeme."
-usage = "bei albernem Entenhumor"
-
-[[emotes]]
-name = "peepoDyingFromToxicFumesReleasedFromASpraypaintCanBecauseHeWasNotWearingAMask"
-meaning = "Traurigkeit, Pain oder Enttaeuschung."
-usage = "bei Pech, Rueckschlaegen oder trauriger Stimmung"
-
-[[emotes]]
-name = "dogMeditation"
-meaning = "Hund/Doge-Moment."
-usage = "wenn ein Hund, Doge oder niedliche Hundereaktion passt"
-
-[[emotes]]
-name = "AREYOUAGIRL"
-meaning = "Awkward Chat-Frage oder cringe Bait."
-usage = "wenn jemand unangenehm neugierig oder weird fragt"
-
-[[emotes]]
-name = "DAMN"
-meaning = "Verdammt; starke Reaktion."
-usage = "bei Ueberraschung, Respekt oder Schock"
-
-[[emotes]]
-name = "YeahBuddy"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "xqcShare"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "SALAMIhand"
-meaning = "Essen oder Snack-Moment."
-usage = "wenn es um Essen, Hunger oder Snacks geht"
-
-[[emotes]]
-name = "SoyPoint2"
-meaning = "Hype oder positive Ueberraschung."
-usage = "bei Erfolg, Vorfreude oder starken Momenten"
-
-[[emotes]]
-name = "miamor"
-meaning = "Liebevoller Mi-amor-Moment."
-usage = "bei Zuneigung, Flirt-Vibe oder herzlicher Ansprache"
-
-[[emotes]]
-name = "PokiShare"
-meaning = "Liebe, Zuneigung oder herzlicher Support."
-usage = "bei lieben, positiven oder supportiven Reaktionen"
-
-[[emotes]]
-name = "shower"
-meaning = "Duschen, Hygiene oder Touch-grass-nahe Aufforderung."
-usage = "wenn jemand scherzhaft duschen oder sich frisch machen soll"
-
-[[emotes]]
-name = "Clowneg"
-meaning = "Clown-Okayeg; laecherliches Verhalten."
-usage = "wenn jemand clownesk oder peinlich handelt"
-
-[[emotes]]
-name = "MarshmellowTime"
-meaning = "Essen, Kochen oder Snack-Moment."
-usage = "wenn Essen oder Kochen Thema ist"
-
-[[emotes]]
-name = "eierschaukeln"
-meaning = "Faulenzen oder nichts Produktives tun."
-usage = "wenn jemand chillt, prokrastiniert oder Arbeit vermeidet"
-
-[[emotes]]
-name = "peepoFeet"
-meaning = "Derber oder horny Meme-Humor."
-usage = "nur bei eindeutig scherzhaftem derbem Chat-Kontext"
-
-[[emotes]]
-name = "Noot"
-meaning = "Noot noot / Pinguin-Meme."
-usage = "bei Pinguin- oder Noot-Momenten"
-
-[[emotes]]
-name = "CURSED"
-meaning = "Cursed; verflucht oder unangenehm seltsam."
-usage = "bei sehr komischen, cursed Bildern oder Aussagen"
-
-[[emotes]]
-name = "SoSnowy"
-meaning = "Gebet, heiliger oder religioeser Meme-Kontext."
-usage = "bei ueberdramatisch heiligen Momenten"
-
-[[emotes]]
-name = "Toothless"
-meaning = "Toothless-Drachenmeme."
-usage = "bei Drachen-, Tanz- oder Toothless-Kontext"
-
-[[emotes]]
-name = "UHM"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "spezifisch"
-meaning = "Spezifisch; sehr genau oder passend."
-usage = "wenn etwas auffaellig spezifisch ist"
-
-[[emotes]]
-name = "Dudge"
-meaning = "Dudge-/Dudege-artige trockene Skepsis."
-usage = "wenn man urteilt, zweifelt oder trocken reagiert"
-
-[[emotes]]
-name = "SoyPoint"
-meaning = "Soyjack-Pointing; uebertriebenes Zeigen oder Fan-Hype."
-usage = "wenn jemand etwas begeistert oder spottend anzeigt"
-
-[[emotes]]
-name = "ARSCHKRATZEN"
-meaning = "Derbes Kratzen-/Faulheitsmeme."
-usage = "bei derbem Koerperhumor"
-
-[[emotes]]
-name = "Nyehehehe"
-meaning = "Lachen; etwas ist lustig oder absurd."
-usage = "bei Witzen, Fails oder absurden Chat-Momenten"
-
-[[emotes]]
-name = "FluteTime"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "monakNotSure"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "peepoMonster"
-meaning = "Peepo-Monster; spielerisch gruselig."
-usage = "bei kleinen Horror-, Monster- oder Boo-Momenten"
-
-[[emotes]]
-name = "NOWAYING"
-meaning = "Unglaeubigkeit; bruh-Moment oder kaum zu fassen."
-usage = "bei absurden, peinlichen oder schwer glaubbaren Aussagen"
-
-[[emotes]]
-name = "DaGoth"
-meaning = "Dagoth-/Morrowind-Meme."
-usage = "bei Dagoth- oder Elder-Scrolls-Kontext"
-
-[[emotes]]
-name = "marc_yoyo"
-meaning = "Spongebob-/Marc-Insider."
-usage = "bei albernen, verwirrten oder cartoonigen Momenten"
-
-[[emotes]]
-name = "annehatschonwiedernichtszutunwährenddesazb"
-meaning = "AZB-/Anne-Insider; scheinbar nichts zu tun."
-usage = "wenn jemand im Ausbildungs-/Arbeitskontext idle wirkt"
-
-[[emotes]]
-name = "grrr"
-meaning = "Knurren oder kleine Wut."
-usage = "bei spielerischer Aggression"
-
-[[emotes]]
-name = "LOGGERS"
-meaning = "Logger-/Holzfäller-Meme."
-usage = "bei Holz, Logs oder Logging"
-
-[[emotes]]
-name = "bieberbutzemanPepe"
-meaning = "Bieberbutzemann-/Pepe-Insider."
-usage = "bei skurrilen lokalen oder Pepe-Insider-Momenten"
-
-[[emotes]]
-name = "Truck"
-meaning = "Truck/LKW."
-usage = "bei LKW oder Transport"
-
-[[emotes]]
-name = "Nilstime"
-meaning = "Nils-Time; lokaler Insider."
-usage = "wenn Nils oder Nils-Kontext Thema ist"
-
-[[emotes]]
-name = "catSigh"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "monkeSpin"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "totarsch"
-meaning = "Derber Totalarsch-Insider."
-usage = "bei sehr derbem Chat-Humor"
-
-[[emotes]]
-name = "SoCute"
-meaning = "Sehr suess."
-usage = "bei niedlichen Momenten"
-
-[[emotes]]
-name = "hub"
-meaning = "Buh-/Hub-Quatsch als kurzer alberner Ausruf."
-usage = "bei kleinen absurd-komischen Zwischenrufen"
-
-[[emotes]]
-name = "Floppy"
-meaning = "Floppy/Floppa-artiger lockerer Moment."
-usage = "bei goofy oder laessiger Reaktion"
-
-[[emotes]]
-name = "peepoMayo"
-meaning = "Peepo mit Mayo."
-usage = "bei Mayo- oder Food-Meme"
-
-[[emotes]]
-name = "OlesDailyRageWegenDenBubenInCS"
-meaning = "Wut, Tilt oder genervte Stimmung."
-usage = "bei Rage, Rants oder Frust"
-
-[[emotes]]
-name = "Egium"
-meaning = "Egium-Insider als ruhiger Chat-Ausruf."
-usage = "bei Egium-Name-Momenten oder trockenem Insider-Kontext"
-
-[[emotes]]
-name = "EGIUM"
-meaning = "Egium-Insider als lauter Chat-Ausruf."
-usage = "bei Egium-Name-Momenten oder betontem Insider-Kontext"
-
-[[emotes]]
-name = "NOTSUSSY"
-meaning = "Sus; etwas wirkt verdaechtig."
-usage = "bei verdächtigen, zweideutigen oder Among-Us-artigen Momenten"
-
-[[emotes]]
-name = "ppFoop"
-meaning = "Alberner PP-/Foop-Humor."
-usage = "bei kindischem Quatsch oder Nonsens"
-
-[[emotes]]
-name = "omE"
-meaning = "OmE; kurzer ueberraschter Meme-Ausdruck."
-usage = "bei kleinem Schock"
-
-[[emotes]]
-name = "AlienGathering"
-meaning = "Alien-Versammlung."
-usage = "bei Gruppen- oder Alien-Meme-Kontext"
-
-[[emotes]]
-name = "piwo"
-meaning = "Bier oder Feierabendgetraenk."
-usage = "wenn es um Bier, Feierabend oder Anstossen geht"
-
-[[emotes]]
-name = "devi3"
-meaning = "Getraenk oder Trinkmoment."
-usage = "wenn es um Trinken, Kaffee, Bier oder Hydration geht"
-
-[[emotes]]
-name = "Devi11SekundenNachdemErAusDemAutoSteigtAufSizilien"
-meaning = "Devi-Sizilien-Insider; sofortiger Chaosmoment."
-usage = "wenn Urlaub, Autoausstieg oder schneller Eskalationswitz passt"
-
-[[emotes]]
-name = "Timeout"
-meaning = "Timeout oder kurz rausnehmen."
-usage = "wenn Moderation/Timeout scherzhaft Thema ist"
-
-[[emotes]]
-name = "WennTristenAbsichtlichScheisseInCSGebautHatUndOleGeradeNuklearCrashOutGeht"
-meaning = "Lachen oder Humor-Reaktion."
-usage = "bei lustigen oder absurden Momenten"
-
-[[emotes]]
-name = "darthnotL"
-meaning = "Darth-/Star-Wars-L-Meme."
-usage = "bei Star-Wars- oder Niederlagenmoment"
-
-[[emotes]]
-name = "gorm"
-meaning = "Gorm; lokaler Insider-Name."
-usage = "bei Gorm-Kontext"
-
-[[emotes]]
-name = "piesek"
-meaning = "Hund auf Polnisch."
-usage = "bei Hundemomenten"
-
-[[emotes]]
-name = "happyBUHrday"
-meaning = "Happy Birthday im Buh-Stil."
-usage = "bei Geburtstagen"
-
-[[emotes]]
-name = "PotFriend"
-meaning = "Pot Friend; Topf-/Pflanzenfreund."
-usage = "bei Pflanzen oder freundlichem Objekt-Meme"
-
-[[emotes]]
-name = "MAXWELL"
-meaning = "Katzen-Moment."
-usage = "wenn Katzen, Miauen oder niedliche Cat-Reaktionen passen"
-
-[[emotes]]
-name = "Sainz"
-meaning = "Formel-1-Bezug."
-usage = "wenn Formel 1, Fahrer oder Teams Thema sind"
-
-[[emotes]]
-name = "KKoooona"
-meaning = "KKona-/Amerika- oder Country-Vibe."
-usage = "bei ironischen US-, Country- oder Redneck-Momenten"
-
-[[emotes]]
-name = "MAAAN"
-meaning = "Laengerer Mann/Man-Ausruf."
-usage = "bei Frust oder Erstaunen"
-
-[[emotes]]
-name = "GnoccAir"
-meaning = "Gnocc-Air; lokaler Flug-/Airline-Insider."
-usage = "bei Gnocc oder Flugkontext"
-
-[[emotes]]
-name = "buhssin"
-meaning = "Buh-Insider mit Boss/Vibe."
-usage = "bei lokalem buh-Meme"
-
-[[emotes]]
-name = "GIGATON"
-meaning = "Giga-Ton; massiver Impact."
-usage = "bei sehr grossem Schlag oder Ereignis"
-
-[[emotes]]
-name = "watto"
-meaning = "Watto-/Star-Wars-Meme."
-usage = "bei Star-Wars-Kontext"
-
-[[emotes]]
-name = "CS2"
-meaning = "Gaming oder bestimmtes Spielthema."
-usage = "wenn es direkt um Gaming oder dieses Spiel geht"
-
-[[emotes]]
-name = "IchMussUnbedingtDieSituationÜberwachen."
-meaning = "Muedigkeit oder Ruhebeduerfnis."
-usage = "bei sleepy, spaeter oder erschoepfter Stimmung"
-
-[[emotes]]
-name = "bebop"
-meaning = "Bebop-Charakter/Meme."
-usage = "bei Bebop- oder Deadlock-Kontext"
-
-[[emotes]]
-name = "DEADLOCK"
-meaning = "Gaming oder bestimmtes Spielthema."
-usage = "wenn es direkt um Gaming oder dieses Spiel geht"
-
-[[emotes]]
-name = "bebopstyle"
-meaning = "Bebop-Style."
-usage = "bei Bebop- oder Style-Kontext"
-
-[[emotes]]
-name = "XINEMA"
-meaning = "Cinema mit Xi-/China-Meme."
-usage = "bei dramatischem China- oder Politik-Meme"
-
-[[emotes]]
-name = "OM"
-meaning = "Om; kurze meditative Reaktion."
-usage = "bei ruhiger oder spiritueller Stimmung"
-
-[[emotes]]
-name = "JESUS"
-meaning = "Jesus-/heilige Reaktion."
-usage = "bei ueberraschenden oder heiligen Meme-Momenten"
-
-[[emotes]]
-name = "NOOO"
-meaning = "Nein-Schrei."
-usage = "bei Entsetzen oder Verlust"
-
-[[emotes]]
-name = "nom"
-meaning = "Essen/nommen."
-usage = "bei Snack- oder Essensmomenten"
-
-[[emotes]]
-name = "Smith"
-meaning = "Smith-Name/Charakter-Meme."
-usage = "bei Smith-Kontext"
-
-[[emotes]]
-name = "KOCHEN"
-meaning = "Kochen oder jemand ist am Cooken."
-usage = "wenn jemand eine gute Idee, einen Plan oder echtes Kochen anspricht"
-
-[[emotes]]
-name = "ErmActually"
-meaning = "Big-brain oder nerdige Korrektur."
-usage = "bei schlauen, uebergenauen oder nerdigen Aussagen"
-
-[[emotes]]
-name = "GUBBEL"
-meaning = "Gubbel-Insider."
-usage = "bei lokalem Gubbel-Kontext"
-
-[[emotes]]
-name = "sAAAdge"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "MaggusTime"
-meaning = "Maggus-Zeit."
-usage = "bei Markus-Soeder/Bayern-Kontext"
-
-[[emotes]]
-name = "Magnussy"
-meaning = "Magnus-Insider mit derbem Wortspiel."
-usage = "bei lokalem Magnus-Kontext"
-
-[[emotes]]
-name = "jorkin"
-meaning = "Derber Jorkin-Witz."
-usage = "bei bewusst albernem NSFW-Wortspiel"
-
-[[emotes]]
-name = "Magerquark"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "PauseElefant"
-meaning = "Spannung oder erwartungsvolles Warten."
-usage = "wenn gleich etwas Wichtiges passiert oder ein Ausgang offen ist"
-
-[[emotes]]
-name = "sip"
-meaning = "Getraenk oder Trinkmoment."
-usage = "wenn es um Trinken, Kaffee, Bier oder Hydration geht"
-
-[[emotes]]
-name = "SadKitty"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "Boink"
-meaning = "Boink; kleiner Schlag oder Stups."
-usage = "bei leichtem Hit oder Slapstick"
-
-[[emotes]]
-name = "scheisstag"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "GLOINK"
-meaning = "Gloink; goofy Soundeffekt."
-usage = "bei albernem Impact oder Bewegung"
-
-[[emotes]]
-name = "Zyzzers"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "awakebutatwhatcost"
-meaning = "Erkenntnis; etwas wird unangenehm klar."
-usage = "wenn jemand eine bittere Wahrheit bemerkt oder realisiert"
-
-[[emotes]]
-name = "Elefantastisch"
-meaning = "Elefantastisch; Elefant + fantastisch."
-usage = "bei Elefanten oder guter Laune"
-
-[[emotes]]
-name = "LegExtensions"
-meaning = "Gym, Kraft oder Bodybuilding."
-usage = "wenn es um Training, Kraft oder Gym-Memes geht"
-
-[[emotes]]
-name = "peepoSigh"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
-
-[[emotes]]
-name = "peepoSip"
-meaning = "Getraenk oder Trinkmoment."
-usage = "wenn es um Trinken, Kaffee, Bier oder Hydration geht"
-
-[[emotes]]
-name = "GuidedBirdge"
-meaning = "Vogel-Meme."
-usage = "bei Bird-, Flug- oder Schrei-Momenten"
-
-[[emotes]]
-name = "JOEL"
-meaning = "Joel-Meme."
-usage = "bei Joel-Kontext"
-
-[[emotes]]
-name = "KratosAscent"
-meaning = "Ratten-Meme."
-usage = "bei Rat-, Shake- oder hektischem Meme-Kontext"
-
-[[emotes]]
-name = "pedro"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
-
-[[emotes]]
-name = "HUH2"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
-
-[[emotes]]
-name = "remWave"
-meaning = "Rem winkt."
-usage = "bei Anime-/Rem-Begrüssung"
-
-[[emotes]]
-name = "peepoAachen"
-meaning = "Deutscher Ortsbezug."
-usage = "wenn der konkrete Ort oder die Region Thema ist"
-
-[[emotes]]
-name = "TimeForDeadlock"
-meaning = "Gaming oder bestimmtes Spielthema."
-usage = "wenn es direkt um Gaming oder dieses Spiel geht"
-
-[[emotes]]
-name = "RAGEY"
-meaning = "Wut, Rage oder genervte Stimmung."
-usage = "wenn jemand offensichtlich sauer, getriggert oder am Ranten ist"
+name = "ezz"
+meaning = "Übertrieben lässiges 'easy'."
+usage = "Nach einem einfachen Sieg, einem billigen Joke oder wenn man ironisch so tut, als wäre alles trivial."
 
 [[emotes]]
 name = "factRun"
-meaning = "Fakten rennen los."
-usage = "bei ploetzlich vielen Fakten oder Info-Dump"
+meaning = "Fakten-rennen-los-Meme."
+usage = "Wenn plötzlich Wahrheiten, Statistiken oder harte Fakten schnell in den Chat geworfen werden."
+
+[[emotes]]
+name = "Fatge"
+meaning = "Derbes Körper-/Fettge-Meme."
+usage = "Wird für überzeichnete Trägheit, Völlerei oder absichtlich uncharmante Selbstironie benutzt."
+
+[[emotes]]
+name = "FCKAFD"
+meaning = "Politisches Anti-AfD-Statement-Emote."
+usage = "Nur bei eindeutig politischem Kontext oder als Erkennung der Referenz einsetzen."
+
+[[emotes]]
+name = "FDM"
+meaning = "Naher Ausschnitt eines grünen Froschgesichts mit halb geschlossenen Augen."
+usage = "Für prüfende, skeptische oder müde Blicke, wenn man etwas erst einmal einordnet."
+
+[[emotes]]
+name = "Feels1444Man"
+meaning = "Überfülltes/chaotisches Feels-Man-Bild mit 1444-Anspielung."
+usage = "Für extrem spezifische History-, Zahl- oder Insider-Momente, wenn der Chat die Referenz kennt."
+
+[[emotes]]
+name = "FeelsADHDMan"
+meaning = "Pepe-ähnliches Gefühl von Unruhe/Ablenkung."
+usage = "Wenn Konzentration fehlt oder alles gleichzeitig passiert."
+
+[[emotes]]
+name = "FeelsGladMan"
+meaning = "Glückliches Pepe-Gefühl."
+usage = "Für ehrliche Freude, Erleichterung oder wholesome Erfolg."
+
+[[emotes]]
+name = "FeelsLagMan"
+meaning = "Lag-/Verzögerungsgefühl."
+usage = "Wenn Stream, Spiel oder Reaktion hinterherhängt."
+
+[[emotes]]
+name = "FeelsNukeMan"
+meaning = "Pepe-Moment mit nuklearer Eskalation."
+usage = "Wenn alles übertrieben explodiert oder ein Crashout passiert."
+
+[[emotes]]
+name = "FeelsOldMan"
+meaning = "Nostalgie-/Altfühl-Meme."
+usage = "Wenn etwas an frühere Zeiten erinnert oder man sich alt fühlt."
+
+[[emotes]]
+name = "FeelsQueueMan"
+meaning = "Warteschlangen-Gefühl."
+usage = "Wenn Queue-Zeit, Matchmaking oder langes Warten nervt."
+
+[[emotes]]
+name = "FeelsStrongJAM"
+meaning = "Starkes Jam-/Muskelgefühl."
+usage = "Bei Musik plus Energie, Gym-Vibes oder Power-Momenten."
+
+[[emotes]]
+name = "fentbert"
+meaning = "Edgy Bert-/Substanzwitz-Meme."
+usage = "Wenn etwas wie eine kaputte Sesamstraßen- oder Internet-Überdosis-Pointe wirkt."
+
+[[emotes]]
+name = "Ferrarieg"
+meaning = "Ferrari-/F1-Meme-Gesicht."
+usage = "Für Strategiefehler, rote Autos oder Formel-1-Drama."
+
+[[emotes]]
+name = "Fighter2"
+meaning = "Graustufiges Kampfjet-/Flugzeugmotiv."
+usage = "Für Flugzeug-, Jet-, Militär- oder laute Vorbeiflug-Momente im Meme-Kontext."
+
+[[emotes]]
+name = "Fishinge"
+meaning = "Angel-/Fishing-Meme."
+usage = "Wenn jemand baitet, fischt oder auf Reaktionen wartet."
+
+[[emotes]]
+name = "FLOPPA"
+meaning = "Big-Floppa/Karakal-Meme."
+usage = "Für Caracal-/Floppa-Content oder breite Meme-Reaktionen."
+
+[[emotes]]
+name = "FloppaBing"
+meaning = "Floppa plus Bing-Chilling-Vibe."
+usage = "Für China-/Eis-/Floppa-Insider mit absurdem Humor."
+
+[[emotes]]
+name = "FloppaBusiness"
+meaning = "Floppa im Business-Modus."
+usage = "Wenn Floppa seriös, reich oder geschäftig wirkt."
+
+[[emotes]]
+name = "FLOPPACHAD"
+meaning = "Chad-Floppa."
+usage = "Wenn Floppa maximal souverän oder übermächtig dargestellt wird."
+
+[[emotes]]
+name = "FloppaDespair"
+meaning = "Verzweifelter Floppa."
+usage = "Wenn selbst Floppa keine Hoffnung mehr sieht."
+
+[[emotes]]
+name = "FloppaDude"
+meaning = "Lässiger Floppa-Dude."
+usage = "Für entspannte, coole oder gleichgültige Floppa-Reaktionen."
+
+[[emotes]]
+name = "FloppaL"
+meaning = "Floppa nimmt ein L."
+usage = "Wenn ein Floppa-/Chat-Moment verliert oder scheitert."
+
+[[emotes]]
+name = "FloppaPong"
+meaning = "Floppa beim Ping-Pong."
+usage = "Für Hin-und-her, Sport oder albernes Spieltempo."
+
+[[emotes]]
+name = "FloppaRave"
+meaning = "Ravender Floppa."
+usage = "Bei Techno, Bass, Party oder starkem Beat."
+
+[[emotes]]
+name = "Floppy"
+meaning = "Floppy-/Disketten- oder weicher Floppa-Insider."
+usage = "Für Retro-, Speicher- oder schlaffe Meme-Momente."
+
+[[emotes]]
+name = "flowerr"
+meaning = "Blumen- oder weiches Natur-Emote."
+usage = "Wenn etwas süß, friedlich, hübsch oder unerwartet sanft ist."
+
+[[emotes]]
+name = "flushE"
+meaning = "Flush-/Toiletten- oder Wegspülmeme."
+usage = "Wenn ein Take, Play oder Thema bildlich im Abfluss verschwindet."
+
+[[emotes]]
+name = "FluteTime"
+meaning = "Flöten-/Instrumentenzeit als kleines Musikemote."
+usage = "Wenn Musik, Pfeifen, Flöte oder ein sehr spezifischer Sound-Moment passt."
+
+[[emotes]]
+name = "FORSEN"
+meaning = "Streamer-/Forsen-Meme."
+usage = "Bei klassischen Twitch-Insidern, Forsen-Referenzen oder Chat-Spam."
+
+[[emotes]]
+name = "forsenCD"
+meaning = "Forsen-CD-/Cheating-Meme."
+usage = "Wenn jemand verdächtig spielt oder 'CD' als Cheat-Witz passt."
+
+[[emotes]]
+name = "forsenExplainingHow"
+meaning = "Forsen erklärt etwas."
+usage = "Wenn ein Forsen-bezogener Erklärmoment oder trockene Analyse läuft."
+
+[[emotes]]
+name = "forsenInsane"
+meaning = "Wahnsinniger Forsen-Moment."
+usage = "Wenn Content komplett entgleist oder der Chat irre wird."
+
+[[emotes]]
+name = "forsenLaughingAtYou"
+meaning = "Forsen lacht dich aus."
+usage = "Wenn jemand ausgelacht, besiegt oder bloßgestellt wird."
+
+[[emotes]]
+name = "forsenScoots"
+meaning = "Forsen auf Scooter/Bewegung."
+usage = "Wenn jemand wegrollt, schnell flieht oder Bewegung reinbringt."
+
+[[emotes]]
+name = "FotzenFaschoFritzVonPapen"
+meaning = "Derbes antifaschistisches Geschichts-/Von-Papen-Insideremote mit vulgärer Sprache."
+usage = "Nur als stark politisch-vulgäre Referenz erkennen; für freundliche Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "frfr"
+meaning = "'For real, for real'."
+usage = "Zur echten Zustimmung oder ironischen Bekräftigung."
+
+[[emotes]]
+name = "fricc"
+meaning = "Abgeschwächte 'frick'-Fluchreaktion."
+usage = "Wenn man fluchen will, aber es bewusst albern oder harmlos klingen lässt."
+
+[[emotes]]
+name = "FTZNFRTZ"
+meaning = "Abgekürzte Variante desselben vulgär-antifaschistischen Von-Papen-Insiders."
+usage = "Bei lokalem History-/Politik-Insiderkontext; nicht neutral ausgeben."
+
+[[emotes]]
+name = "fuh"
+meaning = "Katzen-Nahaufnahme als kurzer „fuh“-Laut."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser fuh-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "FUKUYAMA"
+meaning = "Francis-Fukuyama-/Ende-der-Geschichte-Insider."
+usage = "Wenn Politik, Geschichte oder übertheoretische Takes plötzlich memig werden."
+
+[[emotes]]
+name = "gachiHacker"
+meaning = "Gachi-/Hacker-Meme mit Körper-/Macho- und Tech-Anspielung."
+usage = "Wenn Hacker-Ästhetik mit übertrieben maskuliner Meme-Energie kombiniert wird."
+
+[[emotes]]
+name = "GachiPls"
+meaning = "Gachi-Musik-/Tanz-Meme."
+usage = "Wenn gachiBASS-artige Musik, Gym-Humor oder rhythmischer Spam läuft."
+
+[[emotes]]
+name = "gadse"
+meaning = "Grüne Katzen-/Gadse-Figur im memehaften Stil."
+usage = "Für Katzenmomente, lokale Gadse-Witze oder niedlich-schräge Tierreaktionen."
+
+[[emotes]]
+name = "GAMING"
+meaning = "Gaming als überzeichnete Reaktion."
+usage = "Wenn etwas besonders gamerhaft, tryhard oder chaotisch wird."
+
+[[emotes]]
+name = "Gato"
+meaning = "Spanisch/Portugiesisch für Katze."
+usage = "Für Katzenmomente mit internationalem Meme-Vibe."
+
+[[emotes]]
+name = "GermanDank"
+meaning = "Deutscher Dank-/Meme-Humor."
+usage = "Wenn deutsche Kultur, Sprache oder trockene Deutsch-Memes passen."
+
+[[emotes]]
+name = "Geroellge"
+meaning = "Geröll-/Stein- oder Felsinsider als kleines Bild."
+usage = "Für Berg-, Stein-, Absturz- oder „da kommt Geröll“-Momente."
+
+[[emotes]]
+name = "GIGACHAD"
+meaning = "Überzeichnet maskulines Chad-/Selbstbewusstseinsmeme."
+usage = "Wenn jemand extrem souverän, stark oder ironisch „alpha“ wirkt."
+
+[[emotes]]
+name = "GIGALONSO"
+meaning = "Fernando-Alonso-als-Gigachad-Meme."
+usage = "Bei Alonso-Hype, F1-Respekt oder Veteranen-Momenten."
+
+[[emotes]]
+name = "GIGATON"
+meaning = "Gigantische Tonne/gewaltige Masse."
+usage = "Wenn etwas übertrieben groß, schwer oder massiv wirkt."
+
+[[emotes]]
+name = "GIGHABECK"
+meaning = "Übermächtige Habeck-/Gigachad-Variante."
+usage = "Wenn Robert-Habeck-Memes mit maximaler Chad- oder Bossenergie gespielt werden."
+
+[[emotes]]
+name = "GIRLDETECTED"
+meaning = "„Girl detected“-Chat-Insider mit Alarm-/Detektionsvibe."
+usage = "Besser nicht als ernsthafte Aussage verwenden; höchstens als ironischen, potenziell unangenehmen Chat-Reflex erkennen."
+
+[[emotes]]
+name = "glebeGlebe"
+meaning = "Glitschiger Unsinnslaut-/Creature-Insider."
+usage = "Wenn der Chat absichtlich in Nonsenssprache kippt und ein deformierter Klang passt."
+
+[[emotes]]
+name = "GLOINK"
+meaning = "Hellgrüne Katze oder alienartige Katze, die liegend und angespannt nach vorne schaut."
+usage = "Für komische Tiermomente, unerwartete Stille oder wenn etwas leicht unheimlich-niedlich wirkt."
+
+[[emotes]]
+name = "glorpBuisness"
+meaning = "Hellgrünes Glorp-Wesen im Business-Anzug mit kleinem Koffer."
+usage = "Für seriös gespielte Geschäfts-, Meeting- oder Verhandlungs-Momente mit absurdem Unterton."
+
+[[emotes]]
+name = "glorpCheer"
+meaning = "Nahaufnahme eines hellgrünen Glorp-Wesens, das wie jubelnd oder auftauchend wirkt."
+usage = "Für kleine Jubelreaktionen, wenn ein Glorp-artiges Wesen stellvertretend mitfeiert."
+
+[[emotes]]
+name = "glorpDude"
+meaning = "Hellgrünes Glorp-Wesen mit blauem Oberteil und neutralem Gesicht."
+usage = "Für entspannte Dude-Reaktionen, wenn man schlicht anwesend ist oder kommentarlos zuschaut."
+
+[[emotes]]
+name = "glorpNotL"
+meaning = "Sehr kleines hellgrünes Glorp-Wesen als reduzierte Silhouette auf dunklem Hintergrund."
+usage = "Für leise Abgänge, Mini-Reaktionen oder wenn ein Witz nur ganz klein gesetzt werden soll."
+
+[[emotes]]
+name = "GnoccAir"
+meaning = "Gnocc-/Fahrzeug- oder Airborne-Szene mit Bewegung."
+usage = "Für Flug-, Sprung-, Auto- oder „abheben“-Momente im Gnocc-Insiderstil."
+
+[[emotes]]
+name = "GNOCCI"
+meaning = "Gnocc-/Gnocchi-Insider."
+usage = "Für Gnocc-Momente, Höhlen-/Kreaturenwitze oder Channel-Insider."
+
+[[emotes]]
+name = "GoodOneBoomer"
+meaning = "Spöttische „guter Witz, Boomer“-Reaktion."
+usage = "Wenn ein alter, sehr flacher oder typisch boomerhafter Witz gemacht wird."
+
+[[emotes]]
+name = "gorm"
+meaning = "Verzerrte Nahaufnahme einer Katze mit langgezogenem Gesicht und breitem Maulbereich."
+usage = "Für seltsam verzerrte Reaktionen, Schockbilder oder Katzenhumor, der absichtlich derangiert aussieht."
+
+[[emotes]]
+name = "GoslingDrive"
+meaning = "Ryan-Gosling-Drive-Meme."
+usage = "Für stille Autofahrt-Coolness, literally-me-Vibes oder melancholische Neon-Nachtmomente."
+
+[[emotes]]
+name = "GotCaughtTrolling"
+meaning = "Beim Trollen erwischt."
+usage = "Wenn jemand offensichtlich baitet und dabei auffliegt."
+
+[[emotes]]
+name = "GotCaughtTrolling1"
+meaning = "Alternative Variante von 'beim Trollen erwischt'."
+usage = "Wenn jemand baitet, sich verplappert oder der Trollversuch auffliegt."
+
+[[emotes]]
+name = "GOTEM"
+meaning = "'Hab ihn erwischt'."
+usage = "Wenn ein Bait, Joke oder Fang erfolgreich war."
+
+[[emotes]]
+name = "GOTTEM"
+meaning = "Klassisches 'Got 'em'."
+usage = "Wenn jemand auf einen Witz reinfällt oder gecallt wurde."
+
+[[emotes]]
+name = "GOTTEM2"
+meaning = "Zweite Gottem-/Erwischt-Variante."
+usage = "Wenn ein Bait funktioniert oder jemand ein zweites Mal sauber gecallt wird."
+
+[[emotes]]
+name = "grass"
+meaning = "Touch-grass-/Gras-Meme."
+usage = "Wenn jemand zu online ist und mal rausgehen sollte."
+
+[[emotes]]
+name = "grrr"
+meaning = "Wütende Katze als Knurr-/Grrr-Reaktion."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser grrr-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "GUBBEL"
+meaning = "Pepe-/Froschfigur als orangefarbener runder Vogel mit Kappe und großen Augen."
+usage = "Für alberne, kostümierte oder komplett absurde Auftritte eines Frosch-Charakters."
+
+[[emotes]]
+name = "GuesNoEg"
+meaning = "Eg-Figur als unsichere „guess no“-Ablehnung."
+usage = "Wenn man etwas verneint, aber eher ratlos oder ironisch statt hart ablehnt."
+
+[[emotes]]
+name = "GuidedBirdge"
+meaning = "Birdge/Vogel wird geführt oder gesteuert; im Bild eine Hand-/Zeige-Szene."
+usage = "Wenn ein Birdge-Moment gelenkt, geaimt oder gezielt irgendwohin geschickt wird."
+
+[[emotes]]
+name = "gullScream"
+meaning = "Schreiende Möwe."
+usage = "Wenn der Chat kreischt, Panik macht oder etwas wie ein aggressiver Küstenvogel klingt."
+
+[[emotes]]
+name = "GUMO"
+meaning = "Guten-Morgen-artige Pepe/Ge-Variante mit Schlafmütze."
+usage = "Für Morgenbegrüßungen, verschlafene Starts oder frühe Chat-Momente."
+
+[[emotes]]
+name = "GUNA"
+meaning = "Pepe/Frosch mit blauer Mütze neben einem kleinen weißen Tier."
+usage = "Für verwirrte Begleitmomente, wenn ein Frosch-Charakter mit einem kleinen Sidekick auftaucht."
+
+[[emotes]]
+name = "gurkenrichard"
+meaning = "Einzelne grüne Gurke mit kleinem Gesicht oder Auge."
+usage = "Für Gurkenwitze, schräge Essensreaktionen oder einen sehr trockenen Insider-Moment."
+
+[[emotes]]
+name = "guuh"
+meaning = "Neongrüner verzerrter Frosch-/Gremlinkopf mit dunklen Augen."
+usage = "Für dumpfe, verwirrte oder leicht verfluchte Reaktionen, wenn einem nur noch 'guuh' einfällt."
+
+[[emotes]]
+name = "Gymgers"
+meaning = "Gym-/Fitness-Meme."
+usage = "Bei Training, Muskeln, Pump oder Fitness-Talk."
+
+[[emotes]]
+name = "Haback"
+meaning = "Porträt eines Mannes mit schiefem, fragendem Blick."
+usage = "Für skeptische, irritierte oder trocken urteilende Reaktionen auf eine fragwürdige Aussage."
+
+[[emotes]]
+name = "HabeckGrin"
+meaning = "Robert-Habeck-Grinsen als Meme."
+usage = "Bei Politik-/Habeck-Insidern oder verschmitzten Reaktionen."
+
+[[emotes]]
+name = "habeckO7"
+meaning = "Habeck-Salut-Emote."
+usage = "Wenn Robert-Habeck-Memes respektvoll, ironisch oder militärisch gegrüßt werden."
+
+[[emotes]]
+name = "HalbeBibel"
+meaning = "Sehr lange Textwand-/Bibel-Meme."
+usage = "Wenn jemand einen halben Roman in den Chat schreibt oder ein Essay eskaliert."
+
+[[emotes]]
+name = "HaltEinfachDeineFresseDuHurensohn"
+meaning = "Extrem aggressive und vulgäre „Halt den Mund“-Reaktion."
+usage = "Für Bot-Ausgaben vermeiden; als toxische Chatreaktion oder Moderationssignal behandeln."
+
+[[emotes]]
+name = "Handshakege"
+meaning = "Handshake-/Einigkeits-Meme."
+usage = "Wenn zwei Lager, Ideen oder Personen überraschend zusammenpassen."
+
+[[emotes]]
+name = "Hannover"
+meaning = "Stadt-/Hannover-Insider mit urbanem Bild."
+usage = "Für Hannover-, Orts-, Reise- oder lokale Community-Anspielungen."
+
+[[emotes]]
+name = "happi"
+meaning = "Kleine, einfache Happy-Reaktion."
+usage = "Wenn Freude eher weich, süß und unkompliziert ausgedrückt werden soll."
+
+[[emotes]]
+name = "happyBUHrday"
+meaning = "Geburtstagsvariante des Busted-Buh-Insiders."
+usage = "Für Geburtstagswünsche im Buh-/Busted-Stil oder wenn ein Geburtstag bewusst als Insider-Meme gefeiert wird."
+
+[[emotes]]
+name = "Haram"
+meaning = "Haram-/verboten-Meme mit ironisch-religiöser Anspielung."
+usage = "Wenn etwas als verboten, suspekt oder moralisch fragwürdig gerahmt wird; nicht respektlos gegen Religion verwenden."
+
+[[emotes]]
+name = "headBang"
+meaning = "Headbanging-Meme."
+usage = "Bei Metal, Bass, Hype-Musik oder rhythmischem Ausrasten."
+
+[[emotes]]
+name = "HECOOKED"
+meaning = "Er hat gekocht, also etwas Gutes geliefert."
+usage = "Wenn jemand einen starken Play, Take oder Plan macht."
+
+[[emotes]]
+name = "hehe"
+meaning = "Kurzes, heimliches Kichern."
+usage = "Wenn eine Pointe klein, frech oder leicht schadenfroh ist."
+
+[[emotes]]
+name = "HeimlichManeuver"
+meaning = "Heimlich-Manöver-Referenz."
+usage = "Wenn jemand sich verschluckt, gerettet wird oder ein Notfallwitz passt."
+
+[[emotes]]
+name = "HELLAWICKED"
+meaning = "Übertrieben cooles oder krasses Wicked-Meme."
+usage = "Wenn etwas nicht nur gut, sondern absurd böse, stylisch oder heftig wirkt."
+
+[[emotes]]
+name = "HelloThere"
+meaning = "Obi-Wan-/Star-Wars-Begrüßung."
+usage = "Als nerdige Begrüßung oder wenn General-Kenobi-Antworten erwartet werden."
+
+[[emotes]]
+name = "HELLOWO"
+meaning = "Niedliches Hello-/OwO-Katzenemote mit Schleife."
+usage = "Als verspielte Begrüßung oder cute Einstieg in den Chat."
+
+[[emotes]]
+name = "HetIsVoorbij"
+meaning = "Niederländische Variante von 'es ist vorbei'."
+usage = "Wenn ein Run, Match, Argument oder Traum endgültig erledigt ist."
+
+[[emotes]]
+name = "Heyge"
+meaning = "Freundliches Hey-Meme."
+usage = "Für kleine Begrüßungen oder sanftes Aufmerksam-Machen."
+
+[[emotes]]
+name = "hmjj"
+meaning = "Einfach gezeichneter grüner Froschkopf, der nachdenklich die Hand ans Kinn hält."
+usage = "Für stilles Grübeln, vorsichtige Zustimmung oder ein sehr kleines 'hmm'."
+
+[[emotes]]
+name = "Hmmge"
+meaning = "Nachdenkliches Hmm-Meme."
+usage = "Wenn man grübelt, skeptisch ist oder etwas verdächtig findet."
+
+[[emotes]]
+name = "Hmmm"
+meaning = "Langes Nachdenken."
+usage = "Wenn man eine Situation analysiert oder nicht ganz überzeugt ist."
+
+[[emotes]]
+name = "HMmm"
+meaning = "Langes Nachdenken."
+usage = "Wenn man eine Situation analysiert oder nicht ganz überzeugt ist."
+
+[[emotes]]
+name = "HmmmBye"
+meaning = "Nachdenklicher Abschied."
+usage = "Wenn man mit Skepsis oder awkward aus einer Situation rausgeht."
+
+[[emotes]]
+name = "hmmMeeting"
+meaning = "Meeting-/Besprechungs-Hmm."
+usage = "Wenn Büro, Planung oder sehr seriöse Diskussion gespielt wird."
+
+[[emotes]]
+name = "HmmmLaptop"
+meaning = "Nachdenken am Laptop."
+usage = "Wenn jemand recherchiert, arbeitet oder digital grübelt."
+
+[[emotes]]
+name = "HmmmOK"
+meaning = "Skeptisches 'okay'."
+usage = "Wenn man etwas akzeptiert, aber nicht wirklich glaubt."
+
+[[emotes]]
+name = "HmmNotes"
+meaning = "Notizen machendes Hmm."
+usage = "Wenn Informationen gesammelt oder verdächtige Aussagen protokolliert werden."
+
+[[emotes]]
+name = "HmmPhone"
+meaning = "Nachdenklich am Telefon."
+usage = "Bei Telefon-, Nachrichten- oder Call-Momenten."
+
+[[emotes]]
+name = "HmmScoots"
+meaning = "Nachdenkliches oder skeptisches Reaktionsmeme."
+usage = "Wenn der Chat analysiert, zweifelt oder über 'HmmScoots' grübelt."
+
+[[emotes]]
+name = "HmmYAPPP"
+meaning = "Nachdenkliches oder skeptisches Reaktionsmeme."
+usage = "Wenn der Chat analysiert, zweifelt oder über 'HmmYAPPP' grübelt."
+
+[[emotes]]
+name = "HolUp"
+meaning = "'Moment mal'-Reaktion."
+usage = "Wenn etwas plötzlich verdächtig, unlogisch oder doppeldeutig wird."
+
+[[emotes]]
+name = "HonestWork"
+meaning = "Ehrliche-Arbeit-Meme."
+usage = "Wenn etwas bodenständig, fleißig oder ironisch mühsam erledigt wird."
+
+[[emotes]]
+name = "hornerC"
+meaning = "Christian-Horner-/F1-Insider."
+usage = "Wenn Red-Bull-, Teamchef-, Formel-1-Drama oder Horner-Memes im Chat auftauchen."
+
+[[emotes]]
+name = "HORNY"
+meaning = "Grober horny-/sexueller Scherz als Textbild."
+usage = "Als NSFW-/Thirst-Reaktion erkennen; in sachlichen oder moderierten Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "HORSEN"
+meaning = "Horse-/Forsen-artiger Insider."
+usage = "Für Pferde- oder Forsen-nahe Meme-Momente."
+
+[[emotes]]
+name = "Houthis"
+meaning = "Geopolitischer Houthi-/Nahost-Insider im Memeformat."
+usage = "Nur bei eindeutigem geopolitischem Meme-Kontext; nicht zur Verherrlichung realer Gewalt nutzen."
+
+[[emotes]]
+name = "howdy"
+meaning = "Westernartige Begrüßung."
+usage = "Wenn jemand lässig, cowboyhaft oder mit trockenem Charme Hallo sagt."
+
+[[emotes]]
+name = "howody"
+meaning = "Verzogene Howdy-Variante."
+usage = "Für eine extra dumme, weiche oder absichtlich falsch ausgesprochene Begrüßung."
+
+[[emotes]]
+name = "hub"
+meaning = "Dunkles Foto einer Katze oder eines kleinen Tiers, das frontal in die Kamera schaut."
+usage = "Für plötzliche Aufmerksamkeit, verdutztes Auftauchen oder einen kurzen Tier-Blick in die Runde."
+
+[[emotes]]
+name = "hugg"
+meaning = "Umarmungs-Emote in weicher Schreibweise."
+usage = "Wenn der Chat jemanden trösten, feiern oder freundlich drücken will."
+
+[[emotes]]
+name = "HuggingButTheresAnEarthquake"
+meaning = "Umarmung, während alles wackelt."
+usage = "Wenn Trost und Chaos gleichzeitig passieren."
+
+[[emotes]]
+name = "hUh"
+meaning = "Verwirrtes 'Huh?'."
+usage = "Wenn eine Aussage komplett unerwartet oder unverständlich ist."
+
+[[emotes]]
+name = "HUH"
+meaning = "Verwirrtes 'Huh?'."
+usage = "Wenn eine Aussage komplett unerwartet oder unverständlich ist."
+
+[[emotes]]
+name = "HUH1"
+meaning = "Variante einer starken Verwirrungsreaktion."
+usage = "Wenn ein einzelner fragwürdiger Moment extra markiert wird."
+
+[[emotes]]
+name = "HUH2"
+meaning = "Weitere HUH-Variante."
+usage = "Wenn die Verwirrung anhält oder eskaliert."
+
+[[emotes]]
+name = "HUHBibi"
+meaning = "Verwirrungs- oder Frage-Reaktion."
+usage = "Wenn etwas unklar, unerwartet oder fragwürdig ist und 'HUHBibi' die Ratlosigkeit markiert."
+
+[[emotes]]
+name = "HUHFarmer"
+meaning = "Verwirrungs- oder Frage-Reaktion."
+usage = "Wenn etwas unklar, unerwartet oder fragwürdig ist und 'HUHFarmer' die Ratlosigkeit markiert."
+
+[[emotes]]
+name = "huhh"
+meaning = "Verwirrungs- oder Frage-Reaktion."
+usage = "Wenn etwas unklar, unerwartet oder fragwürdig ist und 'huhh' die Ratlosigkeit markiert."
+
+[[emotes]]
+name = "huhu"
+meaning = "Verwirrungs- oder Frage-Reaktion."
+usage = "Wenn etwas unklar, unerwartet oder fragwürdig ist und 'huhu' die Ratlosigkeit markiert."
+
+[[emotes]]
+name = "HUHW"
+meaning = "Breite/übertriebene HUH-Reaktion."
+usage = "Für besonders große Ratlosigkeit."
+
+[[emotes]]
+name = "HULKW"
+meaning = "Breites Hulk-/W-Meme."
+usage = "Wenn etwas massiv, grün, stark oder wütend wirkt."
+
+[[emotes]]
+name = "HusoPepeDank"
+meaning = "Derber Huso-/Pepe-Dank-Insider mit beleidigendem Textbezug."
+usage = "Als aggressive oder vulgäre Pepe-Reaktion erkennen; für normale Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "Hydrationge"
+meaning = "Trinken-/Wasser-Meme."
+usage = "Als Reminder zu trinken oder bei Wasserpausen."
+
+[[emotes]]
+name = "HYPERNODDERS"
+meaning = "Extremes zustimmendes Nicken."
+usage = "Wenn der Chat sehr stark zustimmt oder rhythmisch nickt."
+
+[[emotes]]
+name = "HyperSwoleMEGAdoggersOnPreWorkoutOnLegDayWithAChestPumpGoing"
+meaning = "Extrem muskulöser Dog/Doggers-Gym-Insider mit Preworkout-Energie."
+usage = "Für maximalen Gym-Hype, Pump, übertriebene Motivation oder absurde Fitness-Eskalation."
+
+[[emotes]]
+name = "IASKED"
+meaning = "'Ich habe gefragt'-Gegenmeme."
+usage = "Wenn jemand behauptet, niemand habe gefragt, oder extra Nachfrage simuliert wird."
+
+[[emotes]]
+name = "ICANT"
+meaning = "'Ich kann nicht mehr'."
+usage = "Bei Überforderung, Lachflashs oder mentalem Kollaps."
+
+[[emotes]]
+name = "IchMussUnbedingtDieSituationÜberwachen."
+meaning = "Schlaf-, Müdigkeits- oder Cozy-Emote."
+usage = "Wenn Müdigkeit, Bettzeit oder entspannte Stimmung mit 'IchMussUnbedingtDieSituationÜberwachen.' gezeigt werden soll."
+
+[[emotes]]
+name = "IDontCareIJustWannaSleep"
+meaning = "Gleichgültig und müde."
+usage = "Wenn Diskussion egal ist und Schlaf Priorität hat."
+
+[[emotes]]
+name = "IHaveAQuestion"
+meaning = "Ich habe eine Frage."
+usage = "Wenn jemand eine Nachfrage ankündigt oder Verwirrung formal einleitet."
+
+[[emotes]]
+name = "INSANECAT"
+meaning = "Verrückte Katze."
+usage = "Wenn Katzencontent völlig entgleist oder jemand irre reagiert."
+
+[[emotes]]
+name = "IntothemotherlandtheGermanarmymarchComradesstandsidebysidetostoptheNazichargePanzersonRussiansoil"
+meaning = "Überlanges Sabaton-/History-/Kriegslyrics-Meme."
+usage = "Wenn der Chat Kriegsgeschichte, Sabaton oder pathetische Militärästhetik bewusst übertreibt."
+
+[[emotes]]
+name = "IveGonePastThePointOfInsanity"
+meaning = "Katze/Person in komplett überdrehtem Wahnsinns- oder Burnout-Zustand."
+usage = "Wenn der Punkt der normalen Reaktion überschritten ist und nur noch Chaos bleibt."
+
+[[emotes]]
+name = "jabadabadu"
+meaning = "Nahaufnahme eines Mannes mit rotem Hintergrund und aufgeregtem Gesichtsausdruck."
+usage = "Für laute, hektische oder übermotivierte Reaktionen, wenn jemand emotional loslegt."
+
+[[emotes]]
+name = "JAN"
+meaning = "Kleiner Vogel oder Enten-Charakter, der auf blauem Untergrund gleitet oder vorbeifliegt."
+usage = "Für schnelle Abgänge, komisches Vorbeirutschen oder wenn jemand elegant aus der Situation rausfliegt."
+
+[[emotes]]
+name = "japierdole"
+meaning = "Polnischer Fluch-/Unglaubensausruf."
+usage = "Wenn etwas so absurd, nervig oder chaotisch ist, dass nur noch ein polnischer Ausruf passt."
+
+[[emotes]]
+name = "JarJarSwole"
+meaning = "Star-Wars-bezogenes Meme-Emote."
+usage = "Für Star-Wars-Referenzen, Sci-Fi-Insider oder nerdige Reaktionen mit 'JarJarSwole'."
+
+[[emotes]]
+name = "JDpwease"
+meaning = "Porträt eines lächelnden bärtigen Mannes im Anzug."
+usage = "Für überfreundliche Bitten, höfliches Einschmeicheln oder eine gespielt seriöse Anfrage."
+
+[[emotes]]
+name = "JESUS"
+meaning = "Jesus-Darstellung als Reaktionsbild."
+usage = "Für religiöse, segensartige, „heilige“ oder dramatisch erstaunte Momente; respektvoll einsetzen."
+
+[[emotes]]
+name = "JIPPIE"
+meaning = "Freudiges Yippie."
+usage = "Wenn etwas gelingt, süß ist oder kindliche Freude auslöst."
+
+[[emotes]]
+name = "JoeBiden"
+meaning = "Joe-Biden-Meme."
+usage = "Bei US-Politik-Referenzen oder Biden-Insidern."
+
+[[emotes]]
+name = "JOEL"
+meaning = "Sehr schmales weißes Objekt/Clipbild als Joel-Insider, kein generisches Personenporträt."
+usage = "Für lokale Joel-Calls oder den konkreten Community-Insider; ohne Kontext nur als Bildmotiv interpretieren."
+
+[[emotes]]
+name = "joever"
+meaning = "'It's Joever' Biden-Meme für 'es ist vorbei'."
+usage = "Wenn etwas endgültig gescheitert oder vorbei wirkt."
+
+[[emotes]]
+name = "jorkin"
+meaning = "Derb anzüglicher Wortspiel-/Reaktionsinsider."
+usage = "Für Bot-Ausgaben vermeiden; höchstens als NSFW-/Edgy-Chatwitz erkennen."
+
+[[emotes]]
+name = "JosefScheisser"
+meaning = "Derber Personen-/Josef-Insider mit beleidigendem Klang."
+usage = "Nur als lokale Insiderreferenz erkennen; nicht als normale Beleidigung ausgeben."
+
+[[emotes]]
+name = "JucktMichNicht"
+meaning = "Mir egal."
+usage = "Wenn man demonstrativ Desinteresse zeigt."
+
+[[emotes]]
+name = "juh"
+meaning = "Hamster-/Tierbild als kurzer „juh“-Laut."
+usage = "Bei passendem Insider- oder Bildmoment; nicht als universelle Standardreaktion verwenden."
+
+[[emotes]]
+name = "JUP"
+meaning = "Knappe Ja-/Yup-Bestätigung."
+usage = "Wenn etwas kommentarlos akzeptiert, abgenickt oder trocken bestätigt wird."
+
+[[emotes]]
+name = "Kapp"
+meaning = "Kappa-/Kapp-Gesicht als klassisches Sarkasmussignal."
+usage = "Wenn eine Aussage ironisch, nicht ganz ernst oder mit trockenem Trollface-Unterton gemeint ist."
+
+[[emotes]]
+name = "KEKL"
+meaning = "Lach-Meme, verwandt mit KEKW."
+usage = "Bei sehr lustigen, aber oft etwas trockeneren Situationen."
+
+[[emotes]]
+name = "KEKW"
+meaning = "Breites Lachen nach dem Juan-Joya-Borja/El-Risitas-Meme."
+usage = "Wenn etwas wirklich lustig, lächerlich oder komplett failig ist."
+
+[[emotes]]
+name = "kinkk"
+meaning = "Derb-doppeldeutiges Kink-/Internetmeme."
+usage = "Wenn eine Reaktion bewusst unangenehm, speziell oder zu persönlich wirkt."
+
+[[emotes]]
+name = "kiwiDance"
+meaning = "Musik-, Tanz- oder Jam-Emote."
+usage = "Wenn Musik läuft, der Chat im Rhythmus ist oder 'kiwiDance' als Partyreaktion passt."
+
+[[emotes]]
+name = "KKonaW"
+meaning = "Americana-/Redneck-Meme."
+usage = "Bei USA-, Country-, Patriotismus- oder Cowboy-Klischees."
+
+[[emotes]]
+name = "KKool"
+meaning = "Coole KKona-Variante."
+usage = "Wenn etwas sehr lässig oder ironisch amerikanisch cool wirkt."
+
+[[emotes]]
+name = "KKooool"
+meaning = "Noch länger gezogenes Cool-Meme."
+usage = "Für übertriebene Lässigkeit oder ironische Coolness."
+
+[[emotes]]
+name = "KKoooona"
+meaning = "Überzeichnetes KKona."
+usage = "Bei sehr starkem USA-/Country-/Redneck-Vibe."
+
+[[emotes]]
+name = "KKrikey"
+meaning = "Australisch wirkendes 'Crikey'-Meme."
+usage = "Bei Australien-, Tier- oder Abenteuerklischees."
+
+[[emotes]]
+name = "KLASSIKER"
+meaning = "Ein Klassiker/Running Gag."
+usage = "Wenn exakt derselbe Fehler oder Witz wieder passiert."
+
+[[emotes]]
+name = "KOCHEN"
+meaning = "Kochen als Meme für starke Ideen/Plays."
+usage = "Wenn jemand gerade etwas Gutes vorbereitet oder ausarbeitet."
+
+[[emotes]]
+name = "kok"
+meaning = "Gelbe staub- oder rauchartige Wolke, die wie ein kleiner Ausbruch wirkt."
+usage = "Für Puff-, Knall- oder Chaosmomente, wenn etwas plötzlich verpufft oder eskaliert."
+
+[[emotes]]
+name = "kokface"
+meaning = "Nahaufnahme eines schwarz-weißen Katzengesichts mit großen, dunklen Augen."
+usage = "Für intensives Katzenstarren, misstrauische Beobachtung oder einen sehr fokussierten Blick."
+
+[[emotes]]
+name = "koklick"
+meaning = "Kleines Tier in Nahaufnahme, das an etwas leckt oder knabbert."
+usage = "Für Nasch-, Leck- oder kleine gierige Tierreaktionen, wenn etwas sofort probiert wird."
+
+[[emotes]]
+name = "kola"
+meaning = "Verschwommene Katze oder kleines Tier mit weit offenem Mund."
+usage = "Für lautes Schreien, erschrockene Reaktionen oder komplett überdrehte Tierenergie."
+
+[[emotes]]
+name = "KratosAscent"
+meaning = "Kratos-/Game-Szene mit Aufstieg oder nach oben gerichteter Bewegung."
+usage = "Für Gaming-Momente, dramatische Aufstiege oder wenn jemand sich mühsam hocharbeitet."
+
+[[emotes]]
+name = "KratosFall"
+meaning = "Kratos-Fall-Meme."
+usage = "Wenn ein Aufstieg scheitert oder jemand dramatisch fällt."
+
+[[emotes]]
+name = "Kuhtee"
+meaning = "Kuh-/Farm-bezogenes Meme-Emote."
+usage = "Für Bauernhof-, Milch-, Farm- oder Kuhmomente mit 'Kuhtee'."
+
+[[emotes]]
+name = "Latege"
+meaning = "Spät-/Late-Meme."
+usage = "Wenn jemand zu spät kommt oder eine Reaktion verspätet ist."
+
+[[emotes]]
+name = "latinoHug"
+meaning = "Umarmungs-Emote mit Latino-/Sombrero-Anspielung."
+usage = "Für herzliche Begrüßung, Trost oder freundschaftliche Umarmung mit lokalem Meme-Flair."
+
+[[emotes]]
+name = "leavee"
+meaning = "Abschieds- oder Weggeh-Emote."
+usage = "Wenn jemand geht, ein Thema endet oder 'leavee' als Exit-Reaktion passt."
+
+[[emotes]]
+name = "LegExtensions"
+meaning = "Gym-/Beinübung-Insider, vermutlich Leg Extensions."
+usage = "Für Training, Leg Day, Fitness-Talk oder wenn jemand über Beinübungen spricht."
+
+[[emotes]]
+name = "LETHERCOOK"
+meaning = "Lasst sie kochen."
+usage = "Wenn eine Person gerade etwas Gutes vorbereitet und nicht gestört werden soll."
+
+[[emotes]]
+name = "LETHIMCOOK"
+meaning = "Lasst ihn kochen."
+usage = "Wenn jemand eine Idee noch ausführen soll, bevor man urteilt."
+
+[[emotes]]
+name = "letsgo"
+meaning = "Kleiner 'Los geht's'-Hype."
+usage = "Für weniger laute Zustimmung oder Startenergie."
+
+[[emotes]]
+name = "LETSGO"
+meaning = "Hype-Ruf 'Los geht's'."
+usage = "Bei Start, Erfolg, Clutch, Drop oder Motivation."
+
+[[emotes]]
+name = "LIFE"
+meaning = "Leben-/Existenz-Meme."
+usage = "Wenn etwas lebendig, gerettet oder philosophisch wird."
+
+[[emotes]]
+name = "LifeTogether"
+meaning = "Gemeinschafts-/Zusammenleben-Emote."
+usage = "Wenn Zusammenhalt, Beziehung, Koop-Vibes oder gemeinsames Durchhalten betont werden."
+
+[[emotes]]
+name = "LIFTOFF"
+meaning = "Raketenstart/Abheben."
+usage = "Wenn etwas startet, eskaliert oder durch die Decke geht."
+
+[[emotes]]
+name = "Lindnover"
+meaning = "Lindner-/„it is over“-Politikmeme."
+usage = "Wenn etwas politisch oder metaphorisch vorbei ist; als Joever-ähnliche Over-Reaktion."
+
+[[emotes]]
+name = "Listening"
+meaning = "Zuhören-Meme."
+usage = "Wenn man konzentriert lauscht oder jemandem Raum gibt."
+
+[[emotes]]
+name = "literallyme"
+meaning = "'Das bin literally ich'."
+usage = "Wenn man sich stark mit einer Figur oder Situation identifiziert."
+
+[[emotes]]
+name = "LOGGERS"
+meaning = "Holzfäller-/Log-Meme."
+usage = "Wenn Bäume, Holz, Minecraft, Arbeit oder stumpfes Farmen im Vordergrund stehen."
+
+[[emotes]]
+name = "LOLE"
+meaning = "Lach-/LOL-Variante."
+usage = "Für lockeres Lachen oder ironische Belustigung."
+
+[[emotes]]
+name = "lookDown"
+meaning = "Figur schaut nach unten."
+usage = "Wenn der Fokus unter dem Bild, im Chat darunter oder auf einem peinlichen Detail liegt."
+
+[[emotes]]
+name = "Lookinge"
+meaning = "Seitlich oder genau hinschauende Figur."
+usage = "Wenn man etwas beobachtet, prüft oder den Chat aufmerksam liest."
+
+[[emotes]]
+name = "lookUp"
+meaning = "Figur schaut nach oben."
+usage = "Wenn auf eine vorherige Nachricht, etwas über dem Bild oder einen höheren Punkt verwiesen wird."
+
+[[emotes]]
+name = "LukashenkaExplainingHow"
+meaning = "Lukaschenka-erklärt-etwas-Meme."
+usage = "Wenn jemand autoritär, trocken oder sehr eigenwillig eine Lage erklärt."
+
+[[emotes]]
+name = "LULE"
+meaning = "LUL-Variante für Lachen."
+usage = "Wenn etwas lustig ist, aber nicht maximal OMEGALUL-level."
+
+[[emotes]]
+name = "LUUL"
+meaning = "Überdehnte LUL-Lachvariante."
+usage = "Für länger anhaltendes, albernes Lachen."
+
+[[emotes]]
+name = "luvv"
+meaning = "Kleine Love-/Zuneigungsreaktion."
+usage = "Wenn etwas süß, unterstützend oder sanft positiv aufgenommen wird."
+
+[[emotes]]
+name = "MAAAN"
+meaning = "Genervtes 'Maaaan'."
+usage = "Wenn etwas enttäuschend oder nervig schiefläuft."
+
+[[emotes]]
+name = "MADDIES"
+meaning = "Wütende/traurige Mad-Reaktion."
+usage = "Wenn der Chat kollektiv genervt oder salzig ist."
+
+[[emotes]]
+name = "MADeg"
+meaning = "Wütendes Eg-/ge-Meme."
+usage = "Wenn ein Ei-/Eg-Insider sauer wird."
+
+[[emotes]]
+name = "Madge"
+meaning = "Wütendes Pepe-/Twitch-Meme."
+usage = "Wenn etwas nervt, triggert oder der Chat salzig wird."
+
+[[emotes]]
+name = "MadgeJuice"
+meaning = "Madge plus Saft/Energie."
+usage = "Wenn Wut mit extra Energie oder Tilt verbunden ist."
+
+[[emotes]]
+name = "MadgeLate"
+meaning = "Zu spät und wütend."
+usage = "Wenn eine verspätete Reaktion zusätzlich nervt."
+
+[[emotes]]
+name = "MadgeSit"
+meaning = "Sitzender Madge."
+usage = "Wenn man wütend sitzen bleibt und schmollt."
+
+[[emotes]]
+name = "MadTyper"
+meaning = "Wütend tippender Chat."
+usage = "Wenn jemand im Chat eine empörte Textwand vorbereitet."
+
+[[emotes]]
+name = "Madwokege"
+meaning = "Wokege/Moodge-Variante mit wütend-enttäuschtem Gesicht."
+usage = "Wenn Erkenntnis, Ärger und „ich bin wach, aber sauer“ zusammenkommen."
+
+[[emotes]]
+name = "Magerquark"
+meaning = "Fitness-/Quark-Meme."
+usage = "Bei Gym-Ernährung, Protein oder trockenem deutschen Food-Humor."
+
+[[emotes]]
+name = "Maggus"
+meaning = "Markus-Söder-/Maggus-Meme."
+usage = "Bei Bayern-, CSU-, Kebab- oder Politik-Insidern."
+
+[[emotes]]
+name = "MaggusBased"
+meaning = "Based-Maggus."
+usage = "Wenn ein Maggus/Söder-Take ironisch gefeiert wird."
+
+[[emotes]]
+name = "MaggusTime"
+meaning = "Zeit für Maggus."
+usage = "Wenn Bayern-/Söder-Content oder Maggus-Insider startet."
+
+[[emotes]]
+name = "Magnussy"
+meaning = "Derbes Magnussen-/Magnus-Wortspiel."
+usage = "Für F1-/Magnus-Insider, wenn der Chat bewusst cursed oder doppeldeutig wird."
+
+[[emotes]]
+name = "Mainz"
+meaning = "Mainz-/Lokal- oder Fußballinsider."
+usage = "Wenn Mainz, Rheinland-Pfalz, Karneval oder Fußballreferenzen passen."
+
+[[emotes]]
+name = "MainzerFlu"
+meaning = "Mainzer-Grippe-Insider."
+usage = "Wenn Krankheit, Ausrede oder lokaler Mainz-Humor miteinander vermischt werden."
+
+[[emotes]]
+name = "majj"
+meaning = "Minimalistischer grüner Froschkopf mit zusammengezogenen Augenbrauen."
+usage = "Für leichte Missbilligung, stilles Genervtsein oder skeptisches Runzeln."
+
+[[emotes]]
+name = "makscookingskills"
+meaning = "Ironisches Kochkünste-Emote mit Figur an Topf/Pfanne."
+usage = "Wenn jemand kocht, eine fragwürdige Küchenleistung zeigt oder „lass ihn kochen“ lokal gemeint ist."
+
+[[emotes]]
+name = "maloche"
+meaning = "Ruhrpott-/Arbeitsmeme für harte Arbeit."
+usage = "Wenn jemand schuften muss, Arbeit simuliert oder der Chat Malocher-Energie zeigt."
+
+[[emotes]]
+name = "MaN"
+meaning = "Gestreckte Man-/Mann-Reaktion."
+usage = "Wenn jemand trocken 'man...' denkt, resigniert oder einen Kumpel meint."
+
+[[emotes]]
+name = "MAN"
+meaning = "Großgeschriebene Mann-/Man-Reaktion."
+usage = "Für kräftige Verzweiflung, Anrede oder ein lautes 'Mann, wirklich?'."
+
+[[emotes]]
+name = "Mannheim"
+meaning = "Mannheim-/Ortsinsider mit dunkler Stadt-/Nachtanmutung."
+usage = "Bei Mannheim-Bezug oder lokalem Insider, nicht als allgemeines Deutschland-Emote."
+
+[[emotes]]
+name = "Maracagers"
+meaning = "Maracas-/Rhythmus-Emote."
+usage = "Wenn der Chat rhythmisch klappert, tanzt oder Latin-Percussion-Vibes bekommt."
+
+[[emotes]]
+name = "marc_yoyo"
+meaning = "Gelbe Comicfigur mit langen ausgestreckten Gliedmaßen in einer verrenkten Pose."
+usage = "Für slapstickartige Bewegungen, albernes Herumzappeln oder einen chaotischen Auftritt."
+
+[[emotes]]
+name = "MarkFelton"
+meaning = "Mark-Felton-/History-YouTube-Insider."
+usage = "Wenn militärhistorische Fakten, Doku-Vibes oder trockene Geschichtserklärungen auftauchen."
+
+[[emotes]]
+name = "MarkusLanz"
+meaning = "Markus-Lanz-/Talkshow-Meme."
+usage = "Wenn Diskussionen unangenehm nach deutscher Polit-Talkshow, Nachfragen oder Studioernst klingen."
+
+[[emotes]]
+name = "MarshmellowTime"
+meaning = "Marshmallow-/Snackzeit-Emote."
+usage = "Wenn es cozy, süß, lagerfeuerartig oder snacklastig wird."
+
+[[emotes]]
+name = "Marx"
+meaning = "Karl-Marx-/Kommunismus-Meme."
+usage = "Für linke Theorie, Arbeiterwitz, Kapitalismuskritik oder ironische Revolutionsvibes."
+
+[[emotes]]
+name = "Mashallah"
+meaning = "Arabisch geprägter Lob- oder Staunensausdruck."
+usage = "Wenn etwas beeindruckend, gesegnet, schön oder ironisch überhöht wirkt."
+
+[[emotes]]
+name = "Maul"
+meaning = "Derbes 'halt den Mund'-Kurzsignal."
+usage = "Wenn jemand eine Aussage grob abwürgen oder den Chat zum Schweigen memen will."
+
+[[emotes]]
+name = "MaxRebo"
+meaning = "Max-Rebo-/Star-Wars-Band-Insider."
+usage = "Wenn Star-Wars-Musik, Cantina-Vibes oder schräge Alien-Bandenergie passt."
+
+[[emotes]]
+name = "MAXWELL"
+meaning = "Maxwell-the-Cat-Meme."
+usage = "Wenn eine drehende, vibende oder einfach nur ikonische Internetkatze in die Stimmung passt."
+
+[[emotes]]
+name = "MAYO"
+meaning = "Mayonnaise-Meme."
+usage = "Wenn Mayo als Food- oder Channel-Insider passt."
+
+[[emotes]]
+name = "MEGALUL"
+meaning = "Sehr starkes Lachen."
+usage = "Wenn etwas noch größer als normales LUL wirkt."
+
+[[emotes]]
+name = "MEGALULING"
+meaning = "Aktives/anhaltendes extremes Lachen."
+usage = "Wenn der Chat länger über einen Fail oder Joke lacht."
+
+[[emotes]]
+name = "MeinMann"
+meaning = "Zustimmendes 'mein Mann'."
+usage = "Wenn jemand genau das Richtige sagt, einen guten Move macht oder kumpelhaft gefeiert wird."
+
+[[emotes]]
+name = "MEN"
+meaning = "Männer-/Gigachad-artiger Meme-Ruf."
+usage = "Bei männlich codierten, Gym- oder Bro-Momenten."
+
+[[emotes]]
+name = "MENNO"
+meaning = "Genervtes „Menno“-Emote mit Pepe/Ge-Gesicht."
+usage = "Wenn man kindlich-frustriert, enttäuscht oder trotzig reagiert."
+
+[[emotes]]
+name = "meow"
+meaning = "Miau-/Katzenreaktion."
+usage = "Für Katzencontent oder süßes, kurzes Antworten."
+
+[[emotes]]
+name = "meowdy"
+meaning = "Howdy plus Meow."
+usage = "Als Katzen-Cowboy-Begrüßung."
 
 [[emotes]]
 name = "Merz"
 meaning = "Friedrich-Merz-/Politik-Meme."
-usage = "bei Merz oder CDU-Kontext"
+usage = "Bei CDU-/Merz-/deutscher Politik-Referenz."
 
 [[emotes]]
-name = "kokface"
-meaning = "Kok-Face; Channel-Insider."
-usage = "bei lokalem kok-Kontext"
+name = "Mexicaneg"
+meaning = "Mexikanisch angehauchtes ge-Meme."
+usage = "Bei Mexiko-, Taco-, Sombrero- oder Latino-Insidern."
 
 [[emotes]]
-name = "ElNoSabe"
-meaning = "Er weiss es nicht."
-usage = "wenn jemand ahnungslos ist"
+name = "mexicat"
+meaning = "Mexiko-Katze."
+usage = "Für Katzenmomente mit mexikanischem Vibe."
 
 [[emotes]]
-name = "yogurt"
-meaning = "Joghurt."
-usage = "bei Essen/Joghurt-Kontext"
+name = "mhm"
+meaning = "Pixeliges gelbes Gesicht als „mhm“-Bestätigung."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser mhm-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "miamor"
+meaning = "Spanisch angehauchte 'mein Amor'-Zuneigung."
+usage = "Wenn etwas liebevoll, flirtig oder übertrieben süß kommentiert wird."
+
+[[emotes]]
+name = "MitNicoUndDirkZeltenAberInDerNachtStoßenDieGämseSteineVonDerSteilwand"
+meaning = "Extrem spezifischer Camping-/Alpen-Insider mit Gämse-und-Steine-Szenario."
+usage = "Wenn harmlose Outdoor-Idylle in absurd konkretes Bergchaos kippt."
 
 [[emotes]]
 name = "MLADY"
-meaning = "M’lady-Meme."
-usage = "bei neckbeard/hoeflichem Meme-Kontext"
+meaning = "M'lady-/Fedora-Meme."
+usage = "Wenn jemand übertrieben höflich, nerdig oder cringe charmant ist."
 
 [[emotes]]
-name = "Bobbers"
-meaning = "Bobbers; Angeln/Fischen."
-usage = "bei Fishing- oder Bobber-Kontext"
+name = "mlem"
+meaning = "Zunge-raus-/Schleck-Meme."
+usage = "Für süße Tiere, Geschmack oder kleine Derp-Momente."
 
 [[emotes]]
-name = "DAYZ"
-meaning = "Gaming oder bestimmtes Spielthema."
-usage = "wenn es direkt um Gaming oder dieses Spiel geht"
+name = "MmmHmm"
+meaning = "Zustimmendes Hm-hm."
+usage = "Wenn man ruhig bestätigt oder skeptisch nickt."
 
 [[emotes]]
-name = "OldManYellsAtCloud"
-meaning = "Alter Mann schreit Wolke an."
-usage = "bei boomerigem Meckern"
+name = "modCheck"
+meaning = "Nach Mods schauen."
+usage = "Wenn Moderation gefragt ist oder jemand die Mods ruft."
 
 [[emotes]]
-name = "HUH1"
-meaning = "Verwirrung oder Unsicherheit."
-usage = "wenn etwas unklar, seltsam oder schwer einzuordnen ist"
+name = "monakChrist"
+meaning = "Monak-/Christus-Variante."
+usage = "Wenn ein Monak-Meme mit religiöser, erlösender oder dramatischer Pose kombiniert wird."
 
 [[emotes]]
-name = "FLOPPA"
-meaning = "Floppa-Meme."
-usage = "wenn ein Floppa- oder Chad-Floppa-Moment passt"
+name = "monakHmm"
+meaning = "Nachdenkliches oder skeptisches Reaktionsmeme."
+usage = "Wenn der Chat analysiert, zweifelt oder über 'monakHmm' grübelt."
 
 [[emotes]]
-name = "IDontCareIJustWannaSleep"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
+name = "monakNotSure"
+meaning = "Monak-Figur mit unsicherem, zweifelndem Ausdruck."
+usage = "Wenn man etwas nicht ganz glaubt, vorsichtig skeptisch ist oder „ich weiß nicht“ signalisiert."
 
 [[emotes]]
-name = "Maul"
-meaning = "Maul halten / Mund."
-usage = "bei derber Aufforderung oder Mund-Kontext"
+name = "MONKA"
+meaning = "Katzenaugen-/Angstbild als monka-Variante."
+usage = "Für Nervosität, Anspannung oder wenn eine Situation unheimlich wird."
 
 [[emotes]]
-name = "Haram"
-meaning = "Haram; verboten/unrein im Meme-Sinn."
-usage = "bei scherzhaft verbotenem Verhalten"
+name = "monkaClock"
+meaning = "Monka mit Zeitdruck."
+usage = "Wenn eine Deadline, Uhr oder lange Wartezeit stresst."
 
 [[emotes]]
-name = "bup"
-meaning = "Bup; kleiner goofy Ausruf."
-usage = "bei alberner kurzer Reaktion"
+name = "monkaE"
+meaning = "Monka-Variante mit erhöhter Spannung."
+usage = "Wenn etwas suspekt oder gefährlich wirkt."
 
 [[emotes]]
-name = "PissTime"
-meaning = "Kurze Toilettenpause."
-usage = "wenn jemand kurz aufs Klo muss oder eine Pause macht"
+name = "monkaFly"
+meaning = "Fliegendes Monka."
+usage = "Wenn Panik wortwörtlich abhebt oder jemand wegfliegt."
 
 [[emotes]]
-name = "peepoFingerLeave"
-meaning = "Verabschiedung oder Weggehen."
-usage = "wenn jemand geht, offline geht oder gute Nacht sagt"
+name = "monkaLaugh"
+meaning = "Nervöses Monka-Lachen."
+usage = "Wenn man in Angst oder Awkwardness lacht."
 
 [[emotes]]
 name = "monkaPTSD"
-meaning = "Nervositaet, Angst oder Alarmstimmung."
-usage = "wenn etwas knapp, riskant oder angespannt ist"
+meaning = "Trauma-/Flashback-Monka."
+usage = "Wenn etwas schlechte Erinnerungen an frühere Fails weckt."
 
 [[emotes]]
-name = "ratdance"
-meaning = "Musik, Tanz oder Jam."
-usage = "wenn Musik laeuft, etwas groovt oder Party-Stimmung entsteht"
+name = "monkaSTEER"
+meaning = "Lenk-/Fahr-Monka."
+usage = "Bei heiklem Fahren, Racing oder Steuerungsangst."
 
 [[emotes]]
-name = "ARDA"
-meaning = "Arda-Name/Insider."
-usage = "bei Arda-Kontext"
+name = "monkaTracklimits"
+meaning = "Tracklimits-Angst im Racing-Kontext."
+usage = "Wenn F1/Simracing-Strafen oder Kurvenlimits drohen."
 
 [[emotes]]
-name = "jabadabadu"
-meaning = "Jabadabadu; freudiger Ausruf."
-usage = "bei alberner Freude"
+name = "monkaTriggered"
+meaning = "Getriggertes Monka."
+usage = "Wenn Stress oder Reizüberflutung hochgeht."
 
 [[emotes]]
-name = "UM"
-meaning = "Um; Filler/Zoegern."
-usage = "bei unsicherem Ueberlegen"
+name = "monkaW"
+meaning = "Breites, intensives Angst-Meme."
+usage = "Wenn normale Nervosität nicht ausreicht."
 
 [[emotes]]
-name = "LIFTOFF"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
+name = "monkaX"
+meaning = "Extreme Monka-Angst."
+usage = "Bei maximal brenzligen oder katastrophalen Situationen."
 
 [[emotes]]
-name = "BOOMIES"
-meaning = "Boom/Explosionen."
-usage = "bei lauten Impact- oder Explosionsmomenten"
+name = "MONKE"
+meaning = "Affe/Monkey-Meme."
+usage = "Wenn primitive Instinkte, Chaos oder Affenhumor passen."
 
 [[emotes]]
-name = "eepy"
-meaning = "Muede, schlaefrig oder Zeit fuers Bett."
-usage = "bei Muedigkeit, spaeter Uhrzeit oder sleepy Stimmung"
+name = "MONKEPUTIN"
+meaning = "Politisches Putin-/Monkey-Meme."
+usage = "Bei politisch-satirischen Putin- oder Russland-Memes; nicht als neutrale Aussage verwenden."
 
 [[emotes]]
-name = "oh"
-meaning = "Traurigkeit, Enttaeuschung oder Verzweiflung."
-usage = "bei Pech, kleinen Rueckschlaegen oder traurigen Chat-Momenten"
+name = "monkeSpin"
+meaning = "Drehender Affe."
+usage = "Für Musik, Hypnose, Chaos oder rotierendes Monkey-Verhalten."
 
 [[emotes]]
-name = "RAHHH"
-meaning = "Hype, Freude oder starke positive Ueberraschung."
-usage = "bei guten News, Plays, Erfolgen oder Vorfreude"
+name = "Moodge"
+meaning = "Stimmungs-/Mood-Meme."
+usage = "Wenn ein Emote exakt die aktuelle Laune trifft."
 
 [[emotes]]
-name = "cokebert"
-meaning = "Cokebert-Drogenmeme; ueberdrehter Bert-Moment."
-usage = "wenn jemand hektisch, aufgekratzt oder viel zu wach wirkt"
+name = "Moodwokege"
+meaning = "Mood-/Wokege-Variante: bewusst, melancholisch und leicht resigniert."
+usage = "Wenn ein Realitätscheck die Stimmung trifft oder ein Take schmerzhaft wahr ist."
 
 [[emotes]]
-name = "WennTristenInSizilienAnkommt"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
+name = "MoomTime"
+meaning = "Moom-Zeit-/Personeninsider."
+usage = "Wenn der Moment offiziell nach Moom ruft oder Moom im Chatkontext Thema wird."
 
 [[emotes]]
-name = "fentbert"
-meaning = "Fentbert-Drogenmeme; benommener Bert-Moment."
-usage = "wenn jemand komplett weggetreten oder kaputt wirkt"
+name = "MoomTime2"
+meaning = "Zweite Variante von MoomTime."
+usage = "Wenn der Moom-Moment erneut, stärker oder in einer anderen Stimmung auftritt."
 
 [[emotes]]
-name = "dogkok"
-meaning = "Hund/Doge-Meme."
-usage = "wenn Hund, Doge oder niedlicher Hundemoment passt"
+name = "MOURINHO"
+meaning = "José-Mourinho-Meme."
+usage = "Wenn man taktisch, salzig oder dramatisch schweigt."
 
 [[emotes]]
 name = "muh"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
+meaning = "Kuhlaut/Muh."
+usage = "Für Kuh-, Farm- oder Milch-Momente."
 
 [[emotes]]
-name = "auh"
-meaning = "Katzen-Meme oder Cat-Reaktion."
-usage = "wenn Katzen oder cat-artige Stimmung passt"
+name = "Muhammeg"
+meaning = "Muhammad-/Egg-Wortspiel-Insider."
+usage = "Kontextsensibel verwenden; nicht respektlos gegen Religion oder Personen einsetzen."
+
+[[emotes]]
+name = "MussEinfachNurSchmieden"
+meaning = "Schmiede-/Crafting-Aufgabenmeme."
+usage = "Wenn jemand nur noch stupide schmieden, craften oder grinden muss."
+
+[[emotes]]
+name = "MyExistenceIsNothingButAGrainOfSandComparedToTheEntireScaleOfTheUniverse"
+meaning = "Existenzielle Nichtigkeits-/Kosmos-Überwältigung als langes Meme."
+usage = "Wenn ein Moment so groß, leer oder philosophisch wirkt, dass man sich winzig fühlt."
+
+[[emotes]]
+name = "MyHonestReaction"
+meaning = "Meine ehrliche Reaktion."
+usage = "Wenn ein Bild stellvertretend für die eigene Reaktion steht."
+
+[[emotes]]
+name = "Nerdga"
+meaning = "Nerdge-/Nerd-Variante."
+usage = "Wenn jemand klugscheißt, Fakten droppt oder sehr nerdig auftritt."
+
+[[emotes]]
+name = "Nerdge"
+meaning = "Nerd-Meme-Gesicht."
+usage = "Wenn jemand sehr nerdig, pedantisch oder technisch wird."
+
+[[emotes]]
+name = "NerdRadar"
+meaning = "Radar für Nerdigkeit."
+usage = "Wenn ein Nerd-Moment erkannt oder getrackt wird."
+
+[[emotes]]
+name = "Nessie"
+meaning = "Loch-Ness-/Nessie-Meme."
+usage = "Für mysteriöse, seltene oder monsterhafte Vibes."
+
+[[emotes]]
+name = "NessieParty"
+meaning = "Feiernde Nessie."
+usage = "Bei Party oder Hype mit Nessie-Insider."
+
+[[emotes]]
+name = "nh"
+meaning = "Knappe deutsche Umgangssprachen-Partikel 'ne/nh'."
+usage = "Als kleines Anhängsel, wenn ein Satz frech, beiläufig oder jugendlich klingen soll."
+
+[[emotes]]
+name = "Nilstime"
+meaning = "Pepe/Frosch an einem kleinen Tisch oder mit Gegenstand, als würde er warten oder arbeiten."
+usage = "Für Warte-, Arbeits- oder Routine-Momente, wenn jemand geduldig seine Zeit absitzt."
+
+[[emotes]]
+name = "NilsWennErMorgenInDenChatKommtUndRealisiertDassSeineGanzenLieblingsEmotesRausSind"
+meaning = "Nils-reagiert-auf-gelöschte-Lieblingsemotes-Insider."
+usage = "Wenn Emotes verschwinden, Set-Änderungen wehtun oder jemand morgen einen Schock bekommt."
+
+[[emotes]]
+name = "NoBitches"
+meaning = "Meme über soziale oder romantische Erfolglosigkeit."
+usage = "Wenn jemand ironisch als einsam, chancenlos oder ohne Rizz dargestellt wird; nicht verletzend gegen reale Personen nutzen."
+
+[[emotes]]
+name = "nocap"
+meaning = "'No cap' = kein Witz/keine Lüge."
+usage = "Wenn eine Aussage ernst gemeint ist oder betont wahr wirkt."
+
+[[emotes]]
+name = "NODDERS"
+meaning = "Starkes zustimmendes Nicken."
+usage = "Wenn der Chat geschlossen zustimmt."
+
+[[emotes]]
+name = "NODFEST"
+meaning = "Nicken als Festival."
+usage = "Wenn sehr viele Leute zustimmen oder rhythmisch nicken."
+
+[[emotes]]
+name = "NOIDONTTHINKSO"
+meaning = "Nein, glaube ich nicht."
+usage = "Für trockenen Widerspruch oder skeptisches Ablehnen."
+
+[[emotes]]
+name = "nom"
+meaning = "Ess-/Knabber- oder „nom nom“-Reaktion."
+usage = "Wenn etwas gefressen, probiert, verschlungen oder niedlich angeknabbert wird."
+
+[[emotes]]
+name = "NOOO"
+meaning = "Dramatischer Nein-Schrei."
+usage = "Wenn etwas Schlimmes passiert oder Hoffnung zerbricht."
+
+[[emotes]]
+name = "Noot"
+meaning = "Pinguin-/„noot noot“-Meme mit kleinem Schnabel/Alarmvibe."
+usage = "Für kurze Pinguinlaute, Warnpings oder alberne Noot-Reaktionen."
+
+[[emotes]]
+name = "NOPERS"
+meaning = "Klares Nein/Nope."
+usage = "Wenn etwas abgelehnt wird oder man raus ist."
+
+[[emotes]]
+name = "NoseTime"
+meaning = "Pixelige Nase-/Linienanimation mit rotem Akzent."
+usage = "Wenn ein Nasen-, Schnüffel- oder „Zeit dafür“-Insider passt."
+
+[[emotes]]
+name = "NotALOO"
+meaning = "Nicht ALOO."
+usage = "Wenn ein ALOO-Insider verneint oder kontrastiert wird."
+
+[[emotes]]
+name = "NOTED"
+meaning = "Notiert."
+usage = "Wenn man sich etwas merkt oder jemandem eine Aussage später vorhalten will."
+
+[[emotes]]
+name = "notee"
+meaning = "Kleine Noted-Variante."
+usage = "Für beiläufiges Festhalten von Informationen."
+
+[[emotes]]
+name = "nothingeverhappens"
+meaning = "Meme-Bild mit Texttafel im Stil „nothing ever happens“."
+usage = "Wenn jemand Ereignisse kleinredet oder behauptet, dass sowieso nichts passiert."
+
+[[emotes]]
+name = "NotLikeDuck"
+meaning = "NotLikeThis als Enten-Variante."
+usage = "Wenn ein Entenmoment unangenehm oder tragisch wird."
+
+[[emotes]]
+name = "notListening"
+meaning = "Nicht zuhören."
+usage = "Wenn jemand absichtlich ignoriert oder komplett abgelenkt ist."
+
+[[emotes]]
+name = "NotSure"
+meaning = "Unsichere Reaktion."
+usage = "Wenn man zweifelt oder eine Aussage nicht einordnen kann."
+
+[[emotes]]
+name = "NOTSUSSY"
+meaning = "Kopf-/Gesichtsbild als „not sussy“-Gegenreaktion."
+usage = "Wenn etwas verdächtig wirkt, aber ironisch als überhaupt nicht sus verteidigt wird."
+
+[[emotes]]
+name = "NOWAYING"
+meaning = "Bildreaktion für starkes „no way“."
+usage = "Wenn etwas absurd, kaum glaubwürdig oder komplett überraschend ist."
+
+[[emotes]]
+name = "Nowoted"
+meaning = "„Noted“-Variante mit Schleife: jetzt notiert/anerkannt."
+usage = "Wenn etwas demonstrativ zur Kenntnis genommen, aber cute oder ironisch abgehakt wird."
+
+[[emotes]]
+name = "NukeMoscow"
+meaning = "Extrem überzeichneter Kriegs-/Nuklear-Insider mit weißer Figur im Bild."
+usage = "Nicht als Gewaltaufforderung nutzen; nur als problematische Chat-Hyperbel erkennen."
+
+[[emotes]]
+name = "Nyehehehe"
+meaning = "Schelmisches Bösewicht-Kichern."
+usage = "Wenn jemand trollt, einen Plan ausheckt oder cartoonhaft gemein lacht."
+
+[[emotes]]
+name = "nymnCC"
+meaning = "NymN-/CC-Insider mit grünem Pepe/Charakter im Bild."
+usage = "Für NymN-Chatkultur, Copycat-/CC-Referenzen oder wenn genau dieser Community-Code passt."
+
+[[emotes]]
+name = "o7"
+meaning = "Salute/Salutieren."
+usage = "Als respektvoller Abschied, Gruß oder Ehrenbekundung."
+
+[[emotes]]
+name = "oda"
+meaning = "Sehr kleines weißes Tier oder katzenartiger Kopf auf dunklem Hintergrund."
+usage = "Für winzige, kaum sichtbare Reaktionen oder wenn jemand nur minimal auftaucht."
+
+[[emotes]]
+name = "oh"
+meaning = "Robben-/Tier-Nahaufnahme als kurzes „oh“."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser oh-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "OK"
+meaning = "Neutrales Okay."
+usage = "Wenn man etwas akzeptiert, abhakt oder trocken bestätigt."
+
+[[emotes]]
+name = "OkayChamp"
+meaning = "Okay-Champ-Reaktion."
+usage = "Wenn man freundlich, aber leicht ironisch zustimmt."
+
+[[emotes]]
+name = "Okayegg"
+meaning = "Okay als Egg-Meme."
+usage = "Wenn ein Ei-/Eg-Insider trocken zustimmt."
+
+[[emotes]]
+name = "Okayge"
+meaning = "Okayge ist ein ruhiges Zustimmungs-/Akzeptanzemote."
+usage = "Wenn etwas in Ordnung ist oder man sich fügt."
+
+[[emotes]]
+name = "Okayge7"
+meaning = "Okayge mit Salut."
+usage = "Wenn man akzeptiert und respektvoll abnickt."
+
+[[emotes]]
+name = "OkaygeL"
+meaning = "Okayge mit L-/Loss-Färbung."
+usage = "Wenn man eine Niederlage still akzeptiert."
+
+[[emotes]]
+name = "okge"
+meaning = "Okayge-Variante: neutrales, leicht müdes Abnicken."
+usage = "Wenn man etwas akzeptiert, ohne große Begeisterung, oder trocken „ok“ signalisiert."
+
+[[emotes]]
+name = "okjj"
+meaning = "Schlichter grüner Froschkopf mit neutralem, leicht zufriedenen Gesicht."
+usage = "Für knappes Okay, zurückhaltende Zustimmung oder eine kleine entspannte Reaktion."
+
+[[emotes]]
+name = "okurwa"
+meaning = "Polnisch gefärbte Okay-/Fluchreaktion."
+usage = "Wenn man etwas akzeptiert, aber gleichzeitig genervt, überrascht oder „o kurwa“ denkt."
+
+[[emotes]]
+name = "Oldge"
+meaning = "Altfühl-Meme."
+usage = "Wenn Nostalgie, Alter oder veraltete Referenzen auftauchen."
+
+[[emotes]]
+name = "OldManYellsAtCloud"
+meaning = "Simpsons-Meme: Alter Mann schreit Wolke an."
+usage = "Wenn jemand sinnlos über moderne Dinge meckert."
+
+[[emotes]]
+name = "oleg"
+meaning = "Tanzende oder posierende Person im weißen Oberteil, freigestellt vor transparentem Hintergrund."
+usage = "Für spontane Tanz-, Bewegungs- oder Auftrittsmomente mit leicht absurder Energie."
+
+[[emotes]]
+name = "OlesDailyRageWegenDenBubenInCS"
+meaning = "Wütendes oder salziges Reaktionsmeme."
+usage = "Wenn Frust, Tilt oder Ärger eskaliert und 'OlesDailyRageWegenDenBubenInCS' als Ausdruck passt."
+
+[[emotes]]
+name = "OlesWeeklyValorantMeltdownRant"
+meaning = "Oles wöchentlicher Valorant-Wutanfall."
+usage = "Wenn Valorant wieder tiltend wird und Ole erwartbar in eine lange Beschwerde kippt."
+
+[[emotes]]
+name = "OM"
+meaning = "Meditatives Om."
+usage = "Für Ruhe, Geduld, Zen oder ironische Entspannung."
+
+[[emotes]]
+name = "omE"
+meaning = "OmE-/OMEGA-ähnliche kleine Reaktionsform."
+usage = "Wenn ein Moment größer als normal, aber noch nicht komplett OMEGALUL ist."
+
+[[emotes]]
+name = "OMEGALUL"
+meaning = "Extremes Lachen über etwas Lächerliches."
+usage = "Wenn ein Fail, Witz oder absurder Moment maximal lustig ist."
+
+[[emotes]]
+name = "OMEGALULiguess"
+meaning = "OMEGALUL mit 'glaube ich'-Unsicherheit."
+usage = "Wenn etwas lustig ist, aber die Reaktion halb ironisch bleibt."
+
+[[emotes]]
+name = "Omege"
+meaning = "Omega-/ge-Lach- oder Reaktionsvariante."
+usage = "Für große, aber nicht eindeutig definierte Meme-Reaktionen."
+
+[[emotes]]
+name = "omgHi"
+meaning = "Überraschte Begrüßung."
+usage = "Wenn jemand unerwartet auftaucht und man freundlich überrascht ist."
+
+[[emotes]]
+name = "Overcope"
+meaning = "Maximal übertriebenes Copium im Bett-/Krankenbett-Stil."
+usage = "Wenn jemand sich mit Ausreden zudeckt oder Realitätsverweigerung viel zu weit treibt."
+
+[[emotes]]
+name = "owo7"
+meaning = "OwO plus Salut."
+usage = "Für niedliche, respektvolle oder animehafte Grüße."
+
+[[emotes]]
+name = "owoshy"
+meaning = "Schüchternes OwO."
+usage = "Wenn etwas niedlich, verlegen oder soft wirkt."
+
+[[emotes]]
+name = "owoslay"
+meaning = "OwO plus Slay."
+usage = "Wenn jemand süß und selbstbewusst liefert."
+
+[[emotes]]
+name = "owoWiggle"
+meaning = "Wackelndes OwO."
+usage = "Für niedliche Bewegung, Hype oder kleine Tanzmomente."
+
+[[emotes]]
+name = "P1"
+meaning = "P1-/Racing- oder Platz-1-Insider mit Personenfigur."
+usage = "Für Sieg, Pole Position, erster Platz oder F1-/Racing-Kontext."
+
+[[emotes]]
+name = "Paaag"
+meaning = "Pag-/Pog-Hypevariante."
+usage = "Wenn etwas spannend, stark oder überraschend gut ist."
+
+[[emotes]]
+name = "Pag"
+meaning = "Pog/Pag-Hype."
+usage = "Für beeindruckende, knappe oder aufregende Momente."
+
+[[emotes]]
+name = "PagChomp"
+meaning = "Aufgeregter Hype mit Chomp-Energie."
+usage = "Wenn etwas spannend und gleichzeitig chaotisch ist."
+
+[[emotes]]
+name = "Painsge"
+meaning = "Schmerz-/Pain-Meme."
+usage = "Wenn ein Moment weh tut, cringe ist oder Pech schmerzt."
+
+[[emotes]]
+name = "PartyAnimals"
+meaning = "Feiernde Tiere."
+usage = "Für Party, Chaos oder Gruppenhype."
+
+[[emotes]]
+name = "PartyPls"
+meaning = "Party-/Tanz-Meme."
+usage = "Wenn Musik läuft oder der Chat feiern soll."
+
+[[emotes]]
+name = "pastry"
+meaning = "Gebäck-/Pastry-Emote."
+usage = "Für Croissants, süße Snacks, Bäckerei-Vibes oder kleine kulinarische Pausen."
+
+[[emotes]]
+name = "PauseChamp"
+meaning = "Anspannung/kurze Pause vor der Auflösung."
+usage = "Wenn man auf eine Entscheidung, Enthüllung oder Wendung wartet."
+
+[[emotes]]
+name = "PauseChamps"
+meaning = "Mehrere/erweiterte PauseChamp-Stimmung."
+usage = "Bei kollektivem, angespanntem Warten."
+
+[[emotes]]
+name = "PauseElefant"
+meaning = "Elefanten-Variante von PauseChamp."
+usage = "Wenn man groß und geduldig auf einen Moment wartet."
+
+[[emotes]]
+name = "PausersHype"
+meaning = "Hype- oder Begeisterungs-Emote."
+usage = "Wenn etwas stark, spannend oder positiv überraschend ist und 'PausersHype' dazu passt."
+
+[[emotes]]
+name = "Peace"
+meaning = "Friedens-/Peace-Zeichen."
+usage = "Für entspannte Zustimmung, Abschied oder Deeskalation."
+
+[[emotes]]
+name = "pedro"
+meaning = "Pedro-/Waschbär-Party-Meme."
+usage = "Wenn ein drehender, niedlicher Partyvibe oder viraler Pedro-Moment passt."
+
+[[emotes]]
+name = "PeepiBlush"
+meaning = "Erröteter Peepo."
+usage = "Wenn etwas süß, peinlich oder liebenswert ist."
+
+[[emotes]]
+name = "peepoAachen"
+meaning = "Peepo mit Aachen-/Stadtbezug."
+usage = "Für Aachen-Witze, lokale Referenzen oder wenn die Stadt im Chat Thema ist."
+
+[[emotes]]
+name = "peepoAntifa"
+meaning = "Peepo mit Antifa- bzw. politischem Symbolbezug."
+usage = "Für politische Chatmomente; kontextsensibel und nicht als Angriff gegen Personen verwenden."
+
+[[emotes]]
+name = "peepoArrive"
+meaning = "Peepo kommt an."
+usage = "Zur Begrüßung oder wenn jemand dem Chat beitritt."
+
+[[emotes]]
+name = "peepoAustralia"
+meaning = "Peepo mit Australienflagge/-Bezug."
+usage = "Für Australien, Down-Under-Witze, Akzent- oder Länderreferenzen."
+
+[[emotes]]
+name = "PeepoBerlin"
+meaning = "Peepo mit Berlin-Bezug."
+usage = "Bei Berlin-, Deutschland- oder Hauptstadt-Insidern."
+
+[[emotes]]
+name = "peepoBike"
+meaning = "Peepo fährt Fahrrad."
+usage = "Für Radfahren, Bewegung oder losfahren."
+
+[[emotes]]
+name = "peepoCCP"
+meaning = "Peepo mit CCP-/China-Bezug."
+usage = "Bei politischen China- oder Social-Credit-Memes; nicht für pauschale Abwertung realer Gruppen nutzen."
+
+[[emotes]]
+name = "peepoCheer"
+meaning = "Peepo feuert an."
+usage = "Wenn jemand Support, Jubel oder Motivation braucht."
+
+[[emotes]]
+name = "peepoCoffee"
+meaning = "Peepo mit Kaffee."
+usage = "Für Morgen, Fokus oder Koffeinpausen."
+
+[[emotes]]
+name = "peepoConfused"
+meaning = "Verwirrter Peepo."
+usage = "Wenn etwas schwer verständlich oder unlogisch ist."
+
+[[emotes]]
+name = "peepoCookie"
+meaning = "Peepo mit Keks."
+usage = "Für Snacks, Belohnungen oder süße Momente."
+
+[[emotes]]
+name = "peepoDJ"
+meaning = "Peepo als DJ."
+usage = "Wenn Musik aufgelegt wird oder der Beat übernimmt."
+
+[[emotes]]
+name = "peepoDyingFromToxicFumesReleasedFromASpraypaintCanBecauseHeWasNotWearingAMask"
+meaning = "Peepo mit Spraydosen-/Giftgase-/Sicherheitsinsider."
+usage = "Wenn jemand riskant bastelt, keine Maske trägt oder ein Safety-Fail übertrieben kommentiert wird."
+
+[[emotes]]
+name = "peepoEggs"
+meaning = "Peepo mit Eiern."
+usage = "Für Frühstück, Egg-Insider oder absurde Food-Momente."
+
+[[emotes]]
+name = "peepoEngland"
+meaning = "Peepo mit England-/St.-George-Bezug."
+usage = "Für England, Fußball, UK-Witze oder Länderreferenzen."
+
+[[emotes]]
+name = "peepoExplosion"
+meaning = "Explodierender Peepo."
+usage = "Wenn etwas komplett eskaliert oder eine Reaktion explodiert."
+
+[[emotes]]
+name = "peepoEyeroll"
+meaning = "Peepo rollt mit den Augen."
+usage = "Wenn etwas nervig, dumm oder vorhersehbar ist."
+
+[[emotes]]
+name = "PeepoFarmerRiot"
+meaning = "Peepo als Bauernprotest."
+usage = "Bei Farm-, Politik- oder Protest-Insidern."
+
+[[emotes]]
+name = "peepoFeet"
+meaning = "Peepo mit Fuß-/Hand-Motiv; wirkt wie ein spezieller Feet-Insider."
+usage = "Nur bei entsprechendem Insiderkontext; für neutrale Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "peepoFine"
+meaning = "Peepo sagt, alles sei okay."
+usage = "Wenn offensichtlich nichts okay ist, aber man es überspielt."
+
+[[emotes]]
+name = "peepoFingerLeave"
+meaning = "Peepo zeigt mit dem Finger raus bzw. fordert zum Gehen auf."
+usage = "Wenn jemand die Szene verlassen soll oder ein Take aus dem Chat „rausgezeigt“ wird."
+
+[[emotes]]
+name = "peepoFrance"
+meaning = "Peepo mit Frankreich-Bezug."
+usage = "Bei Frankreich-, Baguette-, Streik- oder Nationenwitzen."
+
+[[emotes]]
+name = "peepoGiggle"
+meaning = "Kichernder Peepo."
+usage = "Für leises, süßes oder schadenfrohes Kichern."
+
+[[emotes]]
+name = "peepoGoodNight"
+meaning = "Peepo sagt gute Nacht."
+usage = "Zum Verabschieden vor dem Schlafen."
+
+[[emotes]]
+name = "peepoGrüne"
+meaning = "Peepo mit Grünen-/Politikbezug."
+usage = "Bei deutschen Politik-Insidern rund um die Grünen."
+
+[[emotes]]
+name = "PeepoHappyLeave"
+meaning = "Glücklicher Peepo verlässt die Szene."
+usage = "Wenn man zufrieden geht oder ein positiver Exit passiert."
+
+[[emotes]]
+name = "peepoHey"
+meaning = "Freundlicher Peepo-Gruß."
+usage = "Als niedliche Begrüßung im Chat."
+
+[[emotes]]
+name = "peepoIgnore"
+meaning = "Peepo ignoriert etwas."
+usage = "Wenn man eine Aussage bewusst übergeht."
+
+[[emotes]]
+name = "peepoKaiserslautern"
+meaning = "Peepo mit Kaiserslautern-/FCK-Bezug."
+usage = "Für Kaiserslautern, Fußball oder lokale Pfalz-Referenzen."
+
+[[emotes]]
+name = "peepoLeave"
+meaning = "Peepo geht weg."
+usage = "Zum Abschied oder wenn man sich entzieht."
+
+[[emotes]]
+name = "peepoLost"
+meaning = "Verlorener Peepo."
+usage = "Wenn jemand orientierungslos oder mental lost ist."
+
+[[emotes]]
+name = "peepoMayo"
+meaning = "Peepo mit Mayo-Bezug."
+usage = "Für Mayonnaise- oder Food-Insider."
+
+[[emotes]]
+name = "peepoMcLaren"
+meaning = "Peepo mit McLaren-/F1-Bezug."
+usage = "Bei Formel-1-, McLaren- oder Rennmomenten."
+
+[[emotes]]
+name = "peepoMonster"
+meaning = "Peepo mit Monster-/Energy-Drink-Bezug."
+usage = "Für Energy, Wachheit oder Koffein-Hype."
+
+[[emotes]]
+name = "peepoNATO"
+meaning = "Peepo mit NATO-Bezug."
+usage = "Bei Geopolitik-/NATO-Insidern; kontextsensibel nutzen."
+
+[[emotes]]
+name = "peepoNetherlands"
+meaning = "Peepo mit Niederlande-Bezug."
+usage = "Bei Holland-, Oranje- oder Nationenwitzen."
+
+[[emotes]]
+name = "peepoPlant"
+meaning = "Peepo mit Pflanze."
+usage = "Für Pflanzen, Wachstum, Gras oder ruhige Vibes."
+
+[[emotes]]
+name = "peepoPonderingEternity"
+meaning = "Peepo denkt über die Ewigkeit nach."
+usage = "Wenn eine Frage philosophisch, endlos oder existenziell wird."
+
+[[emotes]]
+name = "peepoPooRocket"
+meaning = "Peepo auf/bei Toiletten- oder Poop-Raketen-Motiv."
+usage = "Bei derbem Toilettenhumor oder absurdem Raketen-/Abflugwitz."
+
+[[emotes]]
+name = "peepoPride"
+meaning = "Peepo mit Pride-Bezug."
+usage = "Für Pride, Support oder LGBTQ+-positive Momente."
+
+[[emotes]]
+name = "peepoRant"
+meaning = "Peepo rantet."
+usage = "Wenn jemand ausschweifend schimpft oder sich reinsteigert."
+
+[[emotes]]
+name = "peepoRun"
+meaning = "Rennender Peepo."
+usage = "Wenn jemand losläuft, flieht oder schnell handeln muss."
+
+[[emotes]]
+name = "PeepoSad"
+meaning = "Trauriger Peepo."
+usage = "Wenn etwas schade, niederschmetternd oder emotional ist."
+
+[[emotes]]
+name = "peepoShy"
+meaning = "Schüchterner Peepo."
+usage = "Wenn man verlegen, vorsichtig oder soft reagiert."
+
+[[emotes]]
+name = "peepoSick"
+meaning = "Kranker Peepo."
+usage = "Wenn jemand krank ist oder etwas widerlich wirkt."
+
+[[emotes]]
+name = "peepoSigh"
+meaning = "Seufzender Peepo."
+usage = "Bei Resignation, Enttäuschung oder Müdigkeit."
+
+[[emotes]]
+name = "peepoSip"
+meaning = "Peepo trinkt/sippt."
+usage = "Wenn man Tee/Kaffee sippt und Drama beobachtet."
+
+[[emotes]]
+name = "peepoSlam"
+meaning = "Peepo schlägt auf den Tisch."
+usage = "Für Wut, Nachdruck oder dramatische Reaktionen."
+
+[[emotes]]
+name = "peepoSpace"
+meaning = "Peepo im Weltraum."
+usage = "Für Space-, Sci-Fi- oder abgehobene Momente."
+
+[[emotes]]
+name = "peepoSpeziSpin"
+meaning = "Peepo mit Spezi-Flasche, vermutlich drehend/spinnend."
+usage = "Für Spezi-Hype, Getränkezeit oder wenn der Chat mit Spezi-Energie rotiert."
+
+[[emotes]]
+name = "peepoSpit"
+meaning = "Peepo spuckt aus."
+usage = "Bei Schock, Ekel oder wenn etwas zu wild ist."
+
+[[emotes]]
+name = "peepoStrong"
+meaning = "Starker Peepo."
+usage = "Für Kraft, Gym, Motivation oder Durchhaltewillen."
+
+[[emotes]]
+name = "peepoStuttgart"
+meaning = "Peepo mit Stuttgart-/VfB- oder Stadtbezug."
+usage = "Für Stuttgart, Fußball oder lokale Schwaben-Referenzen."
+
+[[emotes]]
+name = "peepoSwim"
+meaning = "Schwimmender Peepo."
+usage = "Bei Wasser, Sommer, Schwimmen oder Untergehen."
+
+[[emotes]]
+name = "peepoTalk"
+meaning = "Redender Peepo."
+usage = "Wenn jemand spricht, erklärt oder der Chat diskutiert."
+
+[[emotes]]
+name = "peepotalkButPeepoIsNotTalkingButInsteadIsOkay"
+meaning = "PeepoTalk-Variante, bei der Peepo nicht spricht, sondern okay wirkt."
+usage = "Wenn ein erwarteter Rant ausbleibt und stattdessen nur stille Zustimmung oder Akzeptanz kommt."
+
+[[emotes]]
+name = "peepoTalkR"
+meaning = "Redender Peepo nach rechts/Variante."
+usage = "Zum Kombinieren in Chat-Kompositionen oder Dialogen."
+
+[[emotes]]
+name = "peepoTinfoil"
+meaning = "Peepo mit Alufolie/Verschwörungsvibe."
+usage = "Wenn jemand wilde Theorien aufstellt."
+
+[[emotes]]
+name = "peepoUK"
+meaning = "Peepo mit UK-Bezug."
+usage = "Bei britischen Witzen, Tee oder UK-Themen."
+
+[[emotes]]
+name = "peepoVanish"
+meaning = "Peepo verschwindet."
+usage = "Wenn jemand sich aus dem Chat zurückzieht oder ein Thema verpufft."
+
+[[emotes]]
+name = "peepoYELLING"
+meaning = "Schreiender Peepo."
+usage = "Wenn laut protestiert, gerufen oder überreagiert wird."
+
+[[emotes]]
+name = "pepeAgony"
+meaning = "Pepe in Qual."
+usage = "Wenn ein Moment seelisch oder spielerisch weh tut."
+
+[[emotes]]
+name = "pepeCD"
+meaning = "Pepe mit CD-/Cheat-Insider."
+usage = "Wenn jemand verdächtig gut spielt oder Cheat-Witze laufen."
+
+[[emotes]]
+name = "pepeD"
+meaning = "Pepe-Tanz-/Musikmeme."
+usage = "Bei Musik, Rhythmus oder lockerer Party."
+
+[[emotes]]
+name = "PepegaDriving"
+meaning = "Pepega fährt Auto."
+usage = "Bei schlechter Fahrweise, Racing-Fails oder Lenkradchaos."
+
+[[emotes]]
+name = "Pepege"
+meaning = "Pepe-/ge-Variante."
+usage = "Als generische Pepe-Reaktion im 7TV-Stil."
+
+[[emotes]]
+name = "PepeGiggle"
+meaning = "Kichernder Pepe."
+usage = "Für leises Lachen, Schadenfreude oder schelmische Witze."
+
+[[emotes]]
+name = "pepeJAM"
+meaning = "Pepe jammt zu Musik."
+usage = "Wenn ein Beat läuft und der Chat mitgeht."
+
+[[emotes]]
+name = "pepeJAMMER"
+meaning = "Intensiver jammender Pepe."
+usage = "Bei besonders guter Musik oder dauerndem Jam-Spam."
+
+[[emotes]]
+name = "PepeLa"
+meaning = "PepeLa-/Lalala-Meme."
+usage = "Wenn gesungen, geträllert oder Musik ignoriert wird."
+
+[[emotes]]
+name = "pepeMeltdown"
+meaning = "Pepe hat einen Meltdown."
+usage = "Wenn jemand mental zerbricht oder komplett tiltet."
+
+[[emotes]]
+name = "pepeP"
+meaning = "Pepe-Musik-/Tanzvariante."
+usage = "Für Rhythmus, Singen oder leichten Hype."
+
+[[emotes]]
+name = "pepePalpatine"
+meaning = "Pepe als dunkle Palpatine-/Sith-Anspielung."
+usage = "Für böse Pläne, dunkle Energie, Macht-Blitze oder Star-Wars-Schurkenvibes im Meme-Sinn."
+
+[[emotes]]
+name = "pepePoint"
+meaning = "Zeigender Pepe."
+usage = "Wenn auf etwas hingewiesen oder jemand ausgelacht wird."
+
+[[emotes]]
+name = "pepeW"
+meaning = "Breite/angespannte Pepe-W-Variante mit skeptischem oder nervösem Blick."
+usage = "Wenn etwas unangenehm, gespannt oder fragwürdig wirkt und man nur seitlich starren kann."
+
+[[emotes]]
+name = "PERHAPS"
+meaning = "Vielleicht."
+usage = "Wenn man sich elegant oder ironisch nicht festlegen will."
+
+[[emotes]]
+name = "PETTHEDOGEGE"
+meaning = "Streichel den Dogege."
+usage = "Wenn ein Hund süß ist oder Trost braucht."
+
+[[emotes]]
+name = "PETTHEPEEPO"
+meaning = "Streichel den Peepo."
+usage = "Für Zuneigung, Trost oder niedliche Peepo-Momente."
+
+[[emotes]]
+name = "PHEW"
+meaning = "Erleichtertes Durchatmen."
+usage = "Wenn etwas knapp gut ausgegangen ist."
+
+[[emotes]]
+name = "PhonegeAddict"
+meaning = "Handyabhängigkeits-Meme."
+usage = "Wenn jemand ständig aufs Telefon schaut."
+
+[[emotes]]
+name = "PhonegeSleepy"
+meaning = "Müde mit Handy."
+usage = "Wenn man spät nachts noch scrollt."
+
+[[emotes]]
+name = "PIASTRI"
+meaning = "Oscar-Piastri-/F1-Bezug."
+usage = "Bei McLaren, F1-Rookies oder Piastri-Momenten."
+
+[[emotes]]
+name = "Pidser"
+meaning = "Pizza-/Pidser-Verballhornung."
+usage = "Wenn Pizza, Snackhunger oder falsch ausgesprochene Essenswünsche Thema sind."
+
+[[emotes]]
+name = "piesek"
+meaning = "Polnisch für Hündchen."
+usage = "Für kleine Hunde, süße Doggo-Momente oder osteuropäisch angehauchte Tierwitze."
+
+[[emotes]]
+name = "pigPls"
+meaning = "Tanzendes/Bitte-Schwein."
+usage = "Für Musik, Party oder niedliches Betteln."
+
+[[emotes]]
+name = "PissTime"
+meaning = "Gelber Bogen/Strahl als derber PissTime-Insider."
+usage = "Für Toiletten-/Pausenhumor; in sachlichen Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "piwo"
+meaning = "Polnisch für Bier."
+usage = "Wenn Bier, Feierabend, Kneipenstimmung oder slawische Trinkwitze auftauchen."
+
+[[emotes]]
+name = "plaisieren"
+meaning = "Altmodisch/österreichisch klingendes Gefallen- oder Spaßemote."
+usage = "Wenn sich jemand vornehm, ironisch oder sehr speziell amüsiert."
+
+[[emotes]]
+name = "Platypus"
+meaning = "Schnabeltier-Meme."
+usage = "Für seltsame, niedliche oder Perry-nahe Tiermomente."
+
+[[emotes]]
+name = "Plaul"
+meaning = "Pepe/Peepo mit Daumen-hoch als Plaul-/Paul-Insider."
+usage = "Für zustimmende, lokale Plaul-Reaktionen oder ein trockenes „passt“."
+
+[[emotes]]
+name = "PLEASE"
+meaning = "Flehend/bittend."
+usage = "Wenn jemand dringend um etwas bittet."
+
+[[emotes]]
+name = "plink"
+meaning = "Kleines Plink-/Sound-Meme."
+usage = "Für zarte Musik, kleine Geräusche oder cute Vibes."
+
+[[emotes]]
+name = "plinkbedge"
+meaning = "Plink plus Schlaf/Bett."
+usage = "Für ruhige, müde Musik oder cozy Einschlafstimmung."
+
+[[emotes]]
+name = "plinkge"
+meaning = "Plink-/ge-Variante."
+usage = "Wenn ein sanfter Plink-Moment als Reaktion passt."
+
+[[emotes]]
+name = "plinkVibe"
+meaning = "Plink mit Vibe."
+usage = "Für entspannte Musik oder kleine Groove-Momente."
+
+[[emotes]]
+name = "plonk"
+meaning = "Katzen-/Tier-Nahaufnahme als dumpfer Plonk-Laut."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser plonk-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "pogg"
+meaning = "Pog-/Hype-Variante."
+usage = "Wenn etwas beeindruckend oder positiv überraschend ist."
+
+[[emotes]]
+name = "PogTasty"
+meaning = "Pog plus schmeckt."
+usage = "Wenn Essen gut aussieht oder ein Play 'lecker' ist."
+
+[[emotes]]
+name = "PogU"
+meaning = "Klassisches PogU-Hypeemote."
+usage = "Bei starken Plays, Überraschungen oder guten Nachrichten."
+
+[[emotes]]
+name = "Pointless"
+meaning = "Sinnlos."
+usage = "Wenn etwas keinen Zweck hat oder komplett unnötig ist."
+
+[[emotes]]
+name = "PokiKiss"
+meaning = "Kuss-/Poki-Meme."
+usage = "Für übertrieben süße, flirtige oder ironische Zuneigung."
+
+[[emotes]]
+name = "PokiShare"
+meaning = "Poki-/Streamer-Share-Meme mit Bild-in-Bild/Teilen-Kontext."
+usage = "Wenn etwas geteilt, weitergegeben oder als Reaction-Clip herumgereicht wird."
+
+[[emotes]]
+name = "Poor"
+meaning = "Mitleid/arm dran."
+usage = "Wenn jemand Pech hat oder traurig bemitleidet wird."
+
+[[emotes]]
+name = "popCat"
+meaning = "Popcat-Meme mit offenem Mund."
+usage = "Für rhythmisches Poppen, Spam oder kurze Reaktionsketten."
+
+[[emotes]]
+name = "PotFriend"
+meaning = "Topf-/Pflanzenfreund-Emote."
+usage = "Für Pflanzen, Kochen, Topfhumor oder harmlose kleine Companion-Vibes."
+
+[[emotes]]
+name = "ppAutismo"
+meaning = "Problematische/ableistische pp-Variante im Twitch-Meme-Stil."
+usage = "Als potenziell beleidigendes Meme erkennen; für respektvolle Bot-Nutzung besser vermeiden."
+
+[[emotes]]
+name = "ppBounce"
+meaning = "Hüpfendes pp-/Peepo-artiges Emote."
+usage = "Für Hype, Bewegung oder albernes Springen."
+
+[[emotes]]
+name = "ppConga"
+meaning = "Conga-Linie-Meme."
+usage = "Wenn der Chat im Zug/Party-Modus mitläuft."
+
+[[emotes]]
+name = "ppFoop"
+meaning = "pp-Poof/Foop: kleines Verschwinden oder Partikeleffekt."
+usage = "Wenn etwas plötzlich verpufft, verschwindet oder als Mini-Gag endet."
+
+[[emotes]]
+name = "ppHop"
+meaning = "Hüpfendes pp-Meme."
+usage = "Für kleine Sprünge, Freude oder Bewegungsenergie."
+
+[[emotes]]
+name = "ppOverheat"
+meaning = "Überhitztes pp-Meme."
+usage = "Wenn etwas zu heiß, zu anstrengend oder überfordert wirkt."
+
+[[emotes]]
+name = "ppPoof"
+meaning = "Verschwinden/Poof."
+usage = "Wenn jemand plötzlich weg ist oder etwas verpufft."
+
+[[emotes]]
+name = "Prayers"
+meaning = "Gebete/Beten."
+usage = "Wenn man Hoffnung, Segen oder Glück braucht."
+
+[[emotes]]
+name = "Prayge"
+meaning = "Betendes Meme-Gesicht."
+usage = "Wenn der Chat für einen guten Ausgang hofft."
+
+[[emotes]]
+name = "PTSDge"
+meaning = "PTSD-/Flashback-Meme mit erschrockener, gestresster Optik."
+usage = "Wenn ein Ereignis an alte Fails erinnert; sensibel verwenden, da psychische Erkrankung als Meme genutzt wird."
+
+[[emotes]]
+name = "pugPls"
+meaning = "Tanzender/bittender Mops."
+usage = "Für Musik, niedliche Hunde oder bettelnde Stimmung."
+
+[[emotes]]
+name = "Purge"
+meaning = "Säuberung/Purge-Meme."
+usage = "Wenn Chat oder Mods aufräumen sollen; oft übertrieben dramatisch."
+
+[[emotes]]
+name = "PUUUH"
+meaning = "Erleichtertes Puh."
+usage = "Wenn etwas knapp überstanden wurde."
+
+[[emotes]]
+name = "racist"
+meaning = "Roter Schuh-/Clip-Insider mit problematischem Namen."
+usage = "Nicht als normale Reaktion verwenden; höchstens als riskanten Chat-Ausdruck erkennen."
+
+[[emotes]]
+name = "RacistModeEngaged"
+meaning = "Dunkles Bild mit problematischem „Racist Mode“-Namen."
+usage = "Als Moderationssignal oder toxischen Edgy-Insider erkennen, nicht positiv verwenden."
+
+[[emotes]]
+name = "RAGEY"
+meaning = "Wütendes Rage-Meme."
+usage = "Wenn Tilt, Schreien oder Ärger eskaliert."
+
+[[emotes]]
+name = "RAHHH"
+meaning = "Katzen-/Tierbild mit lauter, schreiender Energie."
+usage = "Wenn der Chat primal schreit, hyped ist oder etwas plötzlich laut eskaliert."
+
+[[emotes]]
+name = "Rainge"
+meaning = "Regen-/traurige Stimmung."
+usage = "Wenn es regnet, melancholisch ist oder etwas betrübt wirkt."
+
+[[emotes]]
+name = "ratdance"
+meaning = "Tanzende Ratte."
+usage = "Für Musik, Kanalisation-Vibes oder chaotischen Spaß."
+
+[[emotes]]
+name = "Ratge"
+meaning = "Ratten-Meme."
+usage = "Für Rattencontent, kleine Schurkenenergie oder Chat-Insider."
+
+[[emotes]]
+name = "RatgeNV"
+meaning = "Ratte mit Nachtsicht-/NV-Anmutung."
+usage = "Für Stealth, Dunkelheit, heimliches Beobachten oder taktische Rattenmomente."
+
+[[emotes]]
+name = "ratgeRacer"
+meaning = "Ratte als Racer."
+usage = "Bei Rennen, Geschwindigkeit oder F1-/Simracing-Insidern."
+
+[[emotes]]
+name = "RatgeStratge"
+meaning = "Ratte im Strategie-/Racing- oder taktischen Kontext."
+usage = "Wenn jemand einen rattigen, cleveren oder fragwürdigen Plan ausführt."
+
+[[emotes]]
+name = "ratJAM"
+meaning = "Ratte jammt."
+usage = "Wenn Musik läuft und der Chat mit der Ratte feiert."
 
 [[emotes]]
 name = "ratking"
-meaning = "Ratten-Meme."
-usage = "bei rattenbezogenen oder hektischen Meme-Momenten"
+meaning = "Rattenkönig-Meme."
+usage = "Wenn viele Ratten/Chatmitglieder als chaotische Masse auftreten."
+
+[[emotes]]
+name = "RatShake"
+meaning = "Schüttelnde Ratte."
+usage = "Für Aufregung, Musik oder nervöse Energie."
+
+[[emotes]]
+name = "RealBenzer"
+meaning = "Echter Benz-/Mercedes-Moment."
+usage = "Wenn es wirklich um Mercedes, Luxusauto-Energie oder einen echten Benzer-Flex geht."
+
+[[emotes]]
+name = "REDFLAG"
+meaning = "Rote Flagge/Warnsignal."
+usage = "Wenn etwas als deutliche Warnung oder Problem erkannt wird."
+
+[[emotes]]
+name = "REEEE"
+meaning = "Übertriebener Rage-Schrei."
+usage = "Wenn jemand schrill ausrastet oder der Chat trollig schreit."
+
+[[emotes]]
+name = "remWave"
+meaning = "Rem-Wave-/Anime-Winken."
+usage = "Zum sanften Hallo, Abschied oder für eine freundliche Anime-Referenz."
+
+[[emotes]]
+name = "Richeg"
+meaning = "Rich-/reiche-Leute-Eg-Variante."
+usage = "Wenn jemand Wohlstand, Business oder unnötigen Luxus ironisch ausstrahlt."
+
+[[emotes]]
+name = "RightThere"
+meaning = "'Genau da'-Zeige- oder Trefferreaktion."
+usage = "Wenn jemand den Punkt exakt trifft oder etwas im Bild/Chat direkt markiert werden soll."
+
+[[emotes]]
+name = "RIPBOZO"
+meaning = "Spöttisches 'Ruhe in Frieden, Bozo'."
+usage = "Als spöttische Schadenfreude erkennen; nicht bei realen Tragödien oder gegen reale Opfer verwenden."
+
+[[emotes]]
+name = "RobertThumbUp"
+meaning = "Robert gibt Daumen hoch."
+usage = "Für Zustimmung, Okay oder Politik-/Robert-Insider."
+
+[[emotes]]
+name = "RollCat"
+meaning = "Rollende Katze."
+usage = "Für süße Bewegung, Rotation oder Cat-Spam."
+
+[[emotes]]
+name = "rooon"
+meaning = "Kleines Bild eines Wegs oder einer Straße im Grünen."
+usage = "Für Weggehen, Loslaufen oder ruhige Reise-/Unterwegs-Momente."
+
+[[emotes]]
+name = "Ryanair"
+meaning = "Billigflug-/Ryanair-Meme."
+usage = "Bei Fliegen, Landungen, Reisechaos oder Low-Budget-Witzen."
+
+[[emotes]]
+name = "sAAAdge"
+meaning = "Übertrieben trauriges Sadge."
+usage = "Bei maximal traurigen oder ironisch traurigen Momenten."
+
+[[emotes]]
+name = "sadd"
+meaning = "Trauriges, schmerzhaftes oder verzweifeltes Reaktionsmeme."
+usage = "Wenn ein Moment enttäuscht, weh tut oder hoffnungslos wirkt und 'sadd' die Stimmung trifft."
+
+[[emotes]]
+name = "Saddies"
+meaning = "Traurige Reaktionsgruppe."
+usage = "Wenn mehrere Leute kollektiv traurig sind."
+
+[[emotes]]
+name = "Sadding"
+meaning = "Trauriges, schmerzhaftes oder verzweifeltes Reaktionsmeme."
+usage = "Wenn ein Moment enttäuscht, weh tut oder hoffnungslos wirkt und 'Sadding' die Stimmung trifft."
+
+[[emotes]]
+name = "Sadeg"
+meaning = "Trauriges ge-Meme."
+usage = "Für kleine, leise Traurigkeit."
+
+[[emotes]]
+name = "SadKitty"
+meaning = "Trauriges Kätzchen."
+usage = "Wenn etwas niedlich-traurig ist oder Trost braucht."
+
+[[emotes]]
+name = "Sainz"
+meaning = "Formel-1-/Racing-bezogenes Meme-Emote."
+usage = "Für Rennsport, Fahrerdrama, Team-Insider oder Strategiemomente mit Bezug zu 'Sainz'."
+
+[[emotes]]
+name = "sajj"
+meaning = "Weiche Sadge-/Sajj-Traurigkeit."
+usage = "Wenn etwas traurig ist, aber eher klein, niedlich oder resigniert wirkt."
+
+[[emotes]]
+name = "sajjbutluvv"
+meaning = "Traurig, aber liebevoll."
+usage = "Wenn man enttäuscht ist, aber trotzdem Zuneigung oder Support ausdrücken will."
+
+[[emotes]]
+name = "SALAMIhand"
+meaning = "Salami-Hand-Meme."
+usage = "Für Food-Insider, Wursthumor oder komische Gesten."
+
+[[emotes]]
+name = "Saved"
+meaning = "Gerettet."
+usage = "Wenn etwas gerade noch gut ausgeht."
+
+[[emotes]]
+name = "Scared"
+meaning = "Verängstigt."
+usage = "Bei Schreckmomenten, Horror oder Risiko."
+
+[[emotes]]
+name = "SCATTER"
+meaning = "Zerstreuen/auseinanderlaufen."
+usage = "Wenn alle fliehen, sich verteilen oder Chaos ausbricht."
+
+[[emotes]]
+name = "ScheiseErwischt"
+meaning = "Beim Mistbauen erwischt."
+usage = "Wenn jemand beim Trollen oder Fehlern auffliegt."
+
+[[emotes]]
+name = "scheisstag"
+meaning = "Schlechter-Tag-Emote."
+usage = "Wenn einfach alles nervt, schiefgeht oder ein Tag komplett verloren wirkt."
+
+[[emotes]]
+name = "SCHIZO"
+meaning = "Edgy Wahn-/Stimmen-im-Kopf-Meme mit Personenbild."
+usage = "Als problematischen Chatjargon erkennen; für respektvolle Bot-Antworten besser neutral umschreiben."
+
+[[emotes]]
+name = "SchizoYoda"
+meaning = "Yoda-Variante eines wirren/Schizo-Memes."
+usage = "Für absurde Gedankensprünge nur sehr vorsichtig; psychische Erkrankungen nicht abwertend verwenden."
+
+[[emotes]]
+name = "Serene"
+meaning = "Ruhig, gelassen, friedlich."
+usage = "Für sehr entspannte oder ästhetische Momente."
+
+[[emotes]]
+name = "SERVUS"
+meaning = "Bayerisch/österreichische Begrüßung."
+usage = "Zum Hallo oder Tschüss mit süddeutschem Vibe."
+
+[[emotes]]
+name = "shower"
+meaning = "Duschen-/Shower-Emote."
+usage = "Für Hygiene, Frische, Reset-Momente oder wenn der Chat jemandem eine Dusche empfiehlt."
+
+[[emotes]]
+name = "Shruge"
+meaning = "Shrug-/Achselzucken-Meme."
+usage = "Wenn man es nicht weiß oder egal findet."
+
+[[emotes]]
+name = "SICHERLICH"
+meaning = "Übertriebenes 'sicherlich'."
+usage = "Wenn Zustimmung ironisch oder zweifelhaft gemeint ist."
+
+[[emotes]]
+name = "sip"
+meaning = "Sippen/Trinken und beobachten."
+usage = "Wenn man Drama ruhig mit einem Getränk verfolgt."
+
+[[emotes]]
+name = "sipp"
+meaning = "Längere Sip-Variante."
+usage = "Für gemütliches oder demonstratives Trinken beim Zuschauen."
+
+[[emotes]]
+name = "Sisi"
+meaning = "Sisi-/Ja-ja-Bestätigung."
+usage = "Wenn etwas sehr weich, höflich oder halb ironisch bejaht wird."
+
+[[emotes]]
+name = "SKILLISSUE"
+meaning = "Problem liegt an fehlendem Skill."
+usage = "Wenn jemand scheitert und der Chat es trocken als Könnenproblem abtut."
+
+[[emotes]]
+name = "slayyy"
+meaning = "Slay-/Selbstbewusstseins-Meme."
+usage = "Wenn jemand stark aussieht, liefert oder glamourös gewinnt."
+
+[[emotes]]
+name = "SMH"
+meaning = "Shaking my head."
+usage = "Bei Enttäuschung, Kopfschütteln oder dummen Entscheidungen."
+
+[[emotes]]
+name = "Smith"
+meaning = "Kleine Texttafel mit gelber Schrift auf dunklem Hintergrund."
+usage = "Für Einblendungen, Meme-Zitate oder wenn ein kurzer Text als Reaktionsbild dienen soll."
+
+[[emotes]]
+name = "SmokeTime"
+meaning = "Rauchpause/Zeit zu rauchen."
+usage = "Wenn Pause, Zigarette oder lässiger Rauchmoment passt."
+
+[[emotes]]
+name = "snailWalk"
+meaning = "Laufende Schnecke."
+usage = "Wenn etwas extrem langsam vorangeht."
+
+[[emotes]]
+name = "SNIFFA"
+meaning = "Sniff-/Schnüffel-Insider mit derber oder verdächtiger Anmutung."
+usage = "Bei Geruchs-, Such- oder Substanzwitzen; vorsichtig und nicht glorifizierend verwenden."
+
+[[emotes]]
+name = "SNIPER"
+meaning = "Dunkles Sniper-/Schusslinien-Motiv."
+usage = "Für FPS-, Aim-, Pick- oder „jemand wurde erwischt“-Momente im Spielkontext."
+
+[[emotes]]
+name = "SOCIALCREDITING"
+meaning = "Lachendes Personen-/Social-Credit-Meme."
+usage = "Für China-/Social-Credit-Witze oder ironische Punktevergabe im Meme-Kontext."
+
+[[emotes]]
+name = "SoCute"
+meaning = "Sehr süß."
+usage = "Für niedliche Tiere, wholesome Momente oder cute Chat-Reaktionen."
+
+[[emotes]]
+name = "SoSnowy"
+meaning = "Sehr verschneit."
+usage = "Bei Winter, Schnee oder frostiger Gemütlichkeit."
+
+[[emotes]]
+name = "SoyPoint"
+meaning = "Zeigender Soyjak/Soy-Meme."
+usage = "Wenn jemand übertrieben begeistert auf etwas zeigt."
+
+[[emotes]]
+name = "SoyPoint2"
+meaning = "Zweite SoyPoint-Variante."
+usage = "Für wiederholtes oder stärkeres Fanboy-Zeigen."
+
+[[emotes]]
+name = "speziCope"
+meaning = "Copium-/Selbsttäuschungs-Meme."
+usage = "Wenn jemand eine Niederlage, Hoffnung oder Ausrede mit 'speziCope' schönredet."
+
+[[emotes]]
+name = "SpeziDank"
+meaning = "Spezi-Getränk plus Dank-Meme."
+usage = "Wenn Spezi, Getränkepause oder deutsche Softdrink-Insider passen."
+
+[[emotes]]
+name = "spezifisch"
+meaning = "Extrem spezifischer Spezi-/„spezifisch“-Insider mit Bildtext."
+usage = "Wenn eine Aussage unnötig genau, sehr deutsch oder auffällig konkret ist."
+
+[[emotes]]
+name = "Spezige"
+meaning = "Spezi-/ge-Meme."
+usage = "Für Spezi-Stimmung, Getränkewitze oder Channel-Insider."
+
+[[emotes]]
+name = "speziTime"
+meaning = "Zeit für Spezi."
+usage = "Wenn eine Getränkepause oder Spezi-Referenz kommt."
+
+[[emotes]]
+name = "spongePls"
+meaning = "SpongeBob-/Tanz-/Bitte-Meme."
+usage = "Bei Musik, albernem Betteln oder SpongeBob-Vibes."
+
+[[emotes]]
+name = "SquidJAM"
+meaning = "Tintenfisch jammt."
+usage = "Für Musik oder aquatisch-albernen Hype."
+
+[[emotes]]
+name = "sStrat"
+meaning = "Kleine Strategie-/„strat“-Anspielung, im Bild mit roter Kappe/Pepe-Optik."
+usage = "Für neue Taktiken, fragwürdige Pläne oder ironische Pro-Gamer-Strategien."
+
+[[emotes]]
+name = "StaregeZoom"
+meaning = "Herangezoomtes Starren."
+usage = "Wenn etwas intensiv beobachtet oder kritisch beäugt wird."
+
+[[emotes]]
+name = "startbeingNice"
+meaning = "Aufforderung, nett zu sein."
+usage = "Wenn der Chat toxisch wird und man freundlich bremsen möchte."
+
+[[emotes]]
+name = "StarwarsTime"
+meaning = "Dunkles Star-Wars-/Laserschwertmotiv."
+usage = "Wenn Star-Wars-Referenzen, Sith-/Jedi-Stimmung oder Sci-Fi-Drama auftauchen."
+
+[[emotes]]
+name = "STONING"
+meaning = "Stoning-/Steinigungs- oder Steinwurf-Anspielung."
+usage = "Nur als problematischen, überzeichneten Gewalt-/Strafwitz erkennen; nicht als Aufforderung verwenden."
+
+[[emotes]]
+name = "stopbeingEg"
+meaning = "Hör auf, Eg zu sein."
+usage = "Wenn jemand im Eg-/Egg-Insider zu tief drin ist."
+
+[[emotes]]
+name = "stopbeingmean"
+meaning = "Hör auf, gemein zu sein."
+usage = "Wenn jemand zu hart trollt oder gemein wirkt."
+
+[[emotes]]
+name = "STRONGERS"
+meaning = "Stark-/Gym-Meme."
+usage = "Wenn etwas kräftig, stabil oder motivierend wirkt."
+
+[[emotes]]
+name = "Suffering"
+meaning = "Leiden."
+usage = "Wenn der Stream, ein Spiel oder ein Take schmerzhaft wird."
+
+[[emotes]]
+name = "sumSmash"
+meaning = "Smash-/Schlag- oder Kollisionsgag mit Person/Hand im Bild."
+usage = "Wenn etwas zerdrückt, hart getroffen oder cartoonhaft „gesmasht“ wird."
+
+[[emotes]]
+name = "SURE"
+meaning = "Sicher/ja klar, oft ironisch."
+usage = "Wenn man etwas zweifelhaft akzeptiert."
+
+[[emotes]]
+name = "Susdog"
+meaning = "Verdächtiger Hund."
+usage = "Wenn ein Hund oder eine Person sus wirkt."
+
+[[emotes]]
+name = "Suseg"
+meaning = "Sus-/ge-Meme."
+usage = "Für verdächtige Aussagen oder Among-Us-artige Momente."
+
+[[emotes]]
+name = "SusegGun"
+meaning = "Susge-Variante mit Waffe im Bild."
+usage = "Bei suspekten oder bedrohlich überspitzten Meme-Momenten; nicht als echte Drohung verstehen oder verwenden."
+
+[[emotes]]
+name = "Susge"
+meaning = "Verdächtiges ge-Meme."
+usage = "Wenn jemand verdächtig, heimlich oder komisch handelt."
+
+[[emotes]]
+name = "SusgeSitCute"
+meaning = "Sitzendes, niedliches Susge."
+usage = "Wenn etwas verdächtig, aber süß wirkt."
+
+[[emotes]]
+name = "SUSSY"
+meaning = "Sehr verdächtig/sus."
+usage = "Bei Among-Us-Witzen oder doppeldeutigen Aussagen."
+
+[[emotes]]
+name = "SUUUUUREEEE"
+meaning = "Langgezogenes, stark ironisches 'sicher'."
+usage = "Wenn man eine Aussage überhaupt nicht glaubt."
+
+[[emotes]]
+name = "teaa"
+meaning = "Tee-/Tea-Meme."
+usage = "Wenn Klatsch, Drama oder Getränkestimmung aufkommt."
+
+[[emotes]]
+name = "TEISCHENTE"
+meaning = "Teichenten-/Duck-Insider mit echter Enten-/Teichszene."
+usage = "Für Enten, Teich, Natur oder harmlose lokale Tierwitze."
+
+[[emotes]]
+name = "TESTSIEGER"
+meaning = "Textbild „Testsieger“ mit Siegel-/Werbeästhetik."
+usage = "Wenn etwas ironisch als Gewinner, bestes Produkt oder offiziell überlegen markiert wird."
+
+[[emotes]]
+name = "THERE"
+meaning = "Da/dort."
+usage = "Wenn auf eine Stelle, Antwort oder Entdeckung gezeigt wird."
+
+[[emotes]]
+name = "TheVoices"
+meaning = "Die Stimmen im Kopf."
+usage = "Wenn jemand innere Monologe, Chaos oder intrusive thoughts memet."
+
+[[emotes]]
+name = "Thinking"
+meaning = "Nachdenkendes Meme."
+usage = "Wenn überlegt, analysiert oder gezweifelt wird."
+
+[[emotes]]
+name = "Thinking2"
+meaning = "Zweite Denk-Variante."
+usage = "Wenn Nachdenken länger oder tiefer geht."
+
+[[emotes]]
+name = "Thisisfine"
+meaning = "'This is fine'-Meme trotz Chaos."
+usage = "Wenn alles brennt, man aber vorgibt, es sei okay."
+
+[[emotes]]
+name = "THONKERS"
+meaning = "Großes Nachdenken/Thonk."
+usage = "Wenn der Chat versucht, eine komplexe oder absurde Sache zu begreifen."
+
+[[emotes]]
+name = "ThumbsUpSadCat"
+meaning = "Traurige Katze mit Daumen hoch."
+usage = "Wenn man Schmerz akzeptiert und trotzdem okay signalisiert."
+
+[[emotes]]
+name = "TimeForDeadlock"
+meaning = "Deadlock-Game-Insider: Zeit, Deadlock zu spielen."
+usage = "Wenn der Chat auf Deadlock wechseln will oder ein Gaming-Callout für Deadlock kommt."
+
+[[emotes]]
+name = "Timeout"
+meaning = "Auszeit/Moderations-Timeout."
+usage = "Wenn jemand eine Pause oder Strafe verdient."
+
+[[emotes]]
+name = "tintinHeadbang"
+meaning = "Tintin/TinTin-Headbang-Emote."
+usage = "Wenn ein Charakter oder der Chat hart zu Musik nickt und Headbang-Energie entsteht."
+
+[[emotes]]
+name = "tintinJesus"
+meaning = "Jesus-/Tintin-Insider, vermutlich zeigend oder erklärend."
+usage = "Für religiöse, ikonische oder absurde Heilsbringer-Reaktionen; nicht als Among-Us/Sus-Meme."
+
+[[emotes]]
+name = "tomatoTime"
+meaning = "Tomaten-/Wurf-Gag als kleines Zeit-für-Tomaten-Emote."
+usage = "Wenn etwas so schlecht, albern oder bühnenhaft failig ist, dass im Meme-Sinn Tomaten fliegen."
+
+[[emotes]]
+name = "TOOBASED"
+meaning = "Zustimmungs- und 'based'-Meme."
+usage = "Wenn ein Take, Play oder Verhalten als stark, mutig oder ironisch korrekt gefeiert wird: 'TOOBASED'."
+
+[[emotes]]
+name = "Toothless"
+meaning = "Drachen-/Ohnezahn-Meme."
+usage = "Für Drachen, niedliche Animationen oder Toothless-Dance-Referenzen."
+
+[[emotes]]
+name = "TOPXI"
+meaning = "Top-XI-/Fußballaufstellungs-Meme."
+usage = "Wenn jemand eine beste Elf, Rangliste oder perfekte Auswahl im Fußballkontext meint."
+
+[[emotes]]
+name = "totarsch"
+meaning = "Derb-vulgäres Tot-/Arsch-Emote."
+usage = "Wenn etwas komplett kaputt, tot oder auf besonders grobe Weise lächerlich ist."
+
+[[emotes]]
+name = "TriDance"
+meaning = "TriHard-/Tanzvariante."
+usage = "Bei Musik, Tanz oder Twitch-Klassiker-Hype."
+
+[[emotes]]
+name = "TriKool"
+meaning = "TriHard-ähnliche Cool-Variante."
+usage = "Wenn etwas lässig und twitchig wirkt."
+
+[[emotes]]
+name = "TrollDespair"
+meaning = "Trollface in Verzweiflung."
+usage = "Wenn ein Troll selbst verliert oder der Plan scheitert."
+
+[[emotes]]
+name = "Trolleg"
+meaning = "Troll-/ge-Meme."
+usage = "Wenn jemand offensichtlich trollt."
+
+[[emotes]]
+name = "TRRRRRRRRRRR"
+meaning = "Maschinengewehr-/Rattergeräusch-Meme."
+usage = "Für schnelle Schüsse, Motorengeräusche, Spam oder eine plötzlich losratternde Aktion."
+
+[[emotes]]
+name = "Truck"
+meaning = "Lastwagen/Truck-Meme."
+usage = "Bei LKWs, schweren Hits oder Transport-Witzen."
+
+[[emotes]]
+name = "TRUEING"
+meaning = "Aktives 'true'."
+usage = "Wenn der Chat einer Aussage sehr stark zustimmt."
+
+[[emotes]]
+name = "TrumpetTime"
+meaning = "Trompetenzeit."
+usage = "Für Fanfaren, Musik oder komische Ankündigungen."
+
+[[emotes]]
+name = "tucked"
+meaning = "Eingekuschelt oder zugedeckt liegendes Tier."
+usage = "Für Schlafenszeit, Cozy-Modus oder wenn jemand sicher ins Bett gepackt ist."
+
+[[emotes]]
+name = "tuh"
+meaning = "Dunkle flauschige Katzen- oder Tier-Nahaufnahme mit runden Augen."
+usage = "Für dumpfes Starren, leises Unverständnis oder einen sehr soften Tiermoment."
+
+[[emotes]]
+name = "Uhm"
+meaning = "Zögerliches 'ähm'."
+usage = "Wenn man unsicher ist oder etwas awkward wird."
+
+[[emotes]]
+name = "UHM"
+meaning = "Lauteres/auffälligeres Ähm."
+usage = "Wenn eine Aussage seltsam ist und man stockt."
+
+[[emotes]]
+name = "Uhmm"
+meaning = "Längeres Zögern."
+usage = "Wenn man wirklich nicht weiß, wie man reagieren soll."
+
+[[emotes]]
+name = "UltraMad"
+meaning = "Extrem wütend."
+usage = "Wenn normaler Madge nicht reicht und Tilt eskaliert."
+
+[[emotes]]
+name = "UM"
+meaning = "Kurzes Um-/Ähm-Zögern."
+usage = "Wenn jemand ansetzt, aber noch keine sichere Antwort oder Ausrede parat hat."
+
+[[emotes]]
+name = "unkok"
+meaning = "Anti-/Gegenstück zu Kok: „nicht kok“ oder Kok wird aufgehoben."
+usage = "Wenn ein Kok-Moment zurückgenommen, verneint oder ironisch entschärft wird."
+
+[[emotes]]
+name = "UNLUCKY"
+meaning = "Pech gehabt."
+usage = "Wenn etwas knapp schiefgeht oder RNG gegen jemanden ist."
+
+[[emotes]]
+name = "unzips"
+meaning = "Derbes „unzips“-NSFW-Andeutungsmeme."
+usage = "Für Bot-Ausgaben vermeiden; als anzüglichen Chat-Ausbruch erkennen."
+
+[[emotes]]
+name = "uuh"
+meaning = "Nahaufnahme mit großen Augen als unsicherer „uuh“-Laut."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser uuh-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "uwu7"
+meaning = "UwU plus Salut."
+usage = "Für niedliche, respektvolle oder animehafte Zustimmung."
+
+[[emotes]]
+name = "uwuu"
+meaning = "Übertrieben niedliches UwU."
+usage = "Wenn etwas sehr süß oder absichtlich kawaii ist."
+
+[[emotes]]
+name = "VaderListening"
+meaning = "Darth Vader hört zu."
+usage = "Wenn dramatisch zugehört oder Star-Wars-Vibe aufgebaut wird."
+
+[[emotes]]
+name = "veryCat"
+meaning = "Sehr Katze."
+usage = "Wenn etwas maximal katzenhaft ist."
+
+[[emotes]]
+name = "veryPog"
+meaning = "Sehr pog/beeindruckend."
+usage = "Wenn ein Moment stark, hype oder unerwartet gut ist."
+
+[[emotes]]
+name = "VFBierchen"
+meaning = "Getränke- oder Pausen-Emote."
+usage = "Für Kaffee, Tee, Bier, Drama-Beobachtung oder kurze Pausen mit 'VFBierchen'."
+
+[[emotes]]
+name = "VIBE"
+meaning = "Gute Stimmung/Vibe."
+usage = "Wenn Atmosphäre, Musik oder Laune passt."
+
+[[emotes]]
+name = "vibee"
+meaning = "Kleine Vibe-Variante."
+usage = "Für entspannte, positive Hintergrundstimmung."
+
+[[emotes]]
+name = "VOICES"
+meaning = "Stimmen-im-Kopf-Meme."
+usage = "Wenn jemand von innerem Chaos oder Wahnwitz redet."
+
+[[emotes]]
+name = "Voidge"
+meaning = "Void-/Leere-Meme."
+usage = "Wenn etwas leer, dunkel, verloren oder existenziell wirkt."
+
+[[emotes]]
+name = "VS"
+meaning = "Versus-/Gegeneinander-Emote."
+usage = "Wenn zwei Seiten, Teams, Fahrer oder Meinungen gegeneinander antreten."
+
+[[emotes]]
+name = "waa"
+meaning = "Katzenbild als kurzer „waa“-Schrecklaut."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser waa-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "Waiting"
+meaning = "Warten."
+usage = "Wenn der Chat auf etwas wartet."
+
+[[emotes]]
+name = "WaitingAngry"
+meaning = "Wütendes Warten."
+usage = "Wenn Wartezeit nervt oder jemand zu spät ist."
+
+[[emotes]]
+name = "waitingJAM"
+meaning = "Warten, aber mit Musik."
+usage = "Wenn man die Wartezeit mit Jam-Stimmung überbrückt."
+
+[[emotes]]
+name = "Wankge"
+meaning = "Derbes Wank-/NSFW-Wortspiel mit Pepe-Variante."
+usage = "Für neutrale Bot-Ausgaben vermeiden; höchstens als anzüglichen Insider erkennen."
+
+[[emotes]]
+name = "WannDayZ"
+meaning = "'Wann DayZ?'-Spielwunsch-Meme."
+usage = "Wenn der Chat wieder fragt, wann endlich DayZ gespielt wird."
+
+[[emotes]]
+name = "WannEUV"
+meaning = "'Wann EUV/EU4?'-Grand-Strategy-Wunsch."
+usage = "Wenn Leute nach Europa Universalis oder dem nächsten Mapgame fragen."
+
+[[emotes]]
+name = "WannSommer"
+meaning = "'Wann Sommer?'-Jahreszeiten-Meme."
+usage = "Wenn Kälte, Sehnsucht nach Sonne oder Wetterfrust im Chat auftaucht."
+
+[[emotes]]
+name = "WannWinter"
+meaning = "'Wann Winter?'-Gegenstück zu WannSommer."
+usage = "Wenn Hitze nervt, Schnee vermisst wird oder der Chat Winterstimmung will."
+
+[[emotes]]
+name = "WAR"
+meaning = "Krieg-/War-Reaktionsbild."
+usage = "Bei War-/Kampf-/Konflikt-Memes; nicht als reale Gewaltbefürwortung verwenden."
+
+[[emotes]]
+name = "WASHED"
+meaning = "Aus der Form/washed up."
+usage = "Wenn jemand nicht mehr so gut ist wie früher."
+
+[[emotes]]
+name = "WatchingForsen"
+meaning = "Forsen beobachten."
+usage = "Wenn der Chat Forsen-Content schaut oder passiv beobachtet."
+
+[[emotes]]
+name = "watto"
+meaning = "Watto-/Star-Wars-Insider."
+usage = "Für schmierige Deals, Tatooine-Vibes oder sehr spezifische Prequel-Referenzen."
+
+[[emotes]]
+name = "Waving"
+meaning = "Winken."
+usage = "Für Hallo, Tschüss oder Aufmerksamkeit."
+
+[[emotes]]
+name = "WAYTOOBUH"
+meaning = "Übertriebene, stark vergrößerte oder „zu viel“ wirkende Busted-Buh-Variante."
+usage = "Wenn der Buh-Insider überhandnimmt, gespammt wird oder ein Moment absichtlich viel zu buh-lastig ist."
+
+[[emotes]]
+name = "WEEBSDETECTED"
+meaning = "Anime-/Weebs erkannt."
+usage = "Wenn Anime- oder Weeb-Verhalten im Chat auftaucht."
+
+[[emotes]]
+name = "WeeWoo"
+meaning = "Sirenen-/Polizei-/Alarm-Meme."
+usage = "Wenn etwas gemeldet, verboten oder alarmierend wirkt."
+
+[[emotes]]
+name = "WeirdChamp"
+meaning = "Missbilligung/komischer Champ-Moment."
+usage = "Wenn etwas unangenehm, fragwürdig oder cringe ist."
+
+[[emotes]]
+name = "WennNilsMalWiederImChatDasWortMetaLesenMussZuEinerBubenGamingSession"
+meaning = "Nils-reagiert-auf-'Meta'-Gaming-Insider."
+usage = "Wenn das Wort Meta fällt und jemand davon sichtbar genervt oder getriggert wird."
+
+[[emotes]]
+name = "WennTristenAbsichtlichScheisseInCSGebautHatUndOleGeradeNuklearCrashOutGeht"
+meaning = "Tristen-baut-Mist-in-CS-und-Ole-eskaliert-Insider."
+usage = "Wenn ein absichtlicher Fehlplay in Counter-Strike den kompletten Ole-Tilt auslöst."
+
+[[emotes]]
+name = "WennTristenInSizilienAnkommt"
+meaning = "Tristen-auf-Sizilien-Insider."
+usage = "Wenn Urlaubsankunft, Italienchaos oder ein Tristen-spezifischer Moment gemeint ist."
+
+[[emotes]]
+name = "WeWaiting"
+meaning = "Wir warten."
+usage = "Wenn der gesamte Chat auf jemanden oder etwas wartet."
+
+[[emotes]]
+name = "WHAT"
+meaning = "Was?!"
+usage = "Bei Überraschung, Verwirrung oder Unglauben."
+
+[[emotes]]
+name = "WHATAWEEK"
+meaning = "Erschöpftes „what a week“-Bild."
+usage = "Wenn schon nach kurzer Zeit alles chaotisch, anstrengend oder absurd war."
+
+[[emotes]]
+name = "WHERE"
+meaning = "Pepe-/Fragezeichen-Reaktion."
+usage = "Wenn etwas fehlt, gesucht wird oder der Chat verwirrt fragt, wo es ist."
+
+[[emotes]]
+name = "WhereMonkey"
+meaning = "Verwirrungs- oder Frage-Reaktion."
+usage = "Wenn etwas unklar, unerwartet oder fragwürdig ist und 'WhereMonkey' die Ratlosigkeit markiert."
+
+[[emotes]]
+name = "Whey"
+meaning = "Protein-/Whey-Insider mit Shaker oder Supplement-Vibe."
+usage = "Für Gym, Protein, Leg Day oder Fitness-Ernährung."
+
+[[emotes]]
+name = "WHOLETHIMCOOK"
+meaning = "Woody-/Toy-Story-artiger „let him cook“-Insider."
+usage = "Wenn jemand wirklich weitermachen soll, weil sich ein Plan oder Take gerade entwickelt."
+
+[[emotes]]
+name = "WICKED"
+meaning = "Krass/böse/cool."
+usage = "Wenn etwas heftig, stylisch oder gemein beeindruckend ist."
+
+[[emotes]]
+name = "WickedSteer"
+meaning = "Krasses Lenken."
+usage = "Bei Racing, Fahrkunst oder wilden Kurven."
+
+[[emotes]]
+name = "wideduckass"
+meaning = "Breit gezogene Enten-/Duckass-Variante."
+usage = "Wenn ein Entenwitz extra breit, absurd oder panoramisch ausgespielt wird."
+
+[[emotes]]
+name = "WideEgg"
+meaning = "Breites Ei-/Eg-Meme."
+usage = "Wenn ein Egg-Insider in extra breiter Form passt."
+
+[[emotes]]
+name = "wideFlop"
+meaning = "Breiter Floppa."
+usage = "Für Floppa-Reaktionen mit extra Panorama-Wirkung."
+
+[[emotes]]
+name = "Wideg"
+meaning = "Breites ge-Meme."
+usage = "Wenn ein Emote absichtlich verzerrt oder extra breit wirkt."
+
+[[emotes]]
+name = "WIDEGIGALONSO"
+meaning = "Breiter Gigachad-Alonso."
+usage = "Für sehr starken Alonso-/F1-Hype."
+
+[[emotes]]
+name = "wideKok"
+meaning = "Breit gezogener Kok-/Koks- oder Tier-Insider."
+usage = "Wenn ein Kok-Moment extra absurd, langgezogen oder panoramisch wirken soll."
+
+[[emotes]]
+name = "wideNessie"
+meaning = "Breit gezogene Meme-Variante."
+usage = "Wenn eine Reaktion extra überzeichnet, breit oder panoramisch wirken soll: 'wideNessie'."
+
+[[emotes]]
+name = "widepeepoHappy"
+meaning = "Breiter glücklicher Peepo."
+usage = "Für große, aber gemütliche Freude."
+
+[[emotes]]
+name = "widepeepoSad"
+meaning = "Breiter trauriger Peepo."
+usage = "Für überzeichnete Traurigkeit."
+
+[[emotes]]
+name = "wikk"
+meaning = "Kleiner grüner Frosch mit buntem Regenbogenband und dunklen Gliedmaßen."
+usage = "Für bunte, wackelige oder leicht freche Reaktionen im Frosch-Stil."
+
+[[emotes]]
+name = "wikked"
+meaning = "Variante des kleinen grünen Froschs mit buntem Band, die etwas verschobener und frecher wirkt."
+usage = "Für eine minimal bösere oder schelmischere Version von wikk."
+
+[[emotes]]
+name = "WINK"
+meaning = "Zwinkern."
+usage = "Wenn etwas frech, ironisch oder doppeldeutig gemeint ist."
+
+[[emotes]]
+name = "WIRES"
+meaning = "Kabel-/Wire-Chaos oder verdrahtete Optik."
+usage = "Wenn Technik, Kabelsalat, Verkabelung oder „da sind zu viele Drähte“ Thema ist."
+
+[[emotes]]
+name = "WOAH"
+meaning = "Staunendes Wow/Woah."
+usage = "Wenn etwas beeindruckt oder überrascht."
+
+[[emotes]]
+name = "Wokege"
+meaning = "Woke-/ge-Meme."
+usage = "Bei ironischen Kulturkampf- oder Awareness-Momenten; kontextsensibel nutzen."
+
+[[emotes]]
+name = "Wowers"
+meaning = "Wow-/Staun-Meme."
+usage = "Für beeindruckte, aber leicht alberne Reaktionen."
+
+[[emotes]]
+name = "WtF"
+meaning = "What the fuck."
+usage = "Bei kompletter Verwirrung oder Schock."
+
+[[emotes]]
+name = "XD"
+meaning = "Klassisches Textsmiley-Lachen."
+usage = "Für oldschool, trockenes oder ironisches Lachen."
+
+[[emotes]]
+name = "xdd"
+meaning = "Twitch-/7TV-Variante von XD/xdd."
+usage = "Wenn etwas albern, cringe-lustig oder chattypisch witzig ist."
+
+[[emotes]]
+name = "xdding"
+meaning = "Aktives xdd-Lachen."
+usage = "Wenn der Chat dauerhaft xdd reagiert."
+
+[[emotes]]
+name = "xddShrug"
+meaning = "xdd plus Achselzucken."
+usage = "Wenn man lachend keine Ahnung hat oder es egal findet."
+
+[[emotes]]
+name = "XINEMA"
+meaning = "Cinema mit Xi-/China-Insider."
+usage = "Wenn etwas filmreif und zugleich politisch/memig codiert ist; vorsichtig nutzen."
+
+[[emotes]]
+name = "XiPls"
+meaning = "Xi-/China-bezogene Tanz-/Bitte-Variante."
+usage = "Bei China-/Social-Credit-/Xi-Memes; kontextsensibel nutzen."
+
+[[emotes]]
+name = "xqcL"
+meaning = "xQc-Liebe/Herz-Meme."
+usage = "Für Liebe, Support oder xQc-Community-Referenzen."
+
+[[emotes]]
+name = "xqcShare"
+meaning = "xQc-Share/Teilen-Meme."
+usage = "Wenn etwas geteilt oder gemeinsam gefeiert wird."
+
+[[emotes]]
+name = "YeahBuddy"
+meaning = "Ronnie-Coleman-/Gym-Ruf."
+usage = "Bei Fitness, schweren Lifts oder motivierter Bro-Energie."
+
+[[emotes]]
+name = "yeeeee"
+meaning = "Langgezogenes „yeeeee“ als Jubel-/Lautreaktion."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser yeeeee-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "yeeeeeeeeeeeeeeee"
+meaning = "Extrem langgezogener Jubel- oder Meme-Laut."
+usage = "Als kurze lautmalerische Reaktion, wenn genau dieser yeeeeeeeeeeeeeeee-Moment zur Stimmung passt."
+
+[[emotes]]
+name = "YEK"
+meaning = "Pepe/Frosch mit seitlichen Ohren oder Kopfhörern und rotem Fragezeichen über dem Kopf."
+usage = "Für fragende Reaktionen, wenn etwas nicht verstanden wurde oder komplett unklar bleibt."
+
+[[emotes]]
+name = "Yepge"
+meaning = "Ja-/Zustimmungs-ge."
+usage = "Für ruhige, sichere Zustimmung."
+
+[[emotes]]
+name = "YEPL"
+meaning = "Yep plus L/Variante."
+usage = "Wenn man zustimmt, aber der Moment trotzdem wie ein Verlust wirkt."
+
+[[emotes]]
+name = "YEPPERS"
+meaning = "Freundliches, klares Ja."
+usage = "Wenn man positiv und locker bestätigt."
+
+[[emotes]]
+name = "YESIDOTHINKSO"
+meaning = "Ja, ich denke schon."
+usage = "Für eindeutige Zustimmung, oft als Gegenstück zu NOIDONTTHINKSO."
+
+[[emotes]]
+name = "YesYes"
+meaning = "Doppeltes Ja."
+usage = "Wenn man enthusiastisch oder schnell zustimmt."
+
+[[emotes]]
+name = "YoCat"
+meaning = "Yo-Katze."
+usage = "Als lässige Katzenbegrüßung."
+
+[[emotes]]
+name = "YODA"
+meaning = "Yoda-/Star-Wars-Meme."
+usage = "Wenn Star-Wars-Weisheit, Grammatik oder grüner Meister passt."
+
+[[emotes]]
+name = "yodance"
+meaning = "Tanzender Yoda."
+usage = "Bei Musik, Star-Wars-Party oder albernem Tanzen."
+
+[[emotes]]
+name = "yogurt"
+meaning = "Joghurt-/Snackmeme."
+usage = "Für Milchprodukte, kleine Snacks, Fitnessfood oder absurde Essensreferenzen."
+
+[[emotes]]
+name = "Yoink"
+meaning = "Etwas schnell wegnehmen/klauen."
+usage = "Wenn jemand lootet, stiehlt oder sich etwas schnappt."
+
+[[emotes]]
+name = "yonose"
+meaning = "Kleine Katze, die flach auf einer Kante liegt und beide Pfoten seitlich ausstreckt."
+usage = "Für erschöpfte, ausgestreckte oder 'ich liege einfach hier'-Momente."
+
+[[emotes]]
+name = "YOURMOM"
+meaning = "Klassischer „your mom“-Beleidigungswitz."
+usage = "Bei absichtlich kindischem Trash-Talk; für freundliche Bot-Antworten vermeiden."
+
+[[emotes]]
+name = "zazaBinks"
+meaning = "Jar-Jar-Binks/Zaza-Insider."
+usage = "Bei Star-Wars- oder absurden Jar-Jar-Momenten."
+
+[[emotes]]
+name = "Zimb3l"
+meaning = "Kommunismus ist schlecht"
+usage = "Wenn über Kommunismus gesprochen wird."
+
+[[emotes]]
+name = "zonedout"
+meaning = "Ausgezonet/abwesend."
+usage = "Wenn jemand starrt, abschaltet oder mental weg ist."
+
+[[emotes]]
+name = "zoomies"
+meaning = "Plötzliche Energie, meist bei Tieren."
+usage = "Wenn jemand/etwas wild herumflitzt."
+
+[[emotes]]
+name = "ZULUL"
+meaning = "ZULUL-/Tribal-Lachmeme aus älterer Twitch-Kultur."
+usage = "Nur kontextsensibel nutzen, da das Emote kulturell problematisch wirken kann."
+
+[[emotes]]
+name = "ZUSTIMMUNGSVERWEIGERUNG"
+meaning = "Pepe mit ablehnendem Blick als Zustimmungsverweigerung."
+usage = "Wenn jemand ausdrücklich nicht zustimmt, blockt oder einen Antrag ironisch ablehnt."
+
+[[emotes]]
+name = "zyzzBass"
+meaning = "Zyzz-/Gym-/Bass-Meme."
+usage = "Bei Hardstyle, Gym, Pump oder Zyzz-Ästhetik."
+
+[[emotes]]
+name = "Zyzzers"
+meaning = "Zyzz-/Fitness-Community-Meme."
+usage = "Wenn Gym-Bro- oder Hardstyle-Stimmung läuft."
+
+[[emotes]]
+name = "zyzzPls"
+meaning = "Zyzz-Tanz-/Musik-Meme."
+usage = "Bei Hardstyle, Fitness-Hype oder Bodybuilding-Nostalgie."

--- a/crates/twitch-1337/src/ai/command.rs
+++ b/crates/twitch-1337/src/ai/command.rs
@@ -328,19 +328,6 @@ where
             date: &now_berlin,
         };
         let mut system_prompt_head = inject::substitute(&system_template, vars);
-        if let Some(ref emotes) = self.emotes
-            && let Some(block) = emotes.prompt_block(&ctx.privmsg.channel_id).await
-        {
-            system_prompt_head.push_str(&block);
-        }
-        if grok_alias {
-            system_prompt_head.push_str(GROK_SYSTEM_APPENDIX);
-            if self.web.is_some() {
-                system_prompt_head.push_str(GROK_WEB_SYSTEM_APPENDIX);
-            }
-        } else if self.web.is_some() {
-            system_prompt_head.push_str(WEB_TOOLS_SYSTEM_APPENDIX);
-        }
         let instructions_head = inject::substitute(&instructions_template, vars);
 
         let invocation_channel = if cc.is_some_and(|c| c.is_ai_channel(&ctx.privmsg.channel_login))
@@ -369,9 +356,29 @@ where
             },
         )
         .await?;
-        let system_prompt = format!("{system_prompt_head}\n\n{memory}");
 
         let instruction_for_prompt = instruction_with_reply_context(&instruction, &ctx, grok_alias);
+        if let Some(ref emotes) = self.emotes
+            && let Some(block) = emotes
+                .prompt_block_for_turn(
+                    &ctx.privmsg.channel_id,
+                    &instruction_for_prompt,
+                    &recent_chat,
+                )
+                .await
+        {
+            system_prompt_head.push_str(&block);
+        }
+        if grok_alias {
+            system_prompt_head.push_str(GROK_SYSTEM_APPENDIX);
+            if self.web.is_some() {
+                system_prompt_head.push_str(GROK_WEB_SYSTEM_APPENDIX);
+            }
+        } else if self.web.is_some() {
+            system_prompt_head.push_str(WEB_TOOLS_SYSTEM_APPENDIX);
+        }
+        let system_prompt = format!("{system_prompt_head}\n\n{memory}");
+
         let user_message = if recent_chat.is_empty() {
             format!("{instructions_head}\n\n{instruction_for_prompt}")
         } else {

--- a/crates/twitch-1337/src/twitch/seventv.rs
+++ b/crates/twitch-1337/src/twitch/seventv.rs
@@ -32,7 +32,7 @@ pub struct SevenTvEmoteProvider {
 #[derive(Debug, Default)]
 struct PromptCache {
     last_refresh: Option<Instant>,
-    prompt: Option<String>,
+    emotes: Option<Vec<PromptEmote>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -48,6 +48,14 @@ struct GlossaryEmote {
     #[serde(default)]
     usage: Option<String>,
     #[serde(default)]
+    avoid: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PromptEmote {
+    name: String,
+    meaning: String,
+    usage: Option<String>,
     avoid: Option<String>,
 }
 
@@ -101,9 +109,22 @@ impl SevenTvEmoteProvider {
         })
     }
 
-    /// Return the current prompt block for the Twitch channel id, refreshing
-    /// the backing catalog + glossary at most once per configured interval.
-    pub async fn prompt_block(&self, twitch_channel_id: &str) -> Option<String> {
+    /// Return a turn-specific prompt block for the Twitch channel id.
+    ///
+    /// The backing catalog + glossary are refreshed at most once per
+    /// configured interval, but ranking happens per turn so current chat emotes
+    /// and the user instruction can influence which entries the model sees.
+    pub async fn prompt_block_for_turn(
+        &self,
+        twitch_channel_id: &str,
+        instruction: &str,
+        recent_chat: &str,
+    ) -> Option<String> {
+        let emotes = self.prompt_emotes(twitch_channel_id).await?;
+        build_prompt_block(&emotes, self.max_prompt_emotes, instruction, recent_chat)
+    }
+
+    async fn prompt_emotes(&self, twitch_channel_id: &str) -> Option<Vec<PromptEmote>> {
         let mut cache = self.cache.lock().await;
         let now = Instant::now();
 
@@ -111,27 +132,30 @@ impl SevenTvEmoteProvider {
             .last_refresh
             .is_some_and(|last| now.duration_since(last) < self.refresh_interval)
         {
-            return cache.prompt.clone();
+            return cache.emotes.clone();
         }
 
-        match self.refresh_prompt(twitch_channel_id).await {
-            Ok(prompt) => {
+        match self.refresh_prompt_emotes(twitch_channel_id).await {
+            Ok(emotes) => {
                 cache.last_refresh = Some(now);
-                cache.prompt = prompt;
+                cache.emotes = emotes;
             }
             Err(e) => {
                 cache.last_refresh = Some(now);
                 warn!(
                     error = ?e,
-                    "Failed to refresh 7TV emote prompt; using cached prompt if available"
+                    "Failed to refresh 7TV emote glossary; using cached entries if available"
                 );
             }
         }
 
-        cache.prompt.clone()
+        cache.emotes.clone()
     }
 
-    async fn refresh_prompt(&self, twitch_channel_id: &str) -> Result<Option<String>> {
+    async fn refresh_prompt_emotes(
+        &self,
+        twitch_channel_id: &str,
+    ) -> Result<Option<Vec<PromptEmote>>> {
         let glossary = self.load_glossary().await?;
         if glossary.emotes.is_empty() {
             debug!(
@@ -142,8 +166,8 @@ impl SevenTvEmoteProvider {
         }
 
         let available = self.fetch_available_emotes(twitch_channel_id).await?;
-        let prompt = build_prompt_block(&glossary.emotes, &available, self.max_prompt_emotes);
-        Ok(prompt)
+        let emotes = build_available_prompt_emotes(&glossary.emotes, &available);
+        Ok(emotes)
     }
 
     async fn load_glossary(&self) -> Result<Glossary> {
@@ -249,13 +273,12 @@ fn insert_available(available: &mut HashSet<String>, emote: SevenTvEmote) {
     available.insert(emote.name);
 }
 
-fn build_prompt_block(
+fn build_available_prompt_emotes(
     glossary: &[GlossaryEmote],
     available: &HashSet<String>,
-    max_prompt_emotes: usize,
-) -> Option<String> {
+) -> Option<Vec<PromptEmote>> {
     let mut seen = HashSet::new();
-    let mut lines = Vec::new();
+    let mut emotes = Vec::new();
     let mut stale_count = 0usize;
 
     for emote in glossary {
@@ -278,30 +301,22 @@ fn build_prompt_block(
             continue;
         }
 
-        let mut line = format!("- {name}: meaning={meaning}");
-        if let Some(usage) = emote
+        let usage = emote
             .usage
             .as_deref()
             .map(normalize_prompt_field)
-            .filter(|s| !s.is_empty())
-        {
-            line.push_str("; use=");
-            line.push_str(&usage);
-        }
-        if let Some(avoid) = emote
+            .filter(|s| !s.is_empty());
+        let avoid = emote
             .avoid
             .as_deref()
             .map(normalize_prompt_field)
-            .filter(|s| !s.is_empty())
-        {
-            line.push_str("; avoid=");
-            line.push_str(&avoid);
-        }
-        lines.push(line);
-
-        if lines.len() >= max_prompt_emotes {
-            break;
-        }
+            .filter(|s| !s.is_empty());
+        emotes.push(PromptEmote {
+            name: name.to_string(),
+            meaning,
+            usage,
+            avoid,
+        });
     }
 
     if stale_count > 0 {
@@ -311,14 +326,147 @@ fn build_prompt_block(
         );
     }
 
+    if emotes.is_empty() {
+        return None;
+    }
+
+    Some(emotes)
+}
+
+fn build_prompt_block(
+    emotes: &[PromptEmote],
+    max_prompt_emotes: usize,
+    instruction: &str,
+    recent_chat: &str,
+) -> Option<String> {
+    let lines = rank_prompt_emotes(emotes, instruction, recent_chat)
+        .into_iter()
+        .take(max_prompt_emotes)
+        .map(format_prompt_emote_line)
+        .collect::<Vec<_>>();
+
     if lines.is_empty() {
         return None;
     }
 
     Some(format!(
-        "\n\n7TV emotes available in this channel:\nUse only these exact emote codes, only when they naturally match the tone. Do not explain emotes. Use at most one or two emotes per response, and skip emotes for serious topics.\n{}",
+        "\n\n7TV emotes available in this channel:\nUse only these exact emote codes. In normal casual Twitch-chat replies, include exactly one fitting emote by default. Use zero emotes only for extremely serious, administrative, fact-sensitive, or clearly unsuitable topics. Use two emotes only when the chat moment is obviously hype, chaotic, or spammy. Prefer emotes recently used by chat when they fit. Do not invent or explain emotes.\n{}",
         lines.join("\n")
     ))
+}
+
+fn rank_prompt_emotes<'a>(
+    emotes: &'a [PromptEmote],
+    instruction: &str,
+    recent_chat: &str,
+) -> Vec<&'a PromptEmote> {
+    let context_terms = searchable_terms(instruction);
+    let mut ranked = emotes
+        .iter()
+        .enumerate()
+        .map(|(index, emote)| {
+            let recent_count = recent_emote_count(recent_chat, &emote.name);
+            let context_score = context_match_score(emote, &context_terms);
+            (index, recent_count, context_score, emote)
+        })
+        .collect::<Vec<_>>();
+
+    ranked.sort_by(|a, b| {
+        b.1.cmp(&a.1)
+            .then_with(|| b.2.cmp(&a.2))
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    ranked.into_iter().map(|(_, _, _, emote)| emote).collect()
+}
+
+fn format_prompt_emote_line(emote: &PromptEmote) -> String {
+    let mut line = format!("- {}: meaning={}", emote.name, emote.meaning);
+    if let Some(usage) = emote.usage.as_deref() {
+        line.push_str("; use=");
+        line.push_str(usage);
+    }
+    if let Some(avoid) = emote.avoid.as_deref() {
+        line.push_str("; avoid=");
+        line.push_str(avoid);
+    }
+    line
+}
+
+fn recent_emote_count(recent_chat: &str, emote_name: &str) -> usize {
+    recent_chat
+        .split_whitespace()
+        .filter(|token| token_matches_emote(token, emote_name))
+        .count()
+}
+
+fn token_matches_emote(token: &str, emote_name: &str) -> bool {
+    token == emote_name || trim_wrapping_chat_punctuation(token) == emote_name
+}
+
+fn trim_wrapping_chat_punctuation(token: &str) -> &str {
+    token.trim_matches(|c| {
+        matches!(
+            c,
+            ',' | '.' | '!' | ';' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}'
+        )
+    })
+}
+
+fn context_match_score(emote: &PromptEmote, context_terms: &[String]) -> usize {
+    if context_terms.is_empty() {
+        return 0;
+    }
+
+    let mut fields = emote.meaning.clone();
+    if let Some(usage) = emote.usage.as_deref() {
+        fields.push(' ');
+        fields.push_str(usage);
+    }
+    let emote_terms = searchable_terms(&fields);
+
+    context_terms
+        .iter()
+        .filter(|query| emote_terms.iter().any(|term| terms_match(query, term)))
+        .count()
+}
+
+fn searchable_terms(text: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    text.split(|c: char| !c.is_alphanumeric())
+        .map(str::to_lowercase)
+        .filter(|term| term.len() >= 4 && !is_context_stopword(term))
+        .filter(|term| seen.insert(term.clone()))
+        .collect()
+}
+
+fn is_context_stopword(term: &str) -> bool {
+    matches!(
+        term,
+        "eine"
+            | "einer"
+            | "einem"
+            | "einen"
+            | "etwas"
+            | "wenn"
+            | "oder"
+            | "nicht"
+            | "bitte"
+            | "reply"
+            | "message"
+            | "author"
+            | "parent"
+            | "user"
+            | "chat"
+            | "channel"
+    )
+}
+
+fn terms_match(query: &str, term: &str) -> bool {
+    query == term
+        || (query.len() >= 5
+            && term.len() >= 5
+            && (query.starts_with(term) || term.starts_with(query)))
 }
 
 fn normalize_prompt_field(value: &str) -> String {
@@ -396,7 +544,8 @@ mod tests {
             Vec::new(),
         );
 
-        let prompt = build_prompt_block(&glossary, &available, 40).unwrap();
+        let emotes = build_available_prompt_emotes(&glossary, &available).unwrap();
+        let prompt = build_prompt_block(&emotes, 40, "", "").unwrap();
 
         assert!(prompt.contains("KEKW"));
         assert!(prompt.contains("meaning=lachen"));
@@ -483,7 +632,8 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(capture);
 
         tracing::subscriber::with_default(subscriber, || {
-            let prompt = build_prompt_block(&glossary, &available, 40).unwrap();
+            let emotes = build_available_prompt_emotes(&glossary, &available).unwrap();
+            let prompt = build_prompt_block(&emotes, 40, "", "").unwrap();
             assert!(prompt.contains("KEKW"));
             assert!(!prompt.contains("MissingA"));
             assert!(!prompt.contains("MissingB"));
@@ -536,9 +686,94 @@ mod tests {
             Vec::new(),
         );
 
-        let prompt = build_prompt_block(&glossary, &available, 1).unwrap();
+        let emotes = build_available_prompt_emotes(&glossary, &available).unwrap();
+        let prompt = build_prompt_block(&emotes, 1, "", "").unwrap();
 
         assert!(prompt.contains("A"));
         assert!(!prompt.contains("B"));
+    }
+
+    #[test]
+    fn prompt_prioritizes_emotes_seen_in_recent_chat() {
+        let glossary = vec![
+            GlossaryEmote {
+                name: "KEKW".into(),
+                meaning: "lachen".into(),
+                usage: Some("wenn etwas lustig ist".into()),
+                avoid: None,
+            },
+            GlossaryEmote {
+                name: "LocalEmote".into(),
+                meaning: "lokaler Channel-Insider".into(),
+                usage: Some("wenn der Chat den Insider anspricht".into()),
+                avoid: None,
+            },
+        ];
+        let available = merge_emote_sets(
+            vec![
+                SevenTvEmote {
+                    name: "KEKW".into(),
+                },
+                SevenTvEmote {
+                    name: "LocalEmote".into(),
+                },
+            ],
+            Vec::new(),
+        );
+        let emotes = build_available_prompt_emotes(&glossary, &available).unwrap();
+
+        let prompt = build_prompt_block(
+            &emotes,
+            2,
+            "sag etwas lustiges",
+            "## Recent chat (#main)\n[13:37] bob: LocalEmote",
+        )
+        .unwrap();
+
+        let local_pos = prompt.find("- LocalEmote:").unwrap();
+        let kekw_pos = prompt.find("- KEKW:").unwrap();
+        assert!(
+            local_pos < kekw_pos,
+            "recent chat emote should rank first:\n{prompt}"
+        );
+    }
+
+    #[test]
+    fn prompt_prioritizes_context_matches_when_chat_is_neutral() {
+        let glossary = vec![
+            GlossaryEmote {
+                name: "LocalEmote".into(),
+                meaning: "lokaler Channel-Insider".into(),
+                usage: Some("wenn der Chat den Insider anspricht".into()),
+                avoid: None,
+            },
+            GlossaryEmote {
+                name: "KEKW".into(),
+                meaning: "lachen, etwas ist lustig".into(),
+                usage: Some("bei Witzen oder Fail-Momenten".into()),
+                avoid: None,
+            },
+        ];
+        let available = merge_emote_sets(
+            vec![
+                SevenTvEmote {
+                    name: "LocalEmote".into(),
+                },
+                SevenTvEmote {
+                    name: "KEKW".into(),
+                },
+            ],
+            Vec::new(),
+        );
+        let emotes = build_available_prompt_emotes(&glossary, &available).unwrap();
+
+        let prompt = build_prompt_block(&emotes, 2, "sag etwas lustiges", "").unwrap();
+
+        let local_pos = prompt.find("- LocalEmote:").unwrap();
+        let kekw_pos = prompt.find("- KEKW:").unwrap();
+        assert!(
+            kekw_pos < local_pos,
+            "context-matching emote should outrank TOML order:\n{prompt}"
+        );
     }
 }

--- a/crates/twitch-1337/tests/ai.rs
+++ b/crates/twitch-1337/tests/ai.rs
@@ -55,7 +55,7 @@ async fn ai_command_injects_7tv_emote_glossary() {
         .with_ai()
         .with_config(|c| {
             if let Some(ai) = c.ai.as_mut() {
-                ai.history_length = 0;
+                ai.history_length = 10;
                 ai.emotes.enabled = true;
                 ai.emotes.include_global = true;
             }
@@ -112,6 +112,9 @@ meaning = "steht nicht im aktuellen 7TV-Katalog"
         .mount(&bot.seventv_mock)
         .await;
 
+    bot.send("bob", "LocalEmote heute stark").await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
     bot.llm.push_tool_message("passt KEKW");
     bot.send("alice", "!ai sag etwas lustiges").await;
     let body = bot.expect_reply(Duration::from_secs(2)).await;
@@ -129,6 +132,13 @@ meaning = "steht nicht im aktuellen 7TV-Katalog"
     assert!(system_msg.content.contains("meaning=lachen"));
     assert!(system_msg.content.contains("LocalEmote"));
     assert!(!system_msg.content.contains("MissingEmote"));
+    let local_pos = system_msg.content.find("- LocalEmote:").unwrap();
+    let kekw_pos = system_msg.content.find("- KEKW:").unwrap();
+    assert!(
+        local_pos < kekw_pos,
+        "recent chat emote should rank before generic context match:\n{}",
+        system_msg.content
+    );
 
     bot.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- update the 7TV emote glossary data
- rank AI emote prompt entries per turn instead of injecting a static first slice
- prefer emotes recently used in chat, then context matches, then curated TOML order
- bias the AI toward one fitting emote in normal casual Twitch chat, while still allowing no emote for serious or unsuitable topics

## Impact

This keeps Aurora using emotes frequently, but makes the available emote choices better match the current chat moment. The public config and command interface stay unchanged.

## Validation

- `cargo +1.95.0 fmt`
- `cargo +1.95.0 test -p twitch-1337 seventv`
- `cargo +1.95.0 test -p twitch-1337 ai_command_injects_7tv_emote_glossary`
- `cargo +1.95.0 test -p twitch-1337 --test ai`

Note: integration tests were run with permissions to bind local WireMock ports.
