### PR TITLE
refactor(ai): bake 7TV emote glossary into binary

### DIFF
--- a/crates/twitch-1337/config.toml.example
+++ b/crates/twitch-1337/config.toml.example
@@ -82,20 +82,13 @@ client_secret = "your_client_secret"
 # max_writes_per_turn = 8                             # Max memory writes the model may make per turn (1..=64, default: 8)
 #
 # Optional: 7TV emote grounding for !ai
-# Requires a manual glossary file so the model only gets emotes with known meaning.
+# The glossary that maps emote names to meanings is baked into the binary;
+# enable the feature here, no glossary file is read at runtime.
 # [ai.emotes]
 # enabled = true
 # include_global = true
 # refresh_interval_secs = 3600
 # max_prompt_emotes = 40
-# glossary_path = "7tv_emotes.toml"  # Relative paths resolve under the bot data dir
-#
-# Example glossary file:
-# [[emotes]]
-# name = "KEKW"
-# meaning = "laughter; something is funny"
-# usage = "jokes, fail moments, or ironic chat reactions"
-# avoid = "serious topics"
 #
 # Optional: expose web tools to !ai (`web_search` + `read_url`) via SearXNG.
 # The model can search current events and fetch article text at runtime.

--- a/crates/twitch-1337/src/config.rs
+++ b/crates/twitch-1337/src/config.rs
@@ -51,10 +51,6 @@ fn default_ai_channel_history_length() -> u64 {
     50
 }
 
-fn default_emote_glossary_path() -> String {
-    "7tv_emotes.toml".to_string()
-}
-
 fn default_emote_refresh_interval() -> u64 {
     3600
 }
@@ -262,8 +258,6 @@ pub struct AiEmotesConfigSection {
     pub refresh_interval_secs: u64,
     #[serde(default = "default_max_prompt_emotes")]
     pub max_prompt_emotes: usize,
-    #[serde(default = "default_emote_glossary_path")]
-    pub glossary_path: String,
     /// Optional override for tests or private mirrors. Defaults to
     /// `https://7tv.io/v3` when omitted.
     #[serde(default)]
@@ -277,7 +271,6 @@ impl Default for AiEmotesConfigSection {
             include_global: true,
             refresh_interval_secs: default_emote_refresh_interval(),
             max_prompt_emotes: default_max_prompt_emotes(),
-            glossary_path: default_emote_glossary_path(),
             base_url: None,
         }
     }
@@ -793,9 +786,6 @@ pub fn validate_config(config: &Configuration) -> Result<()> {
                 ai.emotes.max_prompt_emotes
             );
         }
