### PR TITLE
fix(web): pings empty-state blue tint + broken row delete

### DIFF
--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -80,7 +80,7 @@ body::before {
   pointer-events: none;
   background-image:
     radial-gradient(at 12% -10%, oklch(var(--accent-l) var(--accent-c) var(--accent-h) / 0.06), transparent 40%),
-    radial-gradient(at 110% 110%, oklch(0.6 0.08 280 / 0.06), transparent 50%);
+    radial-gradient(at 110% 110%, oklch(var(--accent-l) var(--accent-c) var(--accent-h) / 0.04), transparent 50%);
   z-index: 0;
 }
 

--- a/crates/web/templates/pings/list.html
+++ b/crates/web/templates/pings/list.html
@@ -85,7 +85,7 @@
           <button type="button" class="row-act danger" title="Delete"
                   hx-post="/pings/{{ row.name }}/delete"
                   hx-confirm="Delete ping {{ row.name }}?"
-                  hx-target="closest tr"
+                  hx-target="closest .tr"
                   hx-swap="outerHTML"
                   hx-headers='{"X-Csrf-Token": "{{ csrf }}"}'>✕</button>
         </div>

--- a/crates/web/tests/pings_routes.rs
+++ b/crates/web/tests/pings_routes.rs
@@ -90,6 +90,10 @@ async fn list_renders_existing_pings() {
         html.contains("Hey {mentions}"),
         "list should show template; got {html}"
     );
+    assert!(
+        html.contains(r#"hx-target="closest .tr""#),
+        "delete button must target the `.tr` div, not the absent <tr> element; got {html}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Empty Pings page picked up a visible blue cast on text + dividers because the second `body::before` radial gradient still used hue 280. Collapse it to the accent hue (295) at 0.04 alpha — the ambient glow stays, the blue cast is gone.
- Ping row delete button was wired with `hx-target="closest tr"`, but rows are `<div class="tr">` (the table is CSS-grid, not a real `<table>`). htmx fell back to swapping the button itself, leaving the row intact even though `delete_ping` had already succeeded server-side. Switch to `closest .tr` to match the existing member-delete button.

## Test plan
- [x] `cargo nextest run -p twitch-1337-web` (added regression: `list_renders_existing_pings` asserts `hx-target=\"closest .tr\"`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` (full suite)
- [ ] Visual: load `/pings` empty, confirm no blue tint on dividers / `.empty` text
- [ ] Visual: create a ping, click ✕, confirm row disappears without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)