### PR TITLE
fix(web): use moderated_channels for OAuth mod check

### DIFF
--- a/crates/core/src/ai/memory/transcript.rs
+++ b/crates/core/src/ai/memory/transcript.rs
@@ -56,6 +56,9 @@ impl TranscriptWriter {
             .write_all(line.as_bytes())
             .await
             .wrap_err("write transcript")?;
+        // tokio::fs::File buffers internally — flush so the dreamer ritual
+        // (and tests reading the file directly) sees the line immediately.
+        g.handle.flush().await.wrap_err("flush transcript")?;
         Ok(())
     }
 

--- a/crates/web/src/auth/mod_check.rs
+++ b/crates/web/src/auth/mod_check.rs
@@ -45,9 +45,11 @@ pub async fn check_is_mod(
     }
 }
 
-/// Variant used during the OAuth callback. The user's own access token has
-/// `moderation:read` (granted via the requested scope), so the helix call
-/// works regardless of the bot token's scopes.
+/// Variant used during the OAuth callback. Asks Twitch which channels the
+/// user moderates (scope `user:read:moderated_channels` on the user token)
+/// and checks `broadcaster_id` against that list — the
+/// `helix/moderation/moderators` endpoint can't be used here because it
+/// requires the bearer to *be* the broadcaster.
 pub async fn check_is_mod_with_token(
     state: &WebState,
     user_id: &str,
@@ -71,14 +73,14 @@ async fn is_moderator_with_user_token(
     broadcaster_id: &str,
     state: &WebState,
 ) -> eyre::Result<bool> {
-    crate::helix::helix_moderator_check(
+    crate::helix::user_moderates_channel(
         &state.oauth.http,
         "https://api.twitch.tv",
         state.client_id.expose_secret(),
         access_token,
-        broadcaster_id,
         user_id,
-        "helix moderators (user token)",
+        broadcaster_id,
+        "helix moderated channels (user token)",
     )
     .await
 }

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -195,15 +195,16 @@ async fn login(
         );
     }
     let csrf_for_url = csrf.clone();
-    // `moderation:read` lets us check the helix moderators list against the
-    // user's own access token in the callback, so the bot's IRC token does
-    // not need that scope.
+    // `user:read:moderated_channels` lets the callback ask Twitch which
+    // channels the logging-in user moderates and check our broadcaster
+    // against that list — `moderation:read` would only work if the
+    // logging-in user IS the broadcaster.
     let (auth_url, _) = state
         .oauth
         .basic
         .authorize_url(move || csrf_for_url.clone())
         .add_scope(Scope::new("user:read:email".to_owned()))
-        .add_scope(Scope::new("moderation:read".to_owned()))
+        .add_scope(Scope::new("user:read:moderated_channels".to_owned()))
         .url();
     Redirect::to(auth_url.as_ref()).into_response()
 }
