### PR TITLE
fix(web): friendly retry page on OAuth callback failure

### DIFF
--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -189,7 +189,20 @@ async fn callback(
         .exchange_code(AuthorizationCode::new(params.code))
         .request_async(&http_call)
         .await
-        .map_err(|e| WebError::OAuthExchange(eyre::Report::new(e).wrap_err("token exchange")))?;
+        .map_err(|e| {
+            // Twitch returns non-RFC-6749 error bodies that fail Parse; surface
+            // the raw body so logs show the upstream message.
+            let msg = match &e {
+                oauth2::RequestTokenError::Parse(_, body) => {
+                    format!(
+                        "token exchange (response body: {})",
+                        String::from_utf8_lossy(body)
+                    )
+                }
+                _ => "token exchange".into(),
+            };
+            WebError::OAuthExchange(eyre::Report::new(e).wrap_err(msg))
+        })?;
 
     let user_token = token.access_token().secret().to_owned();
     let me = fetch_caller_user(&state, &user_token)

--- a/crates/web/src/error.rs
+++ b/crates/web/src/error.rs
@@ -60,6 +60,10 @@ pub struct ConflictPayload {
 struct DeniedTpl;
 
 #[derive(Template)]
+#[template(path = "auth/oauth_failed.html")]
+struct OAuthFailedTpl;
+
+#[derive(Template)]
 #[template(path = "memory/conflict.html")]
 struct ConflictTpl<'a> {
     kind: &'a str,
@@ -139,7 +143,8 @@ impl IntoResponse for WebError {
                     error = ?err,
                     "oauth exchange failed"
                 );
-                (StatusCode::BAD_GATEWAY, "oauth exchange failed").into_response()
+                // Almost always a stale/reused auth code (refresh, double-tab); offer retry instead of bare 502.
+                render(StatusCode::BAD_GATEWAY, &OAuthFailedTpl)
             }
             WebError::Internal(err) => {
                 tracing::error!(

--- a/crates/web/templates/auth/oauth_failed.html
+++ b/crates/web/templates/auth/oauth_failed.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block layout %}
+<main class="content">
+  <h1>Login failed</h1>
+  <p>Something went wrong while signing you in. The login link may have expired or been used already &mdash; this often happens when the callback page is reloaded or opened in a second tab.</p>
+  <p><a href="/login" role="button">Try again</a></p>
+</main>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Render an HTML "Login failed / Try again" page on `WebError::OAuthExchange` instead of a bare `502 oauth exchange failed` body. Most callback failures are stale or already-used auth codes (refresh, double-tab, expired) — one click on `/login` issues a fresh code.
- Surface Twitch's upstream response body in the error log. oauth2 v5's `RequestTokenError::Parse` keeps the raw bytes, but Twitch returns non-RFC-6749 errors (`{\"status\":400,\"message\":\"...\"}`) so the default `Display` only printed `missing field \`error\` at line 1 column 44`. Pull the body into the eyre wrap so the actual upstream message lands in the log.

## Notes

- Status code retained at 502 (upstream-style failure) — only the response body changes from a plain-text line to a navigable page.
- New template `crates/web/templates/auth/oauth_failed.html` follows the `auth/denied.html` pattern (extends `base.html`, single `<main>`, retry CTA).
- The `tw1337_next` cookie still persists on the failure path, so retry preserves the original deep-link target.

## Test plan

- [ ] Trigger callback with an invalid `code` (e.g. tampered query) — log shows the Twitch body verbatim, browser sees the retry page.
- [ ] Click "Try again" → fresh `/login` round-trip succeeds.
- [ ] CI: fmt + clippy + test, audit, hadolint, trivy, actionlint, zizmor, gitleaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)