### PR TITLE
fix(aviation): keep pre-ADS-B tracked flights with stale schedules

### DIFF
--- a/crates/core/src/aviation/tracker.rs
+++ b/crates/core/src/aviation/tracker.rs
@@ -717,9 +717,38 @@ fn live_poll_interval(flight: &TrackedFlight) -> Duration {
     }
 }
 
+fn pending_unknown_poll_schedule(
+    flight: &TrackedFlight,
+    now: DateTime<Utc>,
+) -> PendingPollSchedule {
+    let expires_at = flight.tracked_at + chrono_seconds(PENDING_UNKNOWN_EXPIRE_AFTER);
+    if now >= expires_at {
+        return PendingPollSchedule::Expired;
+    }
+
+    let age = now.signed_duration_since(flight.tracked_at);
+    let interval = if age < chrono_seconds(PENDING_UNKNOWN_FAST_AFTER_TRACK) {
+        PENDING_POLL_2_MIN
+    } else if age < chrono_seconds(PENDING_UNKNOWN_NORMAL_AFTER_TRACK) {
+        PENDING_POLL_10_MIN
+    } else {
+        PENDING_POLL_30_MIN
+    };
+
+    PendingPollSchedule::Active {
+        interval,
+        expires_at,
+    }
+}
+
 fn pending_poll_schedule(flight: &TrackedFlight, now: DateTime<Utc>) -> PendingPollSchedule {
     if let Some(scheduled_departure_at) = flight.scheduled_departure_at {
         let expires_at = scheduled_departure_at + chrono_seconds(PENDING_SCHEDULED_EXPIRE_AFTER);
+        // Aviationstack can return an older occurrence of a reused flight
+        // number. Do not let stale metadata expire a fresh pending track.
+        if flight.tracked_at >= expires_at {
+            return pending_unknown_poll_schedule(flight, now);
+        }
         if now >= expires_at {
             return PendingPollSchedule::Expired;
         }
@@ -744,24 +773,7 @@ fn pending_poll_schedule(flight: &TrackedFlight, now: DateTime<Utc>) -> PendingP
         };
     }
 
-    let expires_at = flight.tracked_at + chrono_seconds(PENDING_UNKNOWN_EXPIRE_AFTER);
-    if now >= expires_at {
-        return PendingPollSchedule::Expired;
-    }
-
-    let age = now.signed_duration_since(flight.tracked_at);
-    let interval = if age < chrono_seconds(PENDING_UNKNOWN_FAST_AFTER_TRACK) {
-        PENDING_POLL_2_MIN
-    } else if age < chrono_seconds(PENDING_UNKNOWN_NORMAL_AFTER_TRACK) {
-        PENDING_POLL_10_MIN
-    } else {
-        PENDING_POLL_30_MIN
-    };
-
-    PendingPollSchedule::Active {
-        interval,
-        expires_at,
-    }
+    pending_unknown_poll_schedule(flight, now)
 }
 
 fn next_due_after_last_poll(

--- a/crates/core/tests/flight_tracker.rs
+++ b/crates/core/tests/flight_tracker.rs
@@ -285,6 +285,106 @@ async fn track_command_accepts_aviationstack_flight_before_adsb_appears() {
 
 #[tokio::test]
 #[serial]
+async fn track_command_keeps_pending_flight_with_stale_scheduled_departure() {
+    let bot = TestBotBuilder::new()
+        .with_config(enable_aviationstack)
+        .spawn()
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/callsign/RYR196"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ac": [],
+            "ctime": 0,
+            "now": 0,
+            "total": 0
+        })))
+        .mount(&bot.adsb_mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/flights"))
+        .and(query_param("access_key", "test-key"))
+        .and(query_param("flight_iata", "FR196"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{
+                "flight": {
+                    "iata": "FR196",
+                    "icao": "RYR196",
+                    "number": "196"
+                },
+                "airline": {
+                    "iata": "FR",
+                    "icao": "RYR",
+                    "name": "Ryanair"
+                },
+                "departure": {
+                    "iata": "BER",
+                    "icao": "EDDB",
+                    "scheduled": "2026-04-17T10:30:00+00:00",
+                    "actual": null,
+                    "actual_runway": null
+                },
+                "arrival": {
+                    "iata": "BUD",
+                    "icao": "LHBP",
+                    "estimated": "2026-04-17T12:00:00+00:00",
+                    "actual": null
+                },
+                "aircraft": {
+                    "icao24": null,
+                    "icao": "B38M"
+                }
+            }]
+        })))
+        .mount(&bot.adsb_mock)
+        .await;
+
+    let mut bot = bot;
+    bot.send("alice", "!track FR196").await;
+    let ack = bot.expect_say(Duration::from_secs(5)).await;
+    assert!(ack.contains("RYR196"), "got: {ack}");
+    assert!(ack.contains("BER") && ack.contains("BUD"), "got: {ack}");
+
+    bot.expect_silent(Duration::from_millis(200)).await;
+
+    let state_path = bot.data_dir.path().join("flights.ron");
+    let persisted = tokio::fs::read_to_string(state_path).await.unwrap();
+    let state: twitch_1337::aviation::tracker::FlightTrackerState =
+        ron::from_str(&persisted).unwrap();
+    let flight = state.flights.first().expect("persisted flight");
+    assert_eq!(flight.callsign.as_deref(), Some("RYR196"));
+    assert_eq!(flight.route, Some(("BER".to_string(), "BUD".to_string())));
+    assert_eq!(flight.aircraft_type.as_deref(), Some("B38M"));
+    assert_eq!(flight.last_seen, None);
+    assert_eq!(
+        flight.scheduled_departure_at.map(|dt| dt.timestamp()),
+        Some(
+            chrono::DateTime::parse_from_rfc3339("2026-04-17T10:30:00+00:00")
+                .unwrap()
+                .timestamp()
+        )
+    );
+
+    let callsign_requests = bot
+        .adsb_mock
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/callsign/RYR196")
+        .count();
+    assert_eq!(
+        callsign_requests, 1,
+        "stale pending flight should not be repolled immediately"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn pending_flight_polls_when_due_and_becomes_visible() {
     let bot = TestBotBuilder::new()
         .with_config(enable_aviationstack)

--- a/docs/superpowers/specs/2026-04-06-flight-tracker-design.md
+++ b/docs/superpowers/specs/2026-04-06-flight-tracker-design.md
@@ -213,6 +213,8 @@ Flights accepted from metadata before ADS-B visibility are pending (`last_seen =
 Pending flights expire without another ADS-B call after 12h past scheduled
 departure, or after 24h when no scheduled departure is known.
 
+If the scheduled departure was already expired when tracking started, treat it as stale metadata and use the no-scheduled-departure pending schedule instead.
+
 ## Persistence
 
 **File:** `flights.ron` in the data directory (alongside `leaderboard.ron`, `feedback.txt`).


### PR DESCRIPTION
## Summary
- keep Aviationstack-backed pending flights tracked when ADS-B has not seen them yet
- treat already-expired scheduled departure metadata as stale and fall back to the unknown-departure pending schedule
- add regression coverage for `!track FR196` where metadata exists but live ADS-B is still empty

## Test
- cargo +1.95.0 fmt
- cargo +1.95.0 test -p twitch-1337-core --test flight_tracker
- cargo +1.95.0 test -p twitch-1337-core pending_poll_schedule