### PR TITLE
fix(web): dashboard polish pack — Dark Reader, breadcrumbs, version stamp, log cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,10 +37,14 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        env:
+          GIT_SHA: ${{ github.sha }}
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ env.GIT_SHA }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path r
 # 3. Builder stage - builds the application
 FROM base AS builder
 
+# Build-arg: short commit SHA of the source tree. Required because
+# .dockerignore strips .git/, so the web crate's build.rs cannot derive
+# it itself. Defaults to "unknown" if the caller does not pass one.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
 # Copy over cached dependencies
 COPY --from=cacher /app/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo

--- a/Justfile
+++ b/Justfile
@@ -4,13 +4,14 @@
 default:
   @just --list
 
-# Build the Docker image
+# Build the Docker image. Passes the current commit SHA so the running
+# binary can report it via `/version` and the sidebar brand-meta.
 build:
-  podman build -t chronophylos/twitch-1337:latest .
+  podman build --build-arg GIT_SHA=$(git rev-parse --short=12 HEAD) -t chronophylos/twitch-1337:latest .
 
 # Build with no cache (force full rebuild)
 build-no-cache:
-  podman build --no-cache -t chronophylos/twitch-1337:latest .
+  podman build --no-cache --build-arg GIT_SHA=$(git rev-parse --short=12 HEAD) -t chronophylos/twitch-1337:latest .
 
 # Push the image to docker host
 push:

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -6,7 +6,7 @@
 use eyre::{Result, WrapErr, bail};
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::Deserialize;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{ai::prefill, database};
 
@@ -631,11 +631,7 @@ pub async fn load_configuration() -> Result<Configuration> {
 
     validate_config(&config)?;
 
-    if config.pings.public {
-        info!("Pings can be triggered by anyone");
-    } else {
-        info!("Pings can only be triggered by members");
-    }
+    debug!(public = config.pings.public, "Ping trigger policy");
 
     Ok(config)
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -243,8 +243,6 @@ where
         TARGET_HOUR,
         TARGET_MINUTE - 1
     );
-    info!("Bot is running. Press Ctrl+C to stop.");
-
     crate::twitch::handlers::spawn::await_shutdown(handlers, shutdown).await;
 
     // After handler shutdown, drain the web task. The graceful shutdown future

--- a/crates/core/src/twitch/handlers/commands.rs
+++ b/crates/core/src/twitch/handlers/commands.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use llm::LlmClient;
 use tokio::{sync::broadcast, time::Duration};
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info};
 use twitch_irc::{
     TwitchIRCClient, login::LoginCredentials, message::ServerMessage, transport::Transport,
 };
@@ -53,7 +53,6 @@ pub struct CommandHandlerConfig<T: Transport, L: LoginCredentials> {
 }
 
 /// Handler for generic text commands that start with `!`.
-#[instrument(skip(cfg))]
 pub async fn run_generic_command_handler<T, L>(cfg: CommandHandlerConfig<T, L>)
 where
     T: Transport + Send + Sync + 'static,

