### PR TITLE
fix(web): dashboard polish — avatar hue, breadcrumb, cancel URLs, sidebar link

### DIFF
--- a/crates/web/src/error.rs
+++ b/crates/web/src/error.rs
@@ -54,7 +54,6 @@ pub struct ConflictPayload {
     pub user_login: String,
     /// Sidebar highlight key matching the originating editor's section.
     pub current_page: &'static str,
-    /// Where the Cancel link should point — kind-aware (e.g. `/memory/users`).
     pub cancel_url: &'static str,
 }
 

--- a/crates/web/src/error.rs
+++ b/crates/web/src/error.rs
@@ -54,6 +54,8 @@ pub struct ConflictPayload {
     pub user_login: String,
     /// Sidebar highlight key matching the originating editor's section.
     pub current_page: &'static str,
+    /// Where the Cancel link should point — kind-aware (e.g. `/memory/users`).
+    pub cancel_url: &'static str,
 }
 
 #[derive(Template)]
@@ -76,6 +78,7 @@ struct ConflictTpl<'a> {
     csrf: &'a str,
     user_login: &'a str,
     current_page: &'static str,
+    cancel_url: &'static str,
 }
 
 /// Allow only same-origin absolute paths. Anything that smells like a
@@ -138,6 +141,7 @@ impl IntoResponse for WebError {
                     csrf: &payload.csrf,
                     user_login: &payload.user_login,
                     current_page: payload.current_page,
+                    cancel_url: payload.cancel_url,
                 },
             ),
             WebError::OAuthExchange(err) => {

--- a/crates/web/src/routes/memory.rs
+++ b/crates/web/src/routes/memory.rs
@@ -168,6 +168,25 @@ fn subtitle_for_kind(kind: &FileKind) -> &'static str {
     }
 }
 
+/// Section list URL — the page Cancel/Back should return to. SOUL/LORE
+/// have no list page so they fall back to the tree.
+fn list_url_for(kind: &FileKind) -> &'static str {
+    match kind {
+        FileKind::Soul | FileKind::Lore => "/memory",
+        FileKind::User { .. } => "/memory/users",
+        FileKind::State { .. } => "/memory/state",
+    }
+}
+
+fn nav_slug_for(kind: &FileKind) -> &'static str {
+    match kind {
+        FileKind::Soul => crate::nav::MEMORY_SOUL,
+        FileKind::Lore => crate::nav::MEMORY_LORE,
+        FileKind::User { .. } => crate::nav::MEMORY_USERS,
+        FileKind::State { .. } => crate::nav::MEMORY_STATE,
+    }
+}
+
 /// First non-empty line, stripped of a leading `# `, truncated to 140 chars.
 /// Char-aware so we never slice mid-codepoint.
 fn note_excerpt(body: &str) -> String {
@@ -219,18 +238,17 @@ async fn tree(
     })
 }
 