@@ -258,9 +259,10 @@ async fn callback(
         .map_err(|e| WebError::OAuthExchange(e.wrap_err("user lookup")))?;
 
     // Initial mod check uses the user's own access token (granted
-    // `moderation:read` via OAuth scope), so the bot's IRC token does not
-    // need extra scopes. The require_mod middleware re-checks via the bot
-    // token; on failure there it log+admits to avoid lockout.
+    // `user:read:moderated_channels` via OAuth scope), so the bot's IRC
+    // token does not need extra scopes. The require_mod middleware
+    // re-checks via the bot token; on failure there it log+admits to
+    // avoid lockout.
     match crate::auth::mod_check::check_is_mod_with_token(
         &state,
         &me.id,

--- a/crates/web/src/helix.rs
+++ b/crates/web/src/helix.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr as _};
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 #[async_trait]
 pub trait HelixClient: Send + Sync {
@@ -68,24 +69,48 @@ impl ReqwestHelixClient {
         struct UserResp {
             data: Vec<HelixUser>,
         }
-        let mut url = url::Url::parse(&format!("{}/helix/users", self.helix_base))?;
-        for (k, v) in query {
-            url.query_pairs_mut().append_pair(k, v);
-        }
         let token = self.access_token_provider.current_access_token().await?;
-        let resp: UserResp = self
-            .http
-            .get(url)
-            .bearer_auth(&token)
-            .header("Client-Id", self.client_id.expose_secret())
-            .send()
-            .await?
-            .error_for_status()
-            .wrap_err("helix users")?
-            .json()
-            .await?;
+        let resp: UserResp = helix_get(
+            &self.http,
+            &self.helix_base,
+            "/helix/users",
+            query,
+            &token,
+            self.client_id.expose_secret(),
+            "helix users",
+        )
+        .await?;
         Ok(resp.data.into_iter().next())
     }
+}
+
+/// Shared GET → bearer + Client-Id → JSON-decode. All Twitch helix calls
+/// in this module share the same shape; this isolates it so each caller
+/// only writes the path, query, and response type.
+async fn helix_get<T: DeserializeOwned>(
+    http: &reqwest::Client,
+    helix_base: &str,
+    path: &str,
+    query: &[(&str, &str)],
+    bearer_token: &str,
+    client_id: &str,
+    context: &'static str,
+) -> Result<T> {
+    let mut url = url::Url::parse(&format!("{helix_base}{path}"))?;
+    for (k, v) in query {
+        url.query_pairs_mut().append_pair(k, v);
+    }
+    let resp = http
+        .get(url)
+        .bearer_auth(bearer_token)
+        .header("Client-Id", client_id)
+        .send()
+        .await?
+        .error_for_status()
+        .wrap_err(context)?
+        .json::<T>()
+        .await?;
+    Ok(resp)
 }
 
 #[async_trait]
@@ -131,27 +156,19 @@ pub async fn helix_moderator_check(
     struct ModResp {
         data: Vec<serde::de::IgnoredAny>,
     }
-    let mut url = url::Url::parse(&format!("{helix_base}/helix/moderation/moderators"))?;
-    url.query_pairs_mut()
-        .append_pair("broadcaster_id", broadcaster_id)
-        .append_pair("user_id", user_id);
-    let resp: ModResp = http
-        .get(url)
-        .bearer_auth(bearer_token)
-        .header("Client-Id", client_id)
-        .send()
-        .await?
-        .error_for_status()
-        .wrap_err(context)?
-        .json()
-        .await?;
+    let resp: ModResp = helix_get(
+        http,
+        helix_base,
+        "/helix/moderation/moderators",
+        &[("broadcaster_id", broadcaster_id), ("user_id", user_id)],
+        bearer_token,
+        client_id,
+        context,
+    )
+    .await?;
     Ok(!resp.data.is_empty())
 }
 
-/// Calls `helix/moderation/channels?user_id=USER` with the user's own
-/// access token (requires `user:read:moderated_channels` scope) and
-/// returns true iff `broadcaster_id` appears in the returned data.
-///
 /// Used during OAuth callback because `helix/moderation/moderators`
 /// requires the bearer's user id to match `broadcaster_id` (i.e. only
 /// the broadcaster can list their own mods), so a logging-in mod cannot
@@ -177,19 +194,15 @@ pub async fn user_moderates_channel(
     struct Resp {
         data: Vec<Channel>,
     }
-    let mut url = url::Url::parse(&format!("{helix_base}/helix/moderation/channels"))?;
-    url.query_pairs_mut()
-        .append_pair("user_id", user_id)
-        .append_pair("first", "100");
-    let resp: Resp = http
-        .get(url)
-        .bearer_auth(user_access_token)
-        .header("Client-Id", client_id)
-        .send()
-        .await?
-        .error_for_status()
-        .wrap_err(context)?
-        .json()
-        .await?;
+    let resp: Resp = helix_get(
+        http,
+        helix_base,
+        "/helix/moderation/channels",
+        &[("user_id", user_id), ("first", "100")],
+        user_access_token,
+        client_id,
+        context,
+    )
+    .await?;
     Ok(resp.data.iter().any(|c| c.broadcaster_id == broadcaster_id))
 }

--- a/crates/web/src/helix.rs
+++ b/crates/web/src/helix.rs
@@ -114,10 +114,10 @@ impl HelixClient for ReqwestHelixClient {
 }
 
 /// Single helix moderator-list call filtered by `user_id`. Returns true iff
-/// `user_id` is a moderator of `broadcaster_id`. Used by both
-/// `ReqwestHelixClient::is_moderator` (bot token) and the OAuth callback's
-/// `is_moderator_with_user_token` (user token); the only difference is the
-/// bearer.
+/// `user_id` is a moderator of `broadcaster_id`. Used by
+/// `ReqwestHelixClient::is_moderator` (bot token); the OAuth callback path
+/// uses [`user_moderates_channel`] instead because Twitch requires the
+/// token's user to *be* the broadcaster on this endpoint.
 pub async fn helix_moderator_check(
     http: &reqwest::Client,
     helix_base: &str,
@@ -146,4 +146,50 @@ pub async fn helix_moderator_check(
         .json()
         .await?;
     Ok(!resp.data.is_empty())
+}
+
+/// Calls `helix/moderation/channels?user_id=USER` with the user's own
+/// access token (requires `user:read:moderated_channels` scope) and
+/// returns true iff `broadcaster_id` appears in the returned data.
+///
+/// Used during OAuth callback because `helix/moderation/moderators`
+/// requires the bearer's user id to match `broadcaster_id` (i.e. only
+/// the broadcaster can list their own mods), so a logging-in mod cannot
+/// query their own status that way.
+///
+/// Pagination: `first=100` (Twitch's max) without follow-up — at that
+/// many moderated channels the user is almost certainly already an
+/// admin somewhere; deny on overflow is acceptable for this use case.
+pub async fn user_moderates_channel(
+    http: &reqwest::Client,
+    helix_base: &str,
+    client_id: &str,
+    user_access_token: &str,
+    user_id: &str,
+    broadcaster_id: &str,
+    context: &'static str,
+) -> Result<bool> {
+    #[derive(Deserialize)]
+    struct Channel {
+        broadcaster_id: String,
+    }
+    #[derive(Deserialize)]
+    struct Resp {
+        data: Vec<Channel>,
+    }
+    let mut url = url::Url::parse(&format!("{helix_base}/helix/moderation/channels"))?;
+    url.query_pairs_mut()
+        .append_pair("user_id", user_id)
+        .append_pair("first", "100");
+    let resp: Resp = http
+        .get(url)
+        .bearer_auth(user_access_token)
+        .header("Client-Id", client_id)
+        .send()
+        .await?
+        .error_for_status()
+        .wrap_err(context)?
+        .json()
+        .await?;
+    Ok(resp.data.iter().any(|c| c.broadcaster_id == broadcaster_id))
 }

--- a/crates/web/tests/helix_moderator_check.rs
+++ b/crates/web/tests/helix_moderator_check.rs
@@ -68,3 +68,94 @@ async fn is_moderator_returns_false_for_empty_data() {
     );
     assert!(!client.is_moderator("100", "999").await.unwrap());
 }
+
+#[tokio::test]
+async fn user_moderates_channel_finds_broadcaster() {
+    install_crypto();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/helix/moderation/channels"))
+        .and(query_param("user_id", "12345"))
+        .and(query_param("first", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                { "broadcaster_id": "100", "broadcaster_login": "alice", "broadcaster_name": "Alice" },
+                { "broadcaster_id": "200", "broadcaster_login": "bob", "broadcaster_name": "Bob" }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ok = twitch_1337_web::helix::user_moderates_channel(
+        &reqwest::Client::new(),
+        &server.uri(),
+        "client-id",
+        "user-token",
+        "12345",
+        "100",
+        "test ctx",
+    )
+    .await
+    .unwrap();
+    assert!(ok);
+}
+
+#[tokio::test]
+async fn user_moderates_channel_returns_false_when_absent() {
+    install_crypto();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/helix/moderation/channels"))
+        .and(query_param("user_id", "12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                { "broadcaster_id": "200", "broadcaster_login": "bob", "broadcaster_name": "Bob" }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ok = twitch_1337_web::helix::user_moderates_channel(
+        &reqwest::Client::new(),
+        &server.uri(),
+        "client-id",
+        "user-token",
+        "12345",
+        "100",
+        "test ctx",
+    )
+    .await
+    .unwrap();
+    assert!(!ok);
+}
+
+#[tokio::test]
+async fn user_moderates_channel_returns_false_for_empty_data() {
+    install_crypto();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/helix/moderation/channels"))
+        .and(query_param("user_id", "12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ok = twitch_1337_web::helix::user_moderates_channel(
+        &reqwest::Client::new(),
+        &server.uri(),
+        "client-id",
+        "user-token",
+        "12345",
+        "100",
+        "test ctx",
+    )
+    .await
+    .unwrap();
+    assert!(!ok);
+}

--- a/crates/web/tests/helix_moderator_check.rs
+++ b/crates/web/tests/helix_moderator_check.rs
@@ -2,10 +2,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use secrecy::SecretString;
-use serde_json::json;
+use serde_json::{Value, json};
 use twitch_1337_web::helix::{AccessTokenProvider, HelixClient, ReqwestHelixClient};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod helpers;
+use helpers::install_crypto;
 
 struct StubToken;
 
@@ -14,11 +17,6 @@ impl AccessTokenProvider for StubToken {
     async fn current_access_token(&self) -> eyre::Result<String> {
         Ok("test-token".into())
     }
-}
-
-fn install_crypto() {
-    // Workspace pins reqwest = "rustls-no-provider"; tests need a provider.
-    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 #[tokio::test]
@@ -69,93 +67,56 @@ async fn is_moderator_returns_false_for_empty_data() {
     assert!(!client.is_moderator("100", "999").await.unwrap());
 }
 
-#[tokio::test]
-async fn user_moderates_channel_finds_broadcaster() {
+async fn run_user_moderates_channel(body: Value) -> bool {
     install_crypto();
     let server = MockServer::start().await;
-
     Mock::given(method("GET"))
         .and(path("/helix/moderation/channels"))
         .and(query_param("user_id", "12345"))
         .and(query_param("first", "100"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .expect(1)
+        .mount(&server)
+        .await;
+    twitch_1337_web::helix::user_moderates_channel(
+        &reqwest::Client::new(),
+        &server.uri(),
+        "client-id",
+        "user-token",
+        "12345",
+        "100",
+        "test ctx",
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn user_moderates_channel_finds_broadcaster() {
+    assert!(
+        run_user_moderates_channel(json!({
             "data": [
                 { "broadcaster_id": "100", "broadcaster_login": "alice", "broadcaster_name": "Alice" },
                 { "broadcaster_id": "200", "broadcaster_login": "bob", "broadcaster_name": "Bob" }
             ]
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let ok = twitch_1337_web::helix::user_moderates_channel(
-        &reqwest::Client::new(),
-        &server.uri(),
-        "client-id",
-        "user-token",
-        "12345",
-        "100",
-        "test ctx",
-    )
-    .await
-    .unwrap();
-    assert!(ok);
+        }))
+        .await
+    );
 }
 
 #[tokio::test]
 async fn user_moderates_channel_returns_false_when_absent() {
-    install_crypto();
-    let server = MockServer::start().await;
-
-    Mock::given(method("GET"))
-        .and(path("/helix/moderation/channels"))
-        .and(query_param("user_id", "12345"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+    assert!(
+        !run_user_moderates_channel(json!({
             "data": [
                 { "broadcaster_id": "200", "broadcaster_login": "bob", "broadcaster_name": "Bob" }
             ]
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let ok = twitch_1337_web::helix::user_moderates_channel(
-        &reqwest::Client::new(),
-        &server.uri(),
-        "client-id",
-        "user-token",
-        "12345",
-        "100",
-        "test ctx",
-    )
-    .await
-    .unwrap();
-    assert!(!ok);
+        }))
+        .await
+    );
 }
 
 #[tokio::test]
 async fn user_moderates_channel_returns_false_for_empty_data() {
-    install_crypto();
-    let server = MockServer::start().await;
-
-    Mock::given(method("GET"))
-        .and(path("/helix/moderation/channels"))
-        .and(query_param("user_id", "12345"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let ok = twitch_1337_web::helix::user_moderates_channel(
-        &reqwest::Client::new(),
-        &server.uri(),
-        "client-id",
-        "user-token",
-        "12345",
-        "100",
-        "test ctx",
-    )
-    .await
-    .unwrap();
-    assert!(!ok);
+    assert!(!run_user_moderates_channel(json!({ "data": [] })).await);
 }


### PR DESCRIPTION
## Summary
- Twitch's `helix/moderation/moderators` requires the bearer's user id to match `broadcaster_id`, so a logging-in mod's own token gets `401 Unauthorized` — the endpoint can only list mods for the broadcaster's own channel.
- Switch the OAuth callback path to `helix/moderation/channels` (scope `user:read:moderated_channels`), which lets a user list the channels *they* moderate; check `broadcaster_id` against that list.
- Bot-token path (`require_mod` recheck) is untouched — it already log+admits on failure to avoid lockout.

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run -p twitch-1337-web` (73 passed, including 3 new wiremock tests for `user_moderates_channel`)
- [ ] Live: re-auth flow on production (will require re-grant due to scope change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)