### PR TITLE
fix(ci): point data-refresh at crates/core/data

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -33,9 +33,9 @@ jobs:
         id: counts
         run: |
           {
-            echo "airlines=$(wc -l < crates/twitch-1337/data/airlines.csv)"
-            echo "airports=$(wc -l < crates/twitch-1337/data/airports.csv)"
-            echo "plz=$(wc -l < crates/twitch-1337/data/plz.csv)"
+            echo "airlines=$(wc -l < crates/core/data/airlines.csv)"
+            echo "airports=$(wc -l < crates/core/data/airports.csv)"
+            echo "plz=$(wc -l < crates/core/data/plz.csv)"
           } >> "$GITHUB_OUTPUT"
 
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
@@ -48,9 +48,9 @@ jobs:
             Automated weekly refresh of public-dataset CSVs.
 
             **Row counts**
-            - `crates/twitch-1337/data/airlines.csv`: ${{ steps.counts.outputs.airlines }} rows
-            - `crates/twitch-1337/data/airports.csv`: ${{ steps.counts.outputs.airports }} rows
-            - `crates/twitch-1337/data/plz.csv`: ${{ steps.counts.outputs.plz }} rows
+            - `crates/core/data/airlines.csv`: ${{ steps.counts.outputs.airlines }} rows
+            - `crates/core/data/airports.csv`: ${{ steps.counts.outputs.airports }} rows
+            - `crates/core/data/plz.csv`: ${{ steps.counts.outputs.plz }} rows
 
             Merge if the diff looks reasonable. If CI fails, a parser likely
             needs to be adjusted for an upstream schema change.

--- a/scripts/generate_airlines_csv.sh
+++ b/scripts/generate_airlines_csv.sh
@@ -21,6 +21,6 @@ curl -sL "$OPTD_URL" \
   ' \
   | sort \
   | awk -F',' '!seen[$1]++' \
-  > crates/twitch-1337/data/airlines.csv
+  > crates/core/data/airlines.csv
 
-echo "Generated crates/twitch-1337/data/airlines.csv with $(wc -l < crates/twitch-1337/data/airlines.csv) entries"
+echo "Generated crates/core/data/airlines.csv with $(wc -l < crates/core/data/airlines.csv) entries"

--- a/scripts/update-airports.py
+++ b/scripts/update-airports.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # ///
-"""Download airport data from OurAirports and generate crates/twitch-1337/data/airports.csv."""
+"""Download airport data from OurAirports and generate crates/core/data/airports.csv."""
 
 import csv
 import io
@@ -9,7 +9,7 @@ import urllib.request
 from pathlib import Path
 
 OURAIRPORTS_URL = "https://raw.githubusercontent.com/davidmegginson/ourairports-data/main/airports.csv"
-OUTPUT_PATH = Path(__file__).resolve().parent.parent / "crates" / "twitch-1337" / "data" / "airports.csv"
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "crates" / "core" / "data" / "airports.csv"
 
 
 def main():

--- a/scripts/update-plz.py
+++ b/scripts/update-plz.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # ///
-"""Download German postal code data from GeoNames and generate crates/twitch-1337/data/plz.csv."""
+"""Download German postal code data from GeoNames and generate crates/core/data/plz.csv."""
 
 import csv
 import io
@@ -11,7 +11,7 @@ from collections import defaultdict
 from pathlib import Path
 
 GEONAMES_URL = "https://download.geonames.org/export/zip/DE.zip"
-OUTPUT_PATH = Path(__file__).resolve().parent.parent / "crates" / "twitch-1337" / "data" / "plz.csv"
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "crates" / "core" / "data" / "plz.csv"
 
 
 def main():


### PR DESCRIPTION
## Summary
- Data-refresh action failed: `scripts/generate_airlines_csv.sh: line 23: crates/twitch-1337/data/airlines.csv: No such file or directory`
- CSVs moved to `crates/core/data/` during workspace split; scripts + workflow still pointed at old path
- Updated 3 scripts (`generate_airlines_csv.sh`, `update-airports.py`, `update-plz.py`) and `.github/workflows/data-refresh.yml`

## Test plan
- [ ] Trigger `Data refresh` workflow manually via `workflow_dispatch`
- [ ] Confirm all three regenerate steps succeed
- [ ] Confirm row-count step + PR body render correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)