### PR TITLE
feat(web): dev-login Cargo feature for local dashboard testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ ai_memory.ron
 
 # sshfs mount of prod data (root@docker.homelab:/opt/dockhand/stacks/twitch/data)
 /prod-data/
+
+# Local dev data (just dev)
+/dev-data/

--- a/Justfile
+++ b/Justfile
@@ -36,9 +36,12 @@ mount-prod-data:
 unmount-prod-data:
   fusermount -u prod-data
 
-# Run locally with data dir in current directory and debug logging
+# Run bot + dashboard locally with debug logging and OAuth bypass.
+# `dev-login` feature mounts /_dev/login on the dashboard — open it once to
+# mint a mod session without round-tripping Twitch OAuth. Production builds
+# (Dockerfile) compile without the feature, so the route does not exist.
 dev:
-  DATA_DIR=./crates/core/data RUST_LOG=info,twitch_1337=debug,twitch_1337_core=debug cargo run -p twitch-1337
+  DATA_DIR=./dev-data RUST_LOG=info,twitch_1337=debug,twitch_1337_core=debug,twitch_1337_web=debug cargo run -p twitch-1337 --features dev-login
 
 # Run tests with minimal output
 test-brief:

--- a/crates/twitch-1337/Cargo.toml
+++ b/crates/twitch-1337/Cargo.toml
@@ -22,5 +22,9 @@ twitch-irc = { git = "https://github.com/Chronophylos/twitch-irc-rs", branch = "
   "transport-tcp-rustls-webpki-roots",
 ] }
 