-#[allow(clippy::too_many_arguments)] // distinct view-shape inputs; bundling adds noise
 async fn view_kind(
     state: &WebState,
     session: &Session,
     kind: FileKind,
     title: String,
     save_url: String,
-    cancel_url: &'static str,
     delete_url: Option<String>,
-    current_page: &'static str,
     preloaded: Option<MemoryFile>,
 ) -> Result<Response, WebError> {
+    let cancel_url = list_url_for(&kind);
+    let current_page = nav_slug_for(&kind);
     let store = &state.memory_store;
     let mf = match preloaded {
         Some(mf) => mf,
@@ -280,9 +298,7 @@ async fn view_soul(
         FileKind::Soul,
         "SOUL".to_owned(),
         "/memory/soul".to_owned(),
-        "/memory",
         None,
-        crate::nav::MEMORY_SOUL,
         None,
     )
     .await
@@ -298,9 +314,7 @@ async fn view_lore(
         FileKind::Lore,
         "LORE".to_owned(),
         "/memory/lore".to_owned(),
-        "/memory",
         None,
-        crate::nav::MEMORY_LORE,
         None,
     )
     .await
@@ -374,18 +388,7 @@ async fn view_user(
         .unwrap_or(&user_id)
         .to_owned();
     let save_url = format!("/memory/users/{user_id}");
-    view_kind(
-        &state,
-        &session,
-        kind,
-        title,
-        save_url,
-        "/memory/users",
-        None,
-        crate::nav::MEMORY_USERS,
-        Some(mf),
-    )
-    .await
+    view_kind(&state, &session, kind, title, save_url, None, Some(mf)).await
 }
 
 async fn list_state(
@@ -457,9 +460,7 @@ async fn view_state(
         FileKind::State { slug: slug.clone() },
         title,
         save_url,
-        "/memory/state",
         Some(delete_url),
-        crate::nav::MEMORY_STATE,
         None,
     )
     .await
@@ -513,17 +514,8 @@ async fn save_kind(
     if !csrf::verify(&form.csrf, &session.csrf_value) {
         return Err(WebError::CsrfMismatch);
     }
-    let current_page: &'static str = match &kind {
-        FileKind::Soul => crate::nav::MEMORY_SOUL,
-        FileKind::Lore => crate::nav::MEMORY_LORE,
-        FileKind::User { .. } => crate::nav::MEMORY_USERS,
-        FileKind::State { .. } => crate::nav::MEMORY_STATE,
-    };
-    let cancel_url: &'static str = match &kind {
-        FileKind::Soul | FileKind::Lore => "/memory",
-        FileKind::User { .. } => "/memory/users",
-        FileKind::State { .. } => "/memory/state",
-    };
+    let current_page = nav_slug_for(&kind);
+    let cancel_url = list_url_for(&kind);
     let fm_override = FrontmatterOverride {
         username: Some(form.fm_username.clone()),
         display_name: Some(form.fm_display_name.clone()),

--- a/crates/web/src/routes/memory.rs
+++ b/crates/web/src/routes/memory.rs
@@ -72,6 +72,7 @@ struct EditorTpl<'a> {
     /// `usize` into a percentage cleanly.
     pct: u8,
     save_url: &'a str,
+    cancel_url: &'a str,
     delete_url: Option<&'a str>,
     error: Option<String>,
     user_login: &'a str,
@@ -225,6 +226,7 @@ async fn view_kind(
     kind: FileKind,
     title: String,
     save_url: String,
+    cancel_url: &'static str,
     delete_url: Option<String>,
     current_page: &'static str,
     preloaded: Option<MemoryFile>,
@@ -255,6 +257,7 @@ async fn view_kind(
         byte_cap,
         pct,
         save_url: &save_url,
+        cancel_url,
         delete_url: delete_url.as_deref(),
         error: None,
         user_login: &session.user_login,
@@ -277,6 +280,7 @@ async fn view_soul(
         FileKind::Soul,
         "SOUL".to_owned(),
         "/memory/soul".to_owned(),
+        "/memory",
         None,
         crate::nav::MEMORY_SOUL,
         None,
@@ -294,6 +298,7 @@ async fn view_lore(
         FileKind::Lore,
         "LORE".to_owned(),
         "/memory/lore".to_owned(),
+        "/memory",
         None,
         crate::nav::MEMORY_LORE,
         None,
@@ -375,6 +380,7 @@ async fn view_user(
         kind,
         title,
         save_url,
+        "/memory/users",
         None,
         crate::nav::MEMORY_USERS,
         Some(mf),
@@ -451,6 +457,7 @@ async fn view_state(
         FileKind::State { slug: slug.clone() },
         title,
         save_url,
+        "/memory/state",
         Some(delete_url),
         crate::nav::MEMORY_STATE,
         None,
@@ -512,6 +519,11 @@ async fn save_kind(
         FileKind::User { .. } => crate::nav::MEMORY_USERS,
         FileKind::State { .. } => crate::nav::MEMORY_STATE,
     };
+    let cancel_url: &'static str = match &kind {
+        FileKind::Soul | FileKind::Lore => "/memory",
+        FileKind::User { .. } => "/memory/users",
+        FileKind::State { .. } => "/memory/state",
+    };
     let fm_override = FrontmatterOverride {
         username: Some(form.fm_username.clone()),
         display_name: Some(form.fm_display_name.clone()),
@@ -557,6 +569,7 @@ async fn save_kind(
                 csrf: csrf_hex,
                 user_login: session.user_login.clone(),
                 current_page,
+                cancel_url,
             })))
         }
         Err(err) => {
@@ -590,6 +603,7 @@ async fn save_kind(
                     byte_cap: cap,
                     pct: pct_of(form.body.len(), cap),
                     save_url: &redirect_to,
+                    cancel_url,
                     delete_url: delete_url.as_deref(),
                     error: Some(msg),
                     user_login: &session.user_login,
@@ -807,6 +821,7 @@ fn render_state_create(
             byte_cap: cap,
             pct: pct_of(body.len(), cap),
             save_url: "/memory/state",
+            cancel_url: "/memory/state",
             delete_url: None,
             error,
             user_login,

--- a/crates/web/templates/base.html
+++ b/crates/web/templates/base.html
@@ -18,7 +18,7 @@
         <nav class="crumbs" aria-label="Breadcrumb">
           <span class="crumb-root">~</span>
           <span class="crumb-sep">/</span>
-          <span class="crumb-current">{% block crumb %}{{ current_page }}{% endblock %}</span>
+          <span class="crumb-current">{% block crumb %}{{ current_page.replace('_', "/") }}{% endblock %}</span>
         </nav>
         <div class="topbar-right">
           <label class="search">

--- a/crates/web/templates/memory/conflict.html
+++ b/crates/web/templates/memory/conflict.html
@@ -22,7 +22,7 @@
     <textarea class="input" name="body" rows="24" spellcheck="false">{{ draft }}</textarea>
     <div class="form-actions">
       <button type="submit" class="btn primary">Save (overwrite current)</button>
-      <a href="/memory" class="btn ghost">Cancel</a>
+      <a href="{{ cancel_url }}" class="btn ghost">Cancel</a>
     </div>
   </form>
 </div>

--- a/crates/web/templates/memory/editor.html
+++ b/crates/web/templates/memory/editor.html
@@ -3,6 +3,7 @@
 {% block content %}
 <div class="page-head">
   <div>
+    <a href="{{ cancel_url }}" class="link muted" style="display:inline-block;margin-bottom:6px;">← Back</a>
     <h1>{{ title }}</h1>
     <p class="page-sub">{{ subtitle }}</p>
   </div>
@@ -52,7 +53,7 @@
   </div>
   <div class="editor-actions">
     <button type="submit" class="btn primary">Save</button>
-    <a href="/memory" class="btn ghost">Cancel</a>
+    <a href="{{ cancel_url }}" class="btn ghost">Cancel</a>
   </div>
 </form>
 {% if let Some(url) = delete_url %}

--- a/crates/web/templates/memory/state_list.html
+++ b/crates/web/templates/memory/state_list.html
@@ -35,7 +35,7 @@
           <span class="muted">—</span>
         {% else %}
           <span class="by">
-            <span class="avatar" style="width:18px;height:18px;font-size:10px;background:oklch(0.55 0.10 220);">{{ s.created_initial }}</span>
+            <span class="avatar" style="width:18px;height:18px;font-size:10px;background:oklch(0.55 0.10 var(--accent-h));">{{ s.created_initial }}</span>
             <span class="mono">{{ s.created_by }}</span>
           </span>
         {% endif %}

--- a/crates/web/templates/memory/users_list.html
+++ b/crates/web/templates/memory/users_list.html
@@ -15,7 +15,7 @@
   {% for u in items %}
   <div class="user-card" data-filter="{{ u.user_id }} {{ u.display_name }} {{ u.note }}">
     <div class="user-card-head">
-      <span class="avatar" style="width:36px;height:36px;font-size:13px;background:oklch(0.55 0.10 220);">{{ u.initial }}</span>
+      <span class="avatar" style="width:36px;height:36px;font-size:13px;background:oklch(0.55 0.10 var(--accent-h));">{{ u.initial }}</span>
       <div>
         <div class="user-name">{{ u.display_name }}</div>
         <div class="user-id">id {{ u.user_id }}</div>

--- a/crates/web/templates/pings/list.html
+++ b/crates/web/templates/pings/list.html
@@ -75,7 +75,7 @@
         </div>
         <div class="td col-by">
           <span class="by">
-            <span class="avatar" style="width:18px;height:18px;font-size:10px;background:oklch(0.55 0.10 220);">{{ row.created_initial }}</span>
+            <span class="avatar" style="width:18px;height:18px;font-size:10px;background:oklch(0.55 0.10 var(--accent-h));">{{ row.created_initial }}</span>
             {{ row.created_by }}
           </span>
         </div>

--- a/crates/web/templates/sidebar.html
+++ b/crates/web/templates/sidebar.html
@@ -28,6 +28,7 @@
     <div class="nav-group">
       <div class="nav-group-label">Memory</div>
       <ul class="nav-list">
+        {% call nav_item("memory", "/memory", "Tree") %}{% endcall %}
         {% call nav_item("memory_soul", "/memory/soul", "SOUL") %}{% endcall %}
         {% call nav_item("memory_lore", "/memory/lore", "LORE") %}{% endcall %}
         {% call nav_item("memory_users", "/memory/users", "Users") %}{% endcall %}


### PR DESCRIPTION
## Summary
- **Avatar hue** — `oklch(0.55 0.10 220)` (literal blue) → `oklch(0.55 0.10 var(--accent-h))` (theme violet) across `users_list`, `state_list`, `pings/list`. Resolves the blue cast on the user grid that bled through to State/Pings even after PR #174 neutralized `--bg-*`/`--fg-*`.
- **Breadcrumb separator** — render `current_page` slug with `_` → `/` so the topbar shows `memory/users` instead of `memory_users`. Sidebar `active` class key untouched.
- **Editor cancel/back URLs** — derive from `FileKind` so SOUL/LORE/State/User all return to their own section list instead of `/memory`. Conflict page picks up the same URL.
- **Memory tree sidebar link** — fix kind-aware navigation regression.
- **Refactor** — `view_kind` derives `current_page` + `cancel_url` internally from `FileKind`, drops the `#[allow(clippy::too_many_arguments)]`.

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run` — 83 web tests pass locally
- [ ] Visit `/memory/users`, `/memory/state`, `/pings` — avatars violet, no blue cast
- [ ] Topbar breadcrumb on `/memory/users` shows `memory/users`
- [ ] Open/save/cancel on SOUL/LORE/User/State editors returns to the matching list