### PR TITLE
fix(web): handle Twitch scope array + redact tokens in error logs

### DIFF
--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -101,7 +101,7 @@ async fn oauth_http_call(
     let resp = builder.send().await?;
     let status = resp.status();
     let headers = resp.headers().clone();
-    let bytes = resp.bytes().await?.to_vec();
+    let bytes = normalize_twitch_scope(resp.bytes().await?.to_vec());
 
     let mut http_resp = http::Response::builder().status(status.as_u16());
     for (name, value) in headers.iter() {
@@ -110,6 +110,50 @@ async fn oauth_http_call(
     http_resp
         .body(bytes)
         .map_err(|e| OAuthHttpError::Header(e.to_string()))
+}
+
+/// Twitch returns `scope` as a JSON array (`["a","b"]`), but RFC 6749 — and
+/// therefore oauth2 v5's `StandardTokenResponse` deserializer — expects a
+/// space-separated string. Rewrite arrays to strings so token parsing
+/// succeeds. No-op on non-JSON, non-object, or already-string shapes.
+fn normalize_twitch_scope(body: Vec<u8>) -> Vec<u8> {
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return body;
+    };
+    let Some(obj) = value.as_object_mut() else {
+        return body;
+    };
+    let Some(arr) = obj.get("scope").and_then(serde_json::Value::as_array) else {
+        return body;
+    };
+    let joined = arr
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>()
+        .join(" ");
+    obj.insert("scope".to_owned(), serde_json::Value::String(joined));
+    serde_json::to_vec(&value).unwrap_or(body)
+}
+
+/// Replace values of known credential-bearing JSON fields with `<redacted>`
+/// so error logs that include a response body never leak access/refresh
+/// tokens. No-op on non-JSON or non-object bodies.
+fn redact_token_body(body: &[u8]) -> String {
+    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return String::from_utf8_lossy(body).into_owned();
+    };
+    let Some(obj) = value.as_object_mut() else {
+        return String::from_utf8_lossy(body).into_owned();
+    };
+    for key in ["access_token", "refresh_token", "id_token"] {
+        if obj.contains_key(key) {
+            obj.insert(
+                key.to_owned(),
+                serde_json::Value::String("<redacted>".into()),
+            );
+        }
+    }
+    value.to_string()
 }
 
 pub fn auth_router() -> Router<WebState> {
@@ -196,12 +240,13 @@ async fn callback(
         .await
         .map_err(|e| {
             // Twitch returns non-RFC-6749 error bodies that fail Parse; surface
-            // the raw body so logs show the upstream message.
+            // the (token-redacted) raw body so logs show the upstream message
+            // without leaking access/refresh tokens on success-shaped bodies.
             let msg = match &e {
                 oauth2::RequestTokenError::Parse(_, body) => {
                     format!(
                         "token exchange (response body: {})",
-                        String::from_utf8_lossy(body)
+                        redact_token_body(body)
                     )
                 }
                 _ => "token exchange".into(),
@@ -386,4 +431,57 @@ pub async fn require_mod(
 
     req.extensions_mut().insert(session);
     Ok(next.run(req).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_twitch_scope_rewrites_array_to_space_string() {
+        let body = br#"{"access_token":"x","scope":["a","b"],"token_type":"bearer"}"#.to_vec();
+        let out = normalize_twitch_scope(body);
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed["scope"], serde_json::Value::String("a b".into()));
+    }
+
+    #[test]
+    fn normalize_twitch_scope_passes_through_string_scope() {
+        let body = br#"{"access_token":"x","scope":"a b","token_type":"bearer"}"#.to_vec();
+        let out = normalize_twitch_scope(body.clone());
+        // Re-parse rather than byte-compare; serialization order is not guaranteed.
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(parsed["scope"], serde_json::Value::String("a b".into()));
+    }
+
+    #[test]
+    fn normalize_twitch_scope_passes_through_non_json() {
+        let body = b"not json".to_vec();
+        assert_eq!(normalize_twitch_scope(body.clone()), body);
+    }
+
+    #[test]
+    fn redact_token_body_replaces_known_credential_fields() {
+        let body = br#"{"access_token":"secret","refresh_token":"rsecret","scope":["a"]}"#;
+        let out = redact_token_body(body);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["access_token"], "<redacted>");
+        assert_eq!(parsed["refresh_token"], "<redacted>");
+        assert_eq!(parsed["scope"], serde_json::json!(["a"]));
+    }
+
+    #[test]
+    fn redact_token_body_passes_through_error_body() {
+        let body = br#"{"status":400,"message":"missing client id"}"#;
+        let out = redact_token_body(body);
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["status"], 400);
+        assert_eq!(parsed["message"], "missing client id");
+    }
+
+    #[test]
+    fn redact_token_body_passes_through_non_json() {
+        let body = b"plain text";
+        assert_eq!(redact_token_body(body), "plain text");
+    }
 }

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -139,18 +139,16 @@ fn normalize_twitch_scope(body: Vec<u8>) -> Vec<u8> {
 /// so error logs that include a response body never leak access/refresh
 /// tokens. No-op on non-JSON or non-object bodies.
 fn redact_token_body(body: &[u8]) -> String {
-    let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(body) else {
-        return String::from_utf8_lossy(body).into_owned();
+    let mut value = match serde_json::from_slice::<serde_json::Value>(body) {
+        Ok(v) => v,
+        Err(_) => return String::from_utf8_lossy(body).into_owned(),
     };
     let Some(obj) = value.as_object_mut() else {
         return String::from_utf8_lossy(body).into_owned();
     };
     for key in ["access_token", "refresh_token", "id_token"] {
-        if obj.contains_key(key) {
-            obj.insert(
-                key.to_owned(),
-                serde_json::Value::String("<redacted>".into()),
-            );
+        if let Some(slot) = obj.get_mut(key) {
+            *slot = serde_json::Value::String("<redacted>".into());
         }
     }
     value.to_string()
@@ -461,6 +459,31 @@ mod tests {
     }
 
     #[test]
+    fn normalize_twitch_scope_passes_through_missing_scope_field() {
+        let body = br#"{"access_token":"x","token_type":"bearer"}"#.to_vec();
+        assert_eq!(normalize_twitch_scope(body.clone()), body);
+    }
+
+    #[test]
+    fn normalize_twitch_scope_handles_empty_array() {
+        let body = br#"{"access_token":"x","scope":[],"token_type":"bearer"}"#.to_vec();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&normalize_twitch_scope(body)).unwrap();
+        assert_eq!(parsed["scope"], serde_json::Value::String(String::new()));
+    }
+
+    #[test]
+    fn normalize_twitch_scope_drops_non_string_array_elements() {
+        // Twitch should never send numbers in scope, but pin the silent-drop
+        // behavior of `filter_map(as_str)` so a future Twitch quirk surfaces
+        // as a test diff rather than a parse failure on the live endpoint.
+        let body = br#"{"scope":[1,"a",2,"b"]}"#.to_vec();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&normalize_twitch_scope(body)).unwrap();
+        assert_eq!(parsed["scope"], serde_json::Value::String("a b".into()));
+    }
+
+    #[test]
     fn redact_token_body_replaces_known_credential_fields() {
         let body = br#"{"access_token":"secret","refresh_token":"rsecret","scope":["a"]}"#;
         let out = redact_token_body(body);
@@ -483,5 +506,19 @@ mod tests {
     fn redact_token_body_passes_through_non_json() {
         let body = b"plain text";
         assert_eq!(redact_token_body(body), "plain text");
+    }
+
+    #[test]
+    fn redact_token_body_redacts_id_token() {
+        let body = br#"{"id_token":"jwt.payload.sig","scope":"a"}"#;
+        let parsed: serde_json::Value = serde_json::from_str(&redact_token_body(body)).unwrap();
+        assert_eq!(parsed["id_token"], "<redacted>");
+    }
+
+    #[test]
+    fn redact_token_body_passes_through_top_level_array() {
+        let body = br#"["a","b"]"#;
+        // Top-level non-object → fall through to lossy passthrough.
+        assert_eq!(redact_token_body(body), r#"["a","b"]"#);
     }
 }


### PR DESCRIPTION
## Summary

Two bugs in the OAuth callback path, both surfacing as 502s after #167 / #168 unblocked the token exchange.

1. **Scope array parsing.** Twitch returns `scope` as a JSON array (`["a","b"]`), but RFC 6749 — and oauth2 v5's `StandardTokenResponse` — expects a space-separated string. Token exchange now succeeds at the wire level but fails to deserialize. `oauth_http_call` now rewrites the array to a space-joined string before handing the body to oauth2.
2. **Token leak in error log.** #167 added the upstream response body to the eyre chain so we could see Twitch's non-RFC error messages. That made sense for actual error responses, but the scope-parse failure is on a *success* body containing the live `access_token` and `refresh_token`. Logging that body leaked both tokens (one production token pair has been compromised — revoke / expire as needed). Redact `access_token` / `refresh_token` / `id_token` values before formatting the log so success-shaped bodies can't leak credentials, even when parsing fails.

## Test plan

- Unit tests for both helpers: `normalize_twitch_scope` (array → string, string passthrough, non-JSON passthrough), `redact_token_body` (success body redaction, error body passthrough, non-JSON passthrough).
- [ ] OAuth callback completes end-to-end against Twitch — token parses, mod check runs.
- [ ] CI: fmt + clippy + test, audit, hadolint, trivy, actionlint, zizmor, gitleaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)