+[features]
+# Enable the web crate's dev-login bypass (`/_dev/login`). Local dev only.
+dev-login = ["twitch-1337-web/dev-login"]
+
 [lints]
 workspace = true

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -191,6 +191,17 @@ async fn build_web_spawner(
 
     let signed_key = twitch_1337_web::state::derive_session_key(&config.web.session_secret)?;
 
+    #[allow(unused_mut)]
+    let mut hidden_admins = config.twitch.hidden_admins.clone();
+    #[cfg(feature = "dev-login")]
+    {
+        hidden_admins.push(twitch_1337_web::dev::DEV_USER_ID.to_owned());
+        tracing::warn!(
+            target: "twitch_1337_web",
+            "dev-login feature compiled in — /_dev/login mints mod sessions without OAuth (DO NOT SHIP)",
+        );
+    }
+
     let state = twitch_1337_web::WebState {
         sessions,
         helix: helix as Arc<dyn twitch_1337_web::helix::HelixClient>,
@@ -199,7 +210,7 @@ async fn build_web_spawner(
         clock: web_clock,
         channel: Arc::from(config.twitch.channel.as_str()),
         broadcaster_id: Arc::from(broadcaster.id.as_str()),
-        hidden_admins: Arc::from(config.twitch.hidden_admins.clone().into_boxed_slice()),
+        hidden_admins: Arc::from(hidden_admins.into_boxed_slice()),
         client_id: config.twitch.client_id.clone(),
         oauth,
         ping_manager,

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -31,6 +31,12 @@ tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 
+[features]
+# Mounts `/_dev/login` on the public router for local development. NEVER
+# compile this into a production binary — anyone reaching the bind addr
+# can mint a moderator session without OAuth.
+dev-login = []
+
 [dev-dependencies]
 rustls = { workspace = true }
 tempfile = "3"

--- a/crates/web/src/auth/mod.rs
+++ b/crates/web/src/auth/mod.rs
@@ -10,10 +10,10 @@ pub mod csrf;
 pub mod mod_check;
 pub mod session;
 
-mod routes;
+pub(crate) mod routes;
 
 // `require_csrf` is intentionally not re-exported. CSRF is enforced
 // per-handler (form-field `_csrf` path); the header-path middleware would
 // silently admit form-only POSTs by design, so exporting it would mislead
 // callers into thinking it provides blanket protection.
-pub use routes::{OAuthCtx, auth_router, require_mod};
+pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod};

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -25,14 +25,14 @@ use oauth2::{
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
 use tower_cookies::cookie::SameSite;
-use tower_cookies::{Cookie, Cookies};
+use tower_cookies::{Cookie, Cookies, Key};
 
 use crate::auth::mod_check::{ModCheckOutcome, check_is_mod};
 use crate::error::WebError;
 use crate::state::WebState;
 
-const SID_COOKIE: &str = "tw1337_sid";
-const CSRF_COOKIE: &str = "tw1337_csrf";
+pub const SID_COOKIE: &str = "tw1337_sid";
+pub const CSRF_COOKIE: &str = "tw1337_csrf";
 const OAUTH_STATE_COOKIE: &str = "tw1337_oauth_state";
 /// Short-lived cookie that stashes the original requested path captured by
 /// `require_mod` into `?next=`. Consumed (and cleared) by the callback.
@@ -41,6 +41,34 @@ const NEXT_COOKIE: &str = "tw1337_next";
 /// Fully-configured `BasicClient` (auth/token/redirect endpoints all set).
 type ConfiguredClient =
     BasicClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
+
+/// Set the signed sid + csrf cookies that mark a logged-in session. Shared
+/// between the OAuth callback (`secure = true`) and the dev-login bypass
+/// (`secure = false`, since dev runs over plain http on localhost).
+pub(crate) fn issue_session_cookies(
+    cookies: &Cookies,
+    key: &Key,
+    sid: String,
+    csrf_bytes: &[u8; 32],
+    secure: bool,
+) {
+    let signed = cookies.signed(key);
+    signed.add(
+        Cookie::build((SID_COOKIE, sid))
+            .http_only(true)
+            .secure(secure)
+            .same_site(SameSite::Lax)
+            .path("/")
+            .build(),
+    );
+    signed.add(
+        Cookie::build((CSRF_COOKIE, crate::auth::csrf::encode(csrf_bytes)))
+            .secure(secure)
+            .same_site(SameSite::Lax)
+            .path("/")
+            .build(),
+    );
+}
 
 pub struct OAuthCtx {
     pub basic: ConfiguredClient,
@@ -318,24 +346,7 @@ async fn callback(
         .sessions
         .insert(me.id.clone(), me.login.clone())
         .map_err(WebError::Internal)?;
-    let csrf_value_hex = hex::encode(csrf_value);
-
-    let signed = cookies.signed(&state.signed_key);
-    signed.add(
-        Cookie::build((SID_COOKIE, sid))
-            .http_only(true)
-            .secure(true)
-            .same_site(SameSite::Lax)
-            .path("/")
-            .build(),
-    );
-    signed.add(
-        Cookie::build((CSRF_COOKIE, csrf_value_hex))
-            .secure(true)
-            .same_site(SameSite::Lax)
-            .path("/")
-            .build(),
-    );
+    issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_value, true);
 
     let next_path = cookies
         .get(NEXT_COOKIE)

--- a/crates/web/src/dev.rs
+++ b/crates/web/src/dev.rs
@@ -1,0 +1,38 @@
+//! Dev-only login bypass for local testing.
+//!
+//! Compiled in only when the `dev-login` Cargo feature is enabled
+//! (`cargo run --features dev-login`, or `just dev`). When present,
+//! `/_dev/login` mints a signed session for [`DEV_USER_ID`] and redirects
+//! to `/pings`, skipping the OAuth round-trip. The bin pushes
+//! [`DEV_USER_ID`] into `hidden_admins` under the same cfg so the
+//! mod-gate shortcut admits the session.
+//!
+//! Never compile into a production binary — anyone who can reach the
+//! bind addr can mint a moderator session without OAuth.
+
+use axum::Router;
+use axum::extract::State;
+use axum::response::Redirect;
+use axum::routing::get;
+use tower_cookies::Cookies;
+
+use crate::auth::routes::issue_session_cookies;
+use crate::state::WebState;
+
+pub const DEV_USER_ID: &str = "1337";
+pub const DEV_USER_LOGIN: &str = "devmod";
+
+pub fn router(state: WebState) -> Router {
+    Router::new()
+        .route("/_dev/login", get(login))
+        .with_state(state)
+}
+
+async fn login(State(state): State<WebState>, cookies: Cookies) -> Redirect {
+    let (sid, csrf_bytes) = state
+        .sessions
+        .insert(DEV_USER_ID.to_owned(), DEV_USER_LOGIN.to_owned())
+        .expect("insert dev session");
+    issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_bytes, false);
+    Redirect::to("/pings")
+}

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod auth;
 pub mod clock;
 pub mod config;
+#[cfg(feature = "dev-login")]
+pub mod dev;
 pub mod error;
 pub mod flash;
 pub mod helix;
@@ -59,10 +61,15 @@ pub async fn run_web(listener: TcpListener, deps: WebDeps, shutdown: Arc<Notify>
 }
 
 pub fn build_router(state: WebState) -> Router {
-    let public = Router::new()
+    #[allow(unused_mut)]
+    let mut public = Router::new()
         .merge(routes::health::router(state.irc_connected.clone()))
         .merge(routes::assets::router())
         .merge(auth::auth_router().with_state(state.clone()));
+    #[cfg(feature = "dev-login")]
+    {
+        public = public.merge(dev::router(state.clone()));
+    }
 
     let authed = Router::new()
         .route(


### PR DESCRIPTION
## Summary
- Adds `dev-login` Cargo feature on the web crate (and forwarded by the bin) that mounts `/_dev/login` on the public router. The route mints a signed mod session for a fixed dev user, skipping OAuth.
- Bin pushes the dev user id into `hidden_admins` under the same cfg so the mod-gate shortcut admits the session, and emits a startup WARN. Production Docker builds don't enable the feature, so the route/module/consts are compile-time absent.
- Extracts `issue_session_cookies` helper so the OAuth callback and the dev login share one cookie shape (only `secure` differs), and updates the prod callback to use `csrf::encode(&[u8;32])` instead of loose `hex::encode`.
- Moves dev DATA_DIR from `crates/core/data` (the embedded csv dir) to a new `dev-data/` at repo root, gitignored.

## Run flow
```
just dev   # cargo run -p twitch-1337 --features dev-login
# → open http://127.0.0.1:8080/_dev/login → /pings
```

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean (no feature)
- [x] `cargo clippy -p twitch-1337 --all-targets --features dev-login -- -D warnings` clean
- [x] `cargo nextest run` — 429 passed (no feature)
- [x] `cargo nextest run -p twitch-1337-web --features dev-login` — 83 passed
- [x] Local smoke: bot+dashboard up, `/_dev/login` 303→`/pings` 200, ping CRUD usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)