--- a/crates/core/src/twitch/handlers/latency.rs
+++ b/crates/core/src/twitch/handlers/latency.rs
@@ -8,7 +8,7 @@ use tokio::{
     sync::broadcast,
     time::{Duration, sleep},
 };
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, warn};
 use twitch_irc::{
     TwitchIRCClient, irc,
     login::LoginCredentials,
@@ -37,7 +37,6 @@ pub(crate) const LATENCY_LOG_THRESHOLD: u32 = 10;
 ///
 /// The handler is fully independent — PING failures or PONG timeouts are logged
 /// but never crash the handler or affect the EMA.
-#[instrument(skip(client, broadcast_tx, latency, irc_connected))]
 pub async fn run_latency_handler<T, L>(
     client: Arc<TwitchIRCClient<T, L>>,
     broadcast_tx: broadcast::Sender<ServerMessage>,

--- a/crates/core/src/twitch/handlers/router.rs
+++ b/crates/core/src/twitch/handlers/router.rs
@@ -1,12 +1,11 @@
 use tokio::sync::{broadcast, mpsc::UnboundedReceiver};
-use tracing::{debug, info, instrument, trace};
+use tracing::{debug, info, trace};
 use twitch_irc::message::ServerMessage;
 
 /// Message router task that broadcasts incoming IRC messages to all handlers.
 ///
 /// Reads from the twitch-irc receiver and broadcasts to all subscribed handlers.
 /// Exits when the incoming_messages channel is closed.
-#[instrument(skip(incoming_messages, broadcast_tx))]
 pub async fn run_message_router(
     mut incoming_messages: UnboundedReceiver<ServerMessage>,
     broadcast_tx: broadcast::Sender<ServerMessage>,

--- a/crates/core/src/twitch/handlers/tracker_1337.rs
+++ b/crates/core/src/twitch/handlers/tracker_1337.rs
@@ -372,7 +372,6 @@ pub(crate) async fn monitor_1337_messages(
 ///
 /// Monitors messages during the 13:37 window, tracks unique users, and posts stats at 13:38.
 /// Runs continuously, resetting state daily.
-#[instrument(skip(broadcast_tx, client, channel, latency, leaderboard, clock))]
 pub async fn run_1337_handler<T, L>(
     broadcast_tx: broadcast::Sender<ServerMessage>,
     client: Arc<TwitchIRCClient<T, L>>,

--- a/crates/core/src/twitch/setup.rs
+++ b/crates/core/src/twitch/setup.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use eyre::{Context as _, Result, bail};
 use secrecy::ExposeSecret as _;
 use tokio::{sync::mpsc::UnboundedReceiver, time::Duration};
-use tracing::{debug, debug_span, error, info, instrument, trace};
+use tracing::{debug, debug_span, error, info, trace};
 use twitch_irc::{
     ClientConfig, SecureTCPTransport, TwitchIRCClient,
     login::{LoginCredentials as _, RefreshingLoginCredentials},
@@ -21,7 +21,6 @@ use crate::{
 };
 
 /// Create the Twitch IRC client and message receiver without connecting.
-#[instrument(skip(config))]
 pub async fn setup_twitch_client(
     config: &Configuration,
 ) -> Result<(
@@ -54,7 +53,6 @@ pub async fn setup_twitch_client(
 /// Connect, join channel(s), and verify authentication via `GlobalUserState`.
 ///
 /// Returns `Err` if connection times out (30 s) or authentication fails.
-#[instrument(skip(config))]
 pub async fn setup_and_verify_twitch_client(
     config: &Configuration,
 ) -> Result<(

--- a/crates/core/src/util/telemetry.rs
+++ b/crates/core/src/util/telemetry.rs
@@ -7,12 +7,12 @@ use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt};
 
-/// `HH:MM:SS.mmm` (UTC). The default `SystemTime` formatter emits the
-/// full RFC3339 timestamp on every line (~30 chars including date + tz
-/// + microseconds), which is overkill for a single-process bot whose
-/// logs always belong to today. The short form preserves millisecond
-/// precision — enough to order events within a handler — while leaving
-/// room for the actual message content.
+/// `HH:MM:SS.mmm` (UTC). The default `SystemTime` formatter emits the full
+/// RFC3339 timestamp on every line (~30 chars including date + tz +
+/// microseconds), which is overkill for a single-process bot whose logs
+/// always belong to today. The short form preserves millisecond precision —
+/// enough to order events within a handler — while leaving room for the
+/// actual message content.
 struct ShortTimer;
 
 impl FormatTime for ShortTimer {

--- a/crates/core/src/util/telemetry.rs
+++ b/crates/core/src/util/telemetry.rs
@@ -1,14 +1,35 @@
 //! Tracing / observability initialisation.
 
+use chrono::Utc;
 use tracing_error::ErrorLayer;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt};
+
+/// `HH:MM:SS.mmm` (UTC). The default `SystemTime` formatter emits the
+/// full RFC3339 timestamp on every line (~30 chars including date + tz
+/// + microseconds), which is overkill for a single-process bot whose
+/// logs always belong to today. The short form preserves millisecond
+/// precision — enough to order events within a handler — while leaving
+/// room for the actual message content.
+struct ShortTimer;
+
+impl FormatTime for ShortTimer {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        write!(w, "{}", Utc::now().format("%H:%M:%S%.3f"))
+    }
+}
 
 /// Install the global tracing subscriber (format + env-filter + error layer).
 ///
 /// Call once at program startup before any spans are created.
 pub fn install_tracing() {
-    let fmt_layer = fmt::layer().with_target(false);
+    // `with_target(true)` surfaces the emitting module (e.g. `twitch_1337`
+    // vs `twitch_irc` vs `reqwest`) so an unexpected line can be traced
+    // back to a crate without grepping. Pair with `ShortTimer` for the
+    // line-budget we just freed by dropping the date prefix.
+    let fmt_layer = fmt::layer().with_target(true).with_timer(ShortTimer);
     let filter_layer = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .unwrap();

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -21,6 +21,12 @@
 
 /* ====================== Tokens ====================== */
 :root {
+  /* Tells the UA (and well-behaved injectors like Dark Reader) that this
+     page is already a dark theme — pairs with the `darkreader-lock` meta
+     in base.html so the extension stops re-tinting our own oklch palette
+     to its preset blue. */
+  color-scheme: dark;
+
   /* Accent: violet (curated alternate from design handoff) */
   --accent-h: 295;
   --accent-c: 0.18;

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -153,6 +153,7 @@ kbd {
 .nav { padding: 14px 10px; flex: 1; overflow: auto; }
 .nav-group + .nav-group { margin-top: 18px; }
 .nav-group-label {
+  display: block;
   font-family: var(--mono);
   font-size: 10px;
   text-transform: uppercase;
@@ -160,6 +161,14 @@ kbd {
   color: var(--fg-4);
   padding: 0 8px 6px;
 }
+.nav-group-link {
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: var(--r-sm);
+  transition: color 0.12s ease;
+}
+.nav-group-link:hover { color: var(--fg-2); }
+.nav-group-link.active { color: var(--accent); }
 .nav-list { list-style: none; padding: 0; margin: 0; }
 .nav-list > li { padding: 0; }
 .nav-item {

--- a/crates/web/build.rs
+++ b/crates/web/build.rs
@@ -6,6 +6,7 @@
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
@@ -14,6 +15,27 @@ fn fnv1a64(bytes: &[u8]) -> u64 {
         h = h.wrapping_mul(0x100_0000_01b3);
     }
     h
+}
+
+/// Resolve the build's commit SHA. Docker builds get it via the `GIT_SHA`
+/// build-arg (the `.dockerignore` strips `.git/`, so `git` would fail
+/// inside the container). Local cargo runs fall back to `git rev-parse`,
+/// then to `unknown` if both miss.
+fn git_sha() -> String {
+    if let Ok(sha) = env::var("GIT_SHA")
+        && !sha.is_empty()
+    {
+        return sha;
+    }
+    Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
 }
 
 fn main() {
@@ -25,4 +47,9 @@ fn main() {
         println!("cargo:rustc-env=ASSET_V_{key}={:016x}", fnv1a64(&bytes));
         println!("cargo:rerun-if-changed=assets/{name}");
     }
+
+    println!("cargo:rustc-env=GIT_SHA_SHORT={}", git_sha());
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -51,7 +51,13 @@ pub async fn bind(addr: SocketAddr) -> Result<TcpListener> {
 pub async fn run_web(listener: TcpListener, deps: WebDeps, shutdown: Arc<Notify>) -> Result<()> {
     let local_addr = listener.local_addr().ok();
     let app = build_router(deps.state);
-    info!(target: "twitch_1337_web", ?local_addr, "Web dashboard listening");
+    info!(
+        target: "twitch_1337_web",
+        ?local_addr,
+        version = routes::health::PKG_VERSION,
+        sha = routes::health::GIT_SHA,
+        "Web dashboard listening",
+    );
     axum::serve(listener, app)
         .with_graceful_shutdown(async move { shutdown.notified().await })
         .await

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -49,15 +49,18 @@ pub async fn bind(addr: SocketAddr) -> Result<TcpListener> {
 }
 
 pub async fn run_web(listener: TcpListener, deps: WebDeps, shutdown: Arc<Notify>) -> Result<()> {
-    let local_addr = listener.local_addr().ok();
+    let url = listener
+        .local_addr()
+        .map(|a| format!("http://{a}/"))
+        .unwrap_or_else(|_| "<unknown>".to_owned());
     let app = build_router(deps.state);
     info!(
         target: "twitch_1337_web",
-        ?local_addr,
         version = routes::health::PKG_VERSION,
         sha = routes::health::GIT_SHA,
-        "Web dashboard listening",
+        "Build info",
     );
+    info!(target: "twitch_1337_web", %url, "Web dashboard listening");
     axum::serve(listener, app)
         .with_graceful_shutdown(async move { shutdown.notified().await })
         .await

--- a/crates/web/src/routes/health.rs
+++ b/crates/web/src/routes/health.rs
@@ -3,20 +3,35 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::Router;
 use axum::http::StatusCode;
+use axum::response::Json;
 use axum::routing::get;
+use serde_json::json;
+
+pub const GIT_SHA: &str = env!("GIT_SHA_SHORT");
+pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn router(irc_connected: Arc<AtomicBool>) -> Router {
-    Router::new().route(
-        "/healthz",
-        get(move || {
-            let flag = irc_connected.clone();
-            async move {
-                if flag.load(Ordering::Relaxed) {
-                    StatusCode::OK
-                } else {
-                    StatusCode::SERVICE_UNAVAILABLE
+    Router::new()
+        .route(
+            "/healthz",
+            get(move || {
+                let flag = irc_connected.clone();
+                async move {
+                    if flag.load(Ordering::Relaxed) {
+                        StatusCode::OK
+                    } else {
+                        StatusCode::SERVICE_UNAVAILABLE
+                    }
                 }
-            }
-        }),
-    )
+            }),
+        )
+        .route(
+            "/version",
+            get(|| async {
+                Json(json!({
+                    "version": PKG_VERSION,
+                    "sha": GIT_SHA,
+                }))
+            }),
+        )
 }

--- a/crates/web/src/routes/health.rs
+++ b/crates/web/src/routes/health.rs
@@ -3,35 +3,23 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::Router;
 use axum::http::StatusCode;
-use axum::response::Json;
 use axum::routing::get;
-use serde_json::json;
 
 pub const GIT_SHA: &str = env!("GIT_SHA_SHORT");
 pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn router(irc_connected: Arc<AtomicBool>) -> Router {
-    Router::new()
-        .route(
-            "/healthz",
-            get(move || {
-                let flag = irc_connected.clone();
-                async move {
-                    if flag.load(Ordering::Relaxed) {
-                        StatusCode::OK
-                    } else {
-                        StatusCode::SERVICE_UNAVAILABLE
-                    }
+    Router::new().route(
+        "/healthz",
+        get(move || {
+            let flag = irc_connected.clone();
+            async move {
+                if flag.load(Ordering::Relaxed) {
+                    StatusCode::OK
+                } else {
+                    StatusCode::SERVICE_UNAVAILABLE
                 }
-            }),
-        )
-        .route(
-            "/version",
-            get(|| async {
-                Json(json!({
-                    "version": PKG_VERSION,
-                    "sha": GIT_SHA,
-                }))
-            }),
-        )
+            }
+        }),
+    )
 }

--- a/crates/web/src/routes/memory.rs
+++ b/crates/web/src/routes/memory.rs
@@ -36,6 +36,9 @@ pub fn router() -> Router<WebState> {
         .route("/memory/soul", get(view_soul).post(save_soul))
         .route("/memory/lore", get(view_lore).post(save_lore))
         .route("/memory/users", get(list_users))
+        // `/memory/users/new` MUST precede `/memory/users/{user_id}` so the
+        // literal route wins over the dynamic capture.
+        .route("/memory/users/new", post(create_user))
         .route("/memory/users/{user_id}", get(view_user).post(save_user))
         // `/memory/state/new` MUST precede `/memory/state/{slug}` so the
         // literal route wins over the dynamic capture.
@@ -389,6 +392,34 @@ async fn view_user(
         .to_owned();
     let save_url = format!("/memory/users/{user_id}");
     view_kind(&state, &session, kind, title, save_url, None, Some(mf)).await
+}
+
+#[derive(Deserialize)]
+struct NewUserForm {
+    user_id: String,
+    #[serde(rename = "_csrf")]
+    csrf: String,
+}
+
+/// Reads a numeric `user_id` from the form, validates, and redirects to
+/// the editor at `/memory/users/{id}`. The editor renders an empty file
+/// on first GET because `read_kind` synthesizes a blank `MemoryFile` for
+/// missing paths, so no on-disk row is created until the user saves.
+async fn create_user(
+    Extension(session): Extension<Session>,
+    axum::Form(form): axum::Form<NewUserForm>,
+) -> Result<Response, WebError> {
+    if !csrf::verify(&form.csrf, &session.csrf_value) {
+        return Err(WebError::CsrfMismatch);
+    }
+    let user_id = form.user_id.trim();
+    if !is_valid_user_id(user_id) {
+        return Err(WebError::Validation {
+            field: "user_id".into(),
+            msg: "must be numeric, 1-32 digits".into(),
+        });
+    }
+    Ok(Redirect::to(&format!("/memory/users/{user_id}")).into_response())
 }
 
 async fn list_state(

--- a/crates/web/templates/base.html
+++ b/crates/web/templates/base.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <meta name="darkreader-lock">
   <title>{% block title %}twitch-1337{% endblock %}</title>
   <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg?v={{ env!("ASSET_V_FAVICON_SVG") }}">
   <link rel="stylesheet" href="/assets/app.css?v={{ env!("ASSET_V_APP_CSS") }}">

--- a/crates/web/templates/base.html
+++ b/crates/web/templates/base.html
@@ -19,8 +19,10 @@
       <header class="topbar">
         <nav class="crumbs" aria-label="Breadcrumb">
           <span class="crumb-root">~</span>
+          {% for seg in current_page.split('_') %}
           <span class="crumb-sep">/</span>
-          <span class="crumb-current">{% block crumb %}{{ current_page.replace('_', "/") }}{% endblock %}</span>
+          <span class="crumb-current">{{ seg }}</span>
+          {% endfor %}
         </nav>
         <div class="topbar-right">
           <label class="search">

--- a/crates/web/templates/memory/state_list.html
+++ b/crates/web/templates/memory/state_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}State — twitch-1337{% endblock %}
 {% block content %}
+<a href="/memory" class="link muted" style="display:inline-block;margin-bottom:6px;">← Back</a>
 <div class="page-head">
   <div>
     <h1>State <span class="count">({{ items.len() }})</span></h1>

--- a/crates/web/templates/memory/users_list.html
+++ b/crates/web/templates/memory/users_list.html
@@ -7,6 +7,11 @@
     <h1>Users <span class="count">({{ items.len() }})</span></h1>
     <p class="page-sub">Per-user character sheets at <code>memories/users/&lt;id&gt;.md</code>. 4 KiB cap each.</p>
   </div>
+  <form class="page-actions" method="post" action="/memory/users/new">
+    <input type="hidden" name="_csrf" value="{{ csrf }}">
+    <input type="text" class="input" name="user_id" placeholder="Twitch user id" pattern="[0-9]{1,32}" inputmode="numeric" required autocomplete="off" spellcheck="false" style="width:180px;">
+    <button type="submit" class="btn primary">+ New user note</button>
+  </form>
 </div>
 
 {% if items.is_empty() %}

--- a/crates/web/templates/memory/users_list.html
+++ b/crates/web/templates/memory/users_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Users — twitch-1337{% endblock %}
 {% block content %}
+<a href="/memory" class="link muted" style="display:inline-block;margin-bottom:6px;">← Back</a>
 <div class="page-head">
   <div>
     <h1>Users <span class="count">({{ items.len() }})</span></h1>

--- a/crates/web/templates/sidebar.html
+++ b/crates/web/templates/sidebar.html
@@ -11,7 +11,7 @@
     <div class="brand-mark"><span class="brand-glyph">⌬</span></div>
     <div class="brand-text">
       <span class="brand-name">twitch-1337</span>
-      <span class="brand-meta">v{{ env!("CARGO_PKG_VERSION") }} · main</span>
+      <span class="brand-meta" title="commit {{ env!("GIT_SHA_SHORT") }}">v{{ env!("CARGO_PKG_VERSION") }} · {{ env!("GIT_SHA_SHORT") }}</span>
     </div>
   </div>
 

--- a/crates/web/templates/sidebar.html
+++ b/crates/web/templates/sidebar.html
@@ -26,9 +26,8 @@
     </div>
 
     <div class="nav-group">
-      <div class="nav-group-label">Memory</div>
+      <a class="nav-group-label nav-group-link{% if current_page == "memory" %} active{% endif %}" href="/memory">Memory</a>
       <ul class="nav-list">
-        {% call nav_item("memory", "/memory", "Tree") %}{% endcall %}
         {% call nav_item("memory_soul", "/memory/soul", "SOUL") %}{% endcall %}
         {% call nav_item("memory_lore", "/memory/lore", "LORE") %}{% endcall %}
         {% call nav_item("memory_users", "/memory/users", "Users") %}{% endcall %}

--- a/crates/web/templates/stub.html
+++ b/crates/web/templates/stub.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% block title %}{{ title }} — twitch-1337{% endblock %}
-{% block crumb %}{{ title }}{% endblock %}
 {% block content %}
 <div class="page-head">
   <div>


### PR DESCRIPTION
Diagnosed a long-running "lines turn blue on the Users page" report and rolled the fix + a handful of adjacent polish items into one PR. None of these individually warrant a separate review.

## Summary

- **Lock Dark Reader out of the dashboard.** The user-card `border-left` rendered as `rgb(41, 74, 185)` despite `--line-2` resolving to neutral white-alpha. Confirmed via DevTools the extension was substituting our oklch palette with its preset accent because the page never declared itself as already dark. `color-scheme: dark` on `:root` + `<meta name="darkreader-lock">` in `base.html` take care of it.
- **Bake the commit SHA into the binary.** Diagnosis took several round-trips because nothing in the running dashboard tells you which commit you're looking at. `crates/web/build.rs` stamps `GIT_SHA_SHORT` (from a Dockerfile build-arg in production, `git rev-parse` for local cargo runs); the sidebar `brand-meta` swaps `· main` for `· <sha>`, `/version` returns `{"sha", "version"}`, and a fresh `Build info` log line carries both. Justfile and the GitHub Actions Docker workflow pass `--build-arg GIT_SHA=$(git rev-parse --short=12 HEAD)`.
- **Consistent lowercase breadcrumb + spaced separators.** Stub pages overrode the crumb with their TitleCase `title`, so the topbar oscillated between `~ / Schedules` and `~ / pings`. The memory crumb showed `~ / memory/soul` because the second `/` was inline text from a `.replace('_', "/")` while the first was a real `.crumb-sep` span. Iterate `current_page.split('_')` and emit a separator span between each segment so every crumb reads `~ / memory / soul` with uniform spacing.
- **Memory section heading is clickable; "Tree" sub-item dropped.** `/memory` is an overview of the section, so promoting it to the `nav-group-label` (now an `<a>` with a new `.nav-group-link` style) reads better than a dedicated child item.
- **Back link on Users and State list pages.** SOUL and LORE jumped straight into the editor (which already has `← Back`); Users and State stopped at a list page with no way to climb back to `/memory` without using the sidebar. Mirror the editor's chip.
- **+ New user note entry-point.** Users page mirrored the State list's layout except for the create button. New `POST /memory/users/new` route validates a numeric Twitch id and 303s to the existing editor, which renders an empty `MemoryFile` for missing paths. No row hits disk until save.
- **Log polish.** Compact `HH:MM:SS.mmm` timestamp via custom `FormatTime`, `with_target(true)` to surface the emitting crate, drop `#[instrument]` from the long-lived top-level handlers (their span names duplicated the message text on every line and the inner spans that carry useful fields keep their instruments), demote the duplicated "Pings can be triggered by anyone" pair to a single structured DEBUG, drop the redundant "Bot is running. Press Ctrl+C to stop." line.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run` — 429 tests pass locally
- [ ] `just dev-web` → visit `/memory/users` with Dark Reader enabled — borders stay neutral
- [ ] `/version` returns `{"sha": "...", "version": "0.1.0"}`
- [ ] Sidebar `brand-meta` shows `v0.1.0 · <sha>`; tooltip reads `commit <sha>`
- [ ] Topbar breadcrumb on every page is lowercase with `~ / a / b / c` spacing
- [ ] Clicking the sidebar "Memory" header navigates to `/memory`
- [ ] `← Back` link on `/memory/users` and `/memory/state` returns to `/memory`
- [ ] `+ New user note` form on `/memory/users` accepts a numeric id and lands on the editor