-        if ai.emotes.glossary_path.trim().is_empty() {
-            bail!("ai.emotes.glossary_path cannot be empty when emotes are enabled");
-        }
         if let Some(ref base_url) = ai.emotes.base_url
             && base_url.trim().is_empty()
         {
@@ -944,10 +934,6 @@ mod tests {
     fn ai_emotes_default_disabled() {
         assert!(!AiEmotesConfigSection::default().enabled);
         assert!(AiEmotesConfigSection::default().include_global);
-        assert_eq!(
-            AiEmotesConfigSection::default().glossary_path,
-            "7tv_emotes.toml"
-        );
     }
 
     #[test]
@@ -970,7 +956,6 @@ mod tests {
         let mut c = Configuration::test_default();
         let mut ai = ai_with_run_at("04:00");
         ai.emotes.enabled = true;
-        ai.emotes.glossary_path = "7tv_emotes.toml".into();
         ai.emotes.refresh_interval_secs = 60;
         ai.emotes.max_prompt_emotes = 40;
         c.ai = Some(ai);

--- a/crates/twitch-1337/src/lib.rs
+++ b/crates/twitch-1337/src/lib.rs
@@ -76,6 +76,10 @@ pub struct Services {
     pub aviation: Option<AviationClient>,
     pub whisper: Option<Arc<dyn WhisperSender>>,
     pub data_dir: PathBuf,
+    /// Optional override for the 7TV emote glossary TOML. Production leaves
+    /// this `None` so the baked glossary is used; integration tests inject
+    /// custom fixtures.
+    pub emote_glossary_override: Option<String>,
 }
 
 /// Run the bot until `shutdown` fires or a handler exits.
@@ -100,6 +104,7 @@ where
         aviation,
         whisper,
         data_dir,
+        emote_glossary_override,
     } = services;
 
     let schedules_enabled = !config.schedules.is_empty();
@@ -118,6 +123,22 @@ where
     let ai_memory_v2 =
         crate::ai::command::build_ai_memory_v2(config.ai.as_ref(), &data_dir).await?;
     let transcript = ai_memory_v2.as_ref().map(|m| m.transcript.clone());
+
+    // 7TV emote provider: built once at startup so malformed glossary TOML
+    // (baked or test-injected) fails fast instead of silently disabling emotes.
+    let emote_provider = match (llm.as_ref(), config.ai.as_ref()) {
+        (Some(_), Some(ai)) if ai.emotes.enabled => {
+            let glossary_toml = emote_glossary_override
+                .as_deref()
+                .unwrap_or(crate::twitch::seventv::BAKED_GLOSSARY_TOML);
+            let provider =
+                crate::twitch::seventv::SevenTvEmoteProvider::new(ai.emotes.clone(), glossary_toml)
+                    .wrap_err("Failed to initialize 7TV emote provider")?;
+            tracing::info!("7TV emote glossary prompt grounding enabled");
+            Some(Arc::new(provider))
+        }
+        _ => None,
+    };
 
     // Clone before moving into SpawnDeps so the dreamer ritual can also use them.
     let ai_memory_v2_for_ritual = ai_memory_v2.clone();
@@ -140,6 +161,7 @@ where
         whisper,
         aviation,
         aviation_for_commands,
+        emote_provider,
     });
 
     let shutdown_notify = handlers.shutdown_notify.clone();

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -66,6 +66,7 @@ pub async fn main() -> Result<()> {
         aviation: aviation_client,
         whisper: Some(whisper),
         data_dir: get_data_dir(),
+        emote_glossary_override: None,
     };
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();

--- a/crates/twitch-1337/src/twitch/handlers/commands.rs
+++ b/crates/twitch-1337/src/twitch/handlers/commands.rs
@@ -48,6 +48,8 @@ pub struct CommandHandlerConfig<T: Transport, L: LoginCredentials> {
     pub data_dir: std::path::PathBuf,
     pub suspension_manager: Arc<SuspensionManager>,
     pub suspend: SuspendConfig,
+    /// Pre-built 7TV emote provider. `None` disables emote grounding for `!ai`.
+    pub emote_provider: Option<Arc<SevenTvEmoteProvider>>,
 }
 
 /// Handler for generic text commands that start with `!`.
@@ -81,6 +83,7 @@ where
         data_dir,
         suspension_manager,
         suspend,
+        emote_provider,
     } = cfg;
 
     let default_suspend_duration = Duration::from_secs(suspend.default_duration_secs);
@@ -128,20 +131,6 @@ where
         )),
         _ => None,
     };
-
-    let emote_provider = llm_client
-        .as_ref()
-        .and_then(|(_, cfg)| cfg.emotes.enabled.then_some(cfg.emotes.clone()))
-        .and_then(|emotes_cfg| match SevenTvEmoteProvider::new(emotes_cfg, &data_dir) {
-            Ok(provider) => {
-                info!("7TV emote glossary prompt grounding enabled");
-                Some(Arc::new(provider))
-            }
-            Err(e) => {
-                error!(error = ?e, "Failed to initialize 7TV emote provider; AI emotes disabled");
-                None
-            }
-        });
 
     let mut cmd_list: Vec<Box<dyn commands::Command<T, L>>> = vec![
         Box::new(commands::ping_admin::PingAdminCommand::new(

--- a/crates/twitch-1337/src/twitch/handlers/spawn.rs
+++ b/crates/twitch-1337/src/twitch/handlers/spawn.rs
@@ -81,6 +81,9 @@ pub(crate) struct SpawnDeps<T: Transport, L: LoginCredentials> {
     // Flight tracker.
     pub aviation: Option<AviationClient>,
     pub aviation_for_commands: Option<AviationClient>,
+
+    // AI emote grounding.
+    pub emote_provider: Option<Arc<crate::twitch::seventv::SevenTvEmoteProvider>>,
 }
 
 /// Spawn every long-running handler task in the order they currently
@@ -106,6 +109,7 @@ where
         whisper,
         aviation,
         aviation_for_commands,
+        emote_provider,
     } = deps;
 
     let schedules_enabled = !config.schedules.is_empty();
@@ -235,6 +239,7 @@ where
                 data_dir: data_dir.clone(),
                 suspension_manager: suspension_manager.clone(),
                 suspend: config.suspend.clone(),
+                emote_provider,
             })
             .await;
         }

