### PR TITLE
feat(web): web-dev bin for worktree-side dashboard runs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -43,6 +43,14 @@ unmount-prod-data:
 dev:
   DATA_DIR=./dev-data RUST_LOG=info,twitch_1337=debug,twitch_1337_core=debug,twitch_1337_web=debug cargo run -p twitch-1337 --features dev-login
 
+# Run the dashboard alone (no IRC, no Helix) on a non-conflicting port.
+# Lets a worktree iterate on /pings + /memory views in parallel with the
+# full bot above — both share dev-data via atomic tmp+rename, so writes
+# from either side land cleanly (last-writer-wins, never corrupted).
+# Default bind 127.0.0.1:8761; pass `bind=...` to override.
+dev-web bind="127.0.0.1:8761":
+  DATA_DIR=./dev-data BIND_ADDR={{bind}} RUST_LOG=info,twitch_1337_web=debug cargo run -p twitch-1337-web --bin web-dev --features dev-login
+
 # Run tests with minimal output
 test-brief:
     @cargo test --workspace --quiet 2>&1 | grep "test result" | awk ' \

--- a/Justfile
+++ b/Justfile
@@ -51,6 +51,15 @@ dev:
 dev-web bind="127.0.0.1:8761":
   DATA_DIR=./dev-data BIND_ADDR={{bind}} RUST_LOG=info,twitch_1337_web=debug cargo run -p twitch-1337-web --bin web-dev --features dev-login
 
+# One-shot: mint a dev session at /_dev/login + screenshot a path to PNG.
+# Requires `dev-web` already running on `base`. Reuses /tmp/wd-cprof so
+# the second+ shot skips the auth round-trip. Defaults: /pings →
+# /tmp/wd.png. Override `path=`, `file=`, `base=` as needed.
+dev-web-shot path="/pings" file="/tmp/wd.png" base="http://127.0.0.1:8761":
+  @rm -rf /tmp/wd-cprof
+  @chromium --headless=new --no-sandbox --disable-gpu --hide-scrollbars --window-size=1400,900 --user-data-dir=/tmp/wd-cprof --virtual-time-budget=4000 --screenshot={{file}} "{{base}}/_dev/login?next={{path}}" 2>&1 | tail -1
+  @echo "shot {{base}}{{path}} -> {{file}}"
+
 # Run tests with minimal output
 test-brief:
     @cargo test --workspace --quiet 2>&1 | grep "test result" | awk ' \

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -37,6 +37,13 @@ urlencoding = { workspace = true }
 # can mint a moderator session without OAuth.
 dev-login = []
 
+# Standalone dashboard runner — skips IRC, uses StubHelix.
+# `cargo run -p twitch-1337-web --bin web-dev --features dev-login`
+[[bin]]
+name = "web-dev"
+path = "src/bin/web_dev.rs"
+required-features = ["dev-login"]
+
 [dev-dependencies]
 rustls = { workspace = true }
 tempfile = "3"

