### PR TITLE
fix(web): improve OAuth callback error logging + bump askama/tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,11 +128,11 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -141,12 +141,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -157,15 +158,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash",
  "serde",
  "serde_derive",
- "winnow 0.7.15",
+ "unicode-ident",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -986,6 +997,12 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -3058,9 +3075,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4056,6 +4073,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-askama = { version = "0.14" }
+askama = { version = "0.16" }
 async-trait = "0.1.89"
 axum = { version = "0.8", default-features = false, features = ["form", "http1", "json", "query", "tokio", "tower-log", "tracing"] }
 base64 = "0.22"
@@ -35,7 +35,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0.18"
-tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "signal", "time", "fs"] }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "signal", "time", "fs"] }
 toml = "1.1.2"
 tower = { version = "0.5", features = ["util"] }
 tower-cookies = { version = "0.11", features = ["signed", "private"] }

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -189,12 +189,14 @@ async fn callback(
         .exchange_code(AuthorizationCode::new(params.code))
         .request_async(&http_call)
         .await
-        .map_err(|e| WebError::OAuthExchange(e.to_string()))?;
+        .map_err(|e| {
+            WebError::OAuthExchange(eyre::Report::new(e).wrap_err("token exchange"))
+        })?;
 
     let user_token = token.access_token().secret().to_owned();
     let me = fetch_caller_user(&state, &user_token)
         .await
-        .map_err(|e| WebError::OAuthExchange(format!("user lookup: {e}")))?;
+        .map_err(|e| WebError::OAuthExchange(e.wrap_err("user lookup")))?;
 
     // Initial mod check uses the user's own access token (granted
     // `moderation:read` via OAuth scope), so the bot's IRC token does not
@@ -208,7 +210,7 @@ async fn callback(
         &state.hidden_admins,
     )
     .await
-    .map_err(|e| WebError::OAuthExchange(format!("mod check: {e}")))?
+    .map_err(|e| WebError::OAuthExchange(e.wrap_err("mod check")))?
     {
         ModCheckOutcome::Allow => {}
         ModCheckOutcome::Deny => {
@@ -295,21 +297,25 @@ async fn fetch_caller_user(
     struct Resp {
         data: Vec<crate::helix::HelixUser>,
     }
-    let resp: Resp = state
+    let resp = state
         .oauth
         .http
         .get("https://api.twitch.tv/helix/users")
         .bearer_auth(access_token)
         .header("Client-Id", state.client_id.expose_secret())
         .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
-    resp.data
+        .await
+        .wrap_err("helix /users request send")?;
+    let status = resp.status();
+    let resp = resp
+        .error_for_status()
+        .wrap_err_with(|| format!("helix /users returned {status}"))?;
+    let parsed: Resp = resp.json().await.wrap_err("helix /users decode")?;
+    parsed
+        .data
         .into_iter()
         .next()
-        .ok_or_else(|| eyre!("empty user list"))
+        .ok_or_else(|| eyre!("helix /users returned empty data array"))
 }
 
 pub async fn require_mod(

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -189,9 +189,7 @@ async fn callback(
         .exchange_code(AuthorizationCode::new(params.code))
         .request_async(&http_call)
         .await
-        .map_err(|e| {
-            WebError::OAuthExchange(eyre::Report::new(e).wrap_err("token exchange"))
-        })?;
+        .map_err(|e| WebError::OAuthExchange(eyre::Report::new(e).wrap_err("token exchange")))?;
 
     let user_token = token.access_token().secret().to_owned();
     let me = fetch_caller_user(&state, &user_token)

--- a/crates/web/src/error.rs
+++ b/crates/web/src/error.rs
@@ -26,8 +26,12 @@ pub enum WebError {
     /// clippy lint — the inner payload carries multiple String fields.
     #[error("conflict")]
     Conflict(Box<ConflictPayload>),
+    /// OAuth flow failure (token exchange, user lookup, mod check). The
+    /// inner `eyre::Report` carries the wrapped chain — logged via Debug
+    /// (full chain + spantrace) when the response is built so cloudflare's
+    /// 502 has a matching server-side trace.
     #[error("oauth exchange: {0}")]
-    OAuthExchange(String),
+    OAuthExchange(eyre::Report),
     #[error("internal: {0}")]
     Internal(#[from] eyre::Report),
 }
@@ -129,11 +133,14 @@ impl IntoResponse for WebError {
                     current_page: payload.current_page,
                 },
             ),
-            WebError::OAuthExchange(msg) => (
-                StatusCode::BAD_GATEWAY,
-                format!("oauth exchange failed: {msg}"),
-            )
-                .into_response(),
+            WebError::OAuthExchange(err) => {
+                tracing::error!(
+                    target: "twitch_1337_web",
+                    error = ?err,
+                    "oauth exchange failed"
+                );
+                (StatusCode::BAD_GATEWAY, "oauth exchange failed").into_response()
+            }
             WebError::Internal(err) => {
                 tracing::error!(
                     target: "twitch_1337_web",


### PR DESCRIPTION
## Summary
- Bump `askama` 0.14 → 0.16, relax `tokio` pin from `1.52.1` to `1.52` (caret).
- Carry `eyre::Report` on `WebError::OAuthExchange` so the OAuth callback logs the full error chain on failure instead of surfacing only as a cloudflare 502 with no server-side detail.
- Split helix `/users` into send / status / decode stages so a non-2xx or decode error is identifiable in logs.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo nextest run` (402 passed, 1 skipped)
- [x] `cargo clippy -p twitch-1337-web --all-targets -- -D warnings`
- [ ] Reproduce the prod 502: trigger an OAuth callback failure and confirm log line includes stage label + chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)