--- a/crates/twitch-1337/src/twitch/seventv.rs
+++ b/crates/twitch-1337/src/twitch/seventv.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::HashSet,
-    path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
@@ -16,13 +15,17 @@ use crate::{APP_USER_AGENT, config::AiEmotesConfigSection};
 const DEFAULT_BASE_URL: &str = "https://7tv.io/v3";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Manual glossary baked into the binary at build time. Curated alongside the
+/// rest of the codebase; updates ship with the binary, not as a runtime file.
+pub const BAKED_GLOSSARY_TOML: &str = include_str!("../../data/7tv_emotes.toml");
+
 /// Lazily refreshes the available 7TV catalog and builds an LLM prompt block
 /// from the intersection with a manual glossary.
 #[derive(Debug)]
 pub struct SevenTvEmoteProvider {
     http: reqwest::Client,
     base_url: String,
-    glossary_path: PathBuf,
+    glossary: Vec<GlossaryEmote>,
     include_global: bool,
     refresh_interval: Duration,
     max_prompt_emotes: usize,
@@ -77,15 +80,14 @@ struct SevenTvEmote {
 }
 
 impl SevenTvEmoteProvider {
-    /// Build a provider from `[ai.emotes]`. Relative glossary paths resolve
-    /// under the bot data directory.
-    pub fn new(config: AiEmotesConfigSection, data_dir: &Path) -> Result<Self> {
-        let glossary_path = PathBuf::from(&config.glossary_path);
-        let glossary_path = if glossary_path.is_absolute() {
-            glossary_path
-        } else {
-            data_dir.join(glossary_path)
-        };
+    /// Build a provider from `[ai.emotes]` and a TOML glossary string.
+    ///
+    /// Production code passes [`BAKED_GLOSSARY_TOML`]; integration tests pass
+    /// a custom fixture. The glossary is parsed eagerly so malformed TOML
+    /// fails the bot at startup instead of silently disabling emotes.
+    pub fn new(config: AiEmotesConfigSection, glossary_toml: &str) -> Result<Self> {
+        let glossary: Glossary =
+            toml::from_str(glossary_toml).wrap_err("Failed to parse 7TV emote glossary")?;
 
         let http = reqwest::Client::builder()
             .user_agent(APP_USER_AGENT)
@@ -101,7 +103,7 @@ impl SevenTvEmoteProvider {
                 .unwrap_or(DEFAULT_BASE_URL)
                 .trim_end_matches('/')
                 .to_string(),
-            glossary_path,
+            glossary: glossary.emotes,
             include_global: config.include_global,
             refresh_interval: Duration::from_secs(config.refresh_interval_secs),
             max_prompt_emotes: config.max_prompt_emotes,
@@ -156,30 +158,14 @@ impl SevenTvEmoteProvider {
         &self,
         twitch_channel_id: &str,
     ) -> Result<Option<Vec<PromptEmote>>> {
-        let glossary = self.load_glossary().await?;
-        if glossary.emotes.is_empty() {
-            debug!(
-                path = %self.glossary_path.display(),
-                "7TV emote glossary is empty"
-            );
+        if self.glossary.is_empty() {
+            debug!("7TV emote glossary is empty");
             return Ok(None);
         }
 
         let available = self.fetch_available_emotes(twitch_channel_id).await?;
-        let emotes = build_available_prompt_emotes(&glossary.emotes, &available);
+        let emotes = build_available_prompt_emotes(&self.glossary, &available);
         Ok(emotes)
-    }
-
-    async fn load_glossary(&self) -> Result<Glossary> {
-        let text = tokio::fs::read_to_string(&self.glossary_path)
-            .await
-            .wrap_err_with(|| {
-                format!(
-                    "Failed to read 7TV emote glossary at {}",
-                    self.glossary_path.display()
-                )
-            })?;
-        toml::from_str(&text).wrap_err("Failed to parse 7TV emote glossary")
     }
 
     async fn fetch_available_emotes(&self, twitch_channel_id: &str) -> Result<HashSet<String>> {

--- a/crates/twitch-1337/tests/ai.rs
+++ b/crates/twitch-1337/tests/ai.rs
@@ -60,12 +60,8 @@ async fn ai_command_injects_7tv_emote_glossary() {
                 ai.emotes.include_global = true;
             }
         })
-        .spawn()
-        .await;
-
-    tokio::fs::write(
-        bot.data_dir.path().join("7tv_emotes.toml"),
-        r#"
+        .with_emote_glossary(
+            r#"
 [[emotes]]
 name = "KEKW"
 meaning = "lachen, etwas ist lustig"
@@ -81,9 +77,9 @@ usage = "wenn der Chat den Insider anspricht"
 name = "MissingEmote"
 meaning = "steht nicht im aktuellen 7TV-Katalog"
 "#,
-    )
-    .await
-    .unwrap();
+        )
+        .spawn()
+        .await;
 
     Mock::given(method("GET"))
         .and(path("/emote-sets/global"))
@@ -154,19 +150,15 @@ async fn ai_command_continues_when_7tv_unavailable() {
                 ai.emotes.enabled = true;
             }
         })
-        .spawn()
-        .await;
-
-    tokio::fs::write(
-        bot.data_dir.path().join("7tv_emotes.toml"),
-        r#"
+        .with_emote_glossary(
+            r#"
 [[emotes]]
 name = "KEKW"
 meaning = "lachen"
 "#,
-    )
-    .await
-    .unwrap();
+        )
+        .spawn()
+        .await;
 
     Mock::given(method("GET"))
         .and(path("/emote-sets/global"))

--- a/crates/twitch-1337/tests/common/test_bot.rs
+++ b/crates/twitch-1337/tests/common/test_bot.rs
@@ -51,6 +51,7 @@ pub struct TestBotBuilder {
     now: DateTime<Utc>,
     seeded_leaderboard: Option<HashMap<String, PersonalBest>>,
     whisper_failure: bool,
+    emote_glossary_override: Option<String>,
 }
 
 impl TestBotBuilder {
@@ -60,7 +61,16 @@ impl TestBotBuilder {
             now: "2026-04-18T11:00:00Z".parse().unwrap(),
             seeded_leaderboard: None,
             whisper_failure: false,
+            emote_glossary_override: None,
         }
+    }
+
+    /// Inject a custom 7TV emote glossary TOML for this test run instead of
+    /// the baked production glossary. Lets tests assert on bespoke fixtures
+    /// (KEKW/LocalEmote/MissingEmote, etc.) without touching disk.
+    pub fn with_emote_glossary(mut self, toml: impl Into<String>) -> Self {
+        self.emote_glossary_override = Some(toml.into());
+        self
     }
 
     pub fn with_ai(mut self) -> Self {
@@ -185,6 +195,7 @@ impl TestBotBuilder {
             aviation: Some(aviation),
             whisper: Some(whisper.clone() as Arc<dyn WhisperSender>),
             data_dir: data_dir.path().to_path_buf(),
+            emote_glossary_override: self.emote_glossary_override,
         };
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();


### PR DESCRIPTION
## Summary

- Bake \`crates/twitch-1337/data/7tv_emotes.toml\` (152 KB) into the binary via \`include_str!\`, matching the existing pattern for airports/airlines/plz CSVs. Drop the \`[ai.emotes].glossary_path\` config knob.
- Move \`SevenTvEmoteProvider\` construction from the command handler into \`run_bot\` and propagate parse errors with \`?\`. Malformed glossary now fails startup loudly instead of silently disabling emotes.
- Tests inject bespoke fixtures via \`TestBotBuilder::with_emote_glossary(...)\` threaded through a new \`Services.emote_glossary_override\` field; no more on-disk fixture writes.

Stale \`glossary_path = \"...\"\` lines in existing \`config.toml\` files are ignored (no \`deny_unknown_fields\`); no migration needed.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo nextest run\` — 332 passed, 1 skipped
- [ ] CI: 7 required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)