--- a/crates/web/src/bin/web_dev.rs
+++ b/crates/web/src/bin/web_dev.rs
@@ -1,0 +1,116 @@
+//! Standalone dashboard runner — `dev-login` only.
+//!
+//! Spins up the web crate against a shared dev-data dir without going
+//! near IRC, the OAuth callback, or a real Helix client. Lets a parallel
+//! dashboard run from a worktree on a non-conflicting port (default
+//! 8761) while the full bot keeps running on 8760 from the main
+//! checkout.
+//!
+//! Env knobs:
+//!   - `BIND_ADDR`  default `127.0.0.1:8761`
+//!   - `DATA_DIR`   default `./dev-data`
+//!   - `CHANNEL`    default `devchannel`  (cosmetic, breadcrumb only)
+//!
+//! Caveat: `PingManager` and `MemoryStore` use atomic tmp+rename to
+//! persist, so two processes against the same dir will not corrupt each
+//! other's writes — but a last-writer-wins race is real. Don't run this
+//! against the same dev-data the production bot is actively writing to
+//! unless you're aware of that.
+
+use std::env;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+use eyre::{Result, WrapErr as _};
+use secrecy::SecretString;
+use tokio::sync::{Notify, RwLock};
+use twitch_1337_core::ai::memory::store::MemoryStore;
+use twitch_1337_core::ai::memory::types::Caps;
+use twitch_1337_core::ping::PingManager;
+use twitch_1337_core::{install_crypto_provider, install_tracing};
+use twitch_1337_web::auth::OAuthCtx;
+use twitch_1337_web::auth::session::SessionTable;
+use twitch_1337_web::clock::SystemClock;
+use twitch_1337_web::config::WebConfig;
+use twitch_1337_web::dev::{DEV_USER_ID, StubHelix};
+use twitch_1337_web::helix::HelixClient;
+use twitch_1337_web::state::derive_session_key;
+use twitch_1337_web::{WebDeps, WebState, bind, run_web};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    install_tracing();
+    install_crypto_provider();
+
+    let bind_addr: SocketAddr = env::var("BIND_ADDR")
+        .unwrap_or_else(|_| "127.0.0.1:8761".to_owned())
+        .parse()
+        .wrap_err("parse BIND_ADDR")?;
+    let data_dir: PathBuf = env::var_os("DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("./dev-data"));
+    let channel = env::var("CHANNEL").unwrap_or_else(|_| "devchannel".to_owned());
+    let public_url = format!("http://{bind_addr}");
+
+    tracing::warn!(
+        target: "twitch_1337_web",
+        ?bind_addr, ?data_dir, channel = %channel,
+        "web-dev starting (StubHelix, /_dev/login, no IRC) — DO NOT EXPOSE",
+    );
+
+    let pings = PingManager::load(&data_dir).wrap_err("load ping manager")?;
+    let memory_store = MemoryStore::open(&data_dir, Caps::default())
+        .await
+        .wrap_err("open memory store")?;
+
+    let clock = Arc::new(SystemClock);
+    let session_ttl = Duration::from_secs(7 * 24 * 3600);
+    let sessions = Arc::new(SessionTable::new(session_ttl, clock.clone()));
+
+    let session_secret = SecretString::new("0".repeat(64).into());
+    let signed_key = derive_session_key(&session_secret)?;
+
+    let oauth = Arc::new(OAuthCtx::new(
+        "dev-client-id",
+        &SecretString::new("dev-secret".to_owned().into()),
+        &public_url,
+    )?);
+
+    let web_config = Arc::new(WebConfig {
+        bind_addr: bind_addr.to_string(),
+        public_url,
+        session_secret,
+        session_ttl,
+        mod_check_refresh: Duration::from_secs(300),
+    });
+
+    let helix: Arc<dyn HelixClient> = Arc::new(StubHelix);
+
+    let state = WebState {
+        sessions,
+        helix,
+        irc_connected: Arc::new(AtomicBool::new(true)),
+        config: web_config,
+        clock,
+        channel: Arc::from(channel.as_str()),
+        broadcaster_id: Arc::from("0"),
+        hidden_admins: Arc::from(vec![DEV_USER_ID.to_owned()].into_boxed_slice()),
+        client_id: SecretString::new("dev-client-id".to_owned().into()),
+        oauth,
+        ping_manager: Arc::new(RwLock::new(pings)),
+        memory_store,
+        signed_key,
+    };
+
+    let listener = bind(bind_addr).await?;
+    let shutdown = Arc::new(Notify::new());
+    let s = shutdown.clone();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        s.notify_one();
+    });
+    run_web(listener, WebDeps { bind_addr, state }, shutdown).await
+}

--- a/crates/web/src/dev.rs
+++ b/crates/web/src/dev.rs
@@ -16,9 +16,10 @@
 
 use async_trait::async_trait;
 use axum::Router;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::response::Redirect;
 use axum::routing::get;
+use serde::Deserialize;
 use tower_cookies::Cookies;
 
 use crate::auth::routes::issue_session_cookies;
@@ -34,13 +35,30 @@ pub fn router(state: WebState) -> Router {
         .with_state(state)
 }
 
-async fn login(State(state): State<WebState>, cookies: Cookies) -> Redirect {
+#[derive(Deserialize)]
+pub struct DevLoginQuery {
+    /// Same-origin path to land on after the session is minted. Anything
+    /// not starting with `/` (or starting with `//`) falls back to
+    /// `/pings` so the route can't be coerced into open-redirecting.
+    next: Option<String>,
+}
+
+async fn login(
+    State(state): State<WebState>,
+    cookies: Cookies,
+    Query(q): Query<DevLoginQuery>,
+) -> Redirect {
     let (sid, csrf_bytes) = state
         .sessions
         .insert(DEV_USER_ID.to_owned(), DEV_USER_LOGIN.to_owned())
         .expect("insert dev session");
     issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_bytes, false);
-    Redirect::to("/pings")
+    let target = q
+        .next
+        .as_deref()
+        .filter(|p| p.starts_with('/') && !p.starts_with("//"))
+        .unwrap_or("/pings");
+    Redirect::to(target)
 }
 
 /// Zero-network [`HelixClient`] for the `web-dev` bin.

--- a/crates/web/src/dev.rs
+++ b/crates/web/src/dev.rs
@@ -7,9 +7,14 @@
 //! [`DEV_USER_ID`] into `hidden_admins` under the same cfg so the
 //! mod-gate shortcut admits the session.
 //!
+//! Also exposes [`StubHelix`] — a zero-network HelixClient impl used by
+//! the `web-dev` bin so the dashboard can run from a worktree against
+//! shared dev-data without colliding with a real Twitch connection.
+//!
 //! Never compile into a production binary — anyone who can reach the
 //! bind addr can mint a moderator session without OAuth.
 
+use async_trait::async_trait;
 use axum::Router;
 use axum::extract::State;
 use axum::response::Redirect;
@@ -17,6 +22,7 @@ use axum::routing::get;
 use tower_cookies::Cookies;
 
 use crate::auth::routes::issue_session_cookies;
+use crate::helix::{HelixClient, HelixUser};
 use crate::state::WebState;
 
 pub const DEV_USER_ID: &str = "1337";
@@ -35,4 +41,35 @@ async fn login(State(state): State<WebState>, cookies: Cookies) -> Redirect {
         .expect("insert dev session");
     issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_bytes, false);
     Redirect::to("/pings")
+}
+
+/// Zero-network [`HelixClient`] for the `web-dev` bin.
+///
+/// `is_moderator` returns true only for [`DEV_USER_ID`] so the
+/// require_mod sliding recheck admits the dev session and rejects any
+/// other forged sid (the cookie sig already gates that, this is
+/// defense-in-depth). User lookups echo the input so `/auth/callback`
+/// would round-trip if accidentally exercised.
+#[derive(Default)]
+pub struct StubHelix;
+
+#[async_trait]
+impl HelixClient for StubHelix {
+    async fn fetch_user_by_id(&self, id: &str) -> eyre::Result<Option<HelixUser>> {
+        Ok(Some(HelixUser {
+            id: id.to_owned(),
+            login: format!("user{id}"),
+            display_name: format!("user{id}"),
+        }))
+    }
+    async fn fetch_user_by_login(&self, login: &str) -> eyre::Result<Option<HelixUser>> {
+        Ok(Some(HelixUser {
+            id: "0".to_owned(),
+            login: login.to_owned(),
+            display_name: login.to_owned(),
+        }))
+    }
+    async fn is_moderator(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
+        Ok(user_id == DEV_USER_ID)
+    }
 }


### PR DESCRIPTION
## Summary
- New `web-dev` bin in `crates/web` (gated on `dev-login` via `required-features`) so a parallel dashboard can run from a worktree on a non-conflicting port (default `127.0.0.1:8761`) while the full bot keeps running on `127.0.0.1:8760` from the main checkout.
- `StubHelix` (added under the existing `dev-login`-gated `dev` module) returns `is_moderator = true` only for `DEV_USER_ID`, so the `require_mod` sliding recheck admits the dev-login session without a live Twitch connection or OAuth round-trip.
- `just dev-web [bind=...]` recipe to run it.

PingManager / MemoryStore both persist via atomic tmp+rename, so two processes against the same dev-data won't corrupt files. `web_dev.rs` documents the last-writer-wins race so callers know the trade.

## Test plan
- [x] `cargo nextest run --features twitch-1337-web/dev-login` (429 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features twitch-1337-web/dev-login -- -D warnings`
- [x] Smoke: `just dev-web` against `./dev-data`, `/_dev/login` mints a session, `/pings` empty + non-empty render, delete button HTML carries `closest .tr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)