### PR TITLE
fix(aviation): clear pending callsign hexes and improve callsign matching logic

### DIFF
--- a/crates/core/src/aviation/tracker.rs
+++ b/crates/core/src/aviation/tracker.rs
@@ -210,6 +210,20 @@ pub struct FlightTrackerState {
     pub flights: Vec<TrackedFlight>,
 }
 
+fn clear_pending_callsign_hexes(state: &mut FlightTrackerState) -> usize {
+    let mut cleared = 0;
+    for flight in &mut state.flights {
+        if matches!(flight.identifier, FlightIdentifier::Callsign(_))
+            && flight.last_seen.is_none()
+            && flight.hex.is_some()
+        {
+            flight.hex = None;
+            cleared += 1;
+        }
+    }
+    cleared
+}
+
 /// Loads tracked flights from the RON file.
 ///
 /// Returns an empty state if the file doesn't exist or is corrupted.
@@ -217,9 +231,11 @@ pub(crate) async fn load_tracker_state(data_dir: &Path) -> FlightTrackerState {
     let path = data_dir.join(FLIGHTS_FILENAME);
     match fs::read_to_string(&path).await {
         Ok(contents) => match ron::from_str::<FlightTrackerState>(&contents) {
-            Ok(state) => {
+            Ok(mut state) => {
+                let cleared_pending_hexes = clear_pending_callsign_hexes(&mut state);
                 info!(
                     flights = state.flights.len(),
+                    cleared_pending_hexes,
                     "Loaded flight tracker state from {}",
                     path.display()
                 );
@@ -505,11 +521,9 @@ fn apply_aviationstack_metadata(flight: &mut TrackedFlight, metadata: Aviationst
         set_route_from_iata(flight, origin, dest);
     }
 
-    if flight.hex.is_none()
-        && let Some(hex) = metadata.aircraft_icao24
-    {
-        flight.hex = Some(hex.to_uppercase());
-    }
+    // Aviationstack aircraft assignments are schedule metadata, not live ADS-B
+    // identity. Reused flight numbers can point at a future rotation, so only
+    // live ADS-B responses are allowed to set the tracking hex.
 
     if flight.aircraft_type.is_none()
         && let Some(aircraft_type) = metadata.aircraft_icao
@@ -700,6 +714,25 @@ fn add_duration(time: DateTime<Utc>, duration: Duration) -> DateTime<Utc> {
 
 fn is_pending_adsb(flight: &TrackedFlight) -> bool {
     flight.last_seen.is_none()
+}
+
+fn aircraft_callsign(ac: &NearbyAircraft) -> Option<&str> {
+    ac.flight
+        .as_deref()
+        .map(str::trim)
+        .filter(|callsign| !callsign.is_empty())
+}
+
+fn aircraft_matches_tracked_callsign(ac: &NearbyAircraft, flight: &TrackedFlight) -> bool {
+    let expected = match &flight.identifier {
+        FlightIdentifier::Callsign(identifier_callsign) => flight
+            .callsign
+            .as_deref()
+            .unwrap_or(identifier_callsign.as_str()),
+        FlightIdentifier::Hex(_) => return true,
+    };
+
+    aircraft_callsign(ac).is_some_and(|actual| actual.eq_ignore_ascii_case(expected))
 }
 
 fn live_poll_interval(flight: &TrackedFlight) -> Duration {
@@ -1334,9 +1367,10 @@ async fn poll_all_flights<T, L>(
     use crate::aviation::NearbyAircraft;
     type PollResult =
         Result<Result<Option<NearbyAircraft>, eyre::Report>, tokio::time::error::Elapsed>;
+    type PollAttempt = (bool, PollResult);
 
     let mut join_set = tokio::task::JoinSet::new();
-    let mut fetch_results: Vec<Option<PollResult>> =
+    let mut fetch_results: Vec<Option<PollAttempt>> =
         (0..state.flights.len()).map(|_| None).collect();
 
     for (idx, flight) in state.flights.iter().enumerate() {
@@ -1359,32 +1393,40 @@ async fn poll_all_flights<T, L>(
         let id = flight.identifier.clone();
         let hex = flight.hex.clone();
         let callsign = flight.callsign.clone();
+        let has_live_adsb_identity = flight.last_seen.is_some();
         join_set.spawn(async move {
-            let result: PollResult = match &id {
-                FlightIdentifier::Hex(h) => {
-                    tokio::time::timeout(POLL_TIMEOUT, ac.get_aircraft_by_hex(h)).await
-                }
+            let (used_hex, result): PollAttempt = match &id {
+                FlightIdentifier::Hex(h) => (
+                    true,
+                    tokio::time::timeout(POLL_TIMEOUT, ac.get_aircraft_by_hex(h)).await,
+                ),
                 FlightIdentifier::Callsign(cs) => {
-                    if let Some(h) = &hex {
-                        tokio::time::timeout(POLL_TIMEOUT, ac.get_aircraft_by_hex(h)).await
+                    if has_live_adsb_identity && let Some(h) = &hex {
+                        (
+                            true,
+                            tokio::time::timeout(POLL_TIMEOUT, ac.get_aircraft_by_hex(h)).await,
+                        )
                     } else {
                         let lookup_callsign = callsign.as_deref().unwrap_or(cs);
-                        tokio::time::timeout(
-                            POLL_TIMEOUT,
-                            ac.get_aircraft_by_callsign(lookup_callsign),
+                        (
+                            false,
+                            tokio::time::timeout(
+                                POLL_TIMEOUT,
+                                ac.get_aircraft_by_callsign(lookup_callsign),
+                            )
+                            .await,
                         )
-                        .await
                     }
                 }
             };
-            (idx, result)
+            (idx, used_hex, result)
         });
     }
 
     // Collect results indexed by flight position
     while let Some(res) = join_set.join_next().await {
-        if let Ok((idx, poll_result)) = res {
-            fetch_results[idx] = Some(poll_result);
+        if let Ok((idx, used_hex, poll_result)) = res {
+            fetch_results[idx] = Some((used_hex, poll_result));
         }
     }
 
@@ -1396,7 +1438,7 @@ async fn poll_all_flights<T, L>(
 
     #[allow(clippy::needless_range_loop)]
     for idx in 0..state.flights.len() {
-        let Some(ac_result) = fetch_results[idx].take() else {
+        let Some((used_hex, ac_result)) = fetch_results[idx].take() else {
             continue;
         };
         let flight = &mut state.flights[idx];
@@ -1440,6 +1482,18 @@ async fn poll_all_flights<T, L>(
             }
         };
 
+        if !aircraft_matches_tracked_callsign(&ac, flight) {
+            debug!(
+                identifier = %flight.identifier,
+                aircraft_callsign = aircraft_callsign(&ac).unwrap_or("<missing>"),
+                "Ignoring ADS-B aircraft with mismatched callsign"
+            );
+            if used_hex && flight.hex.is_some() {
+                flight.hex = None;
+            }
+            continue;
+        }
+
         if was_pending {
             messages.push(msg_adsb_visible(flight));
         }
@@ -1474,7 +1528,7 @@ async fn poll_all_flights<T, L>(
                 flight.route = Some((origin, dest));
             }
         }
-        if flight.hex.is_none()
+        if (flight.hex.is_none() || was_pending)
             && let Some(hex) = &ac.hex
         {
             debug!(identifier = %flight.identifier, hex = %hex, "Resolved hex");
@@ -1653,6 +1707,58 @@ mod tests {
         }
     }
 
+    #[test]
+    fn clear_pending_callsign_hexes_drops_untrusted_hex_only_before_adsb_seen() {
+        let mut pending_callsign = tracked_flight();
+        pending_callsign.hex = Some("48C2A2".to_string());
+
+        let mut live_callsign = tracked_flight();
+        live_callsign.hex = Some("3C6589".to_string());
+        live_callsign.last_seen = Some(dt("2026-04-18T11:00:00Z"));
+
+        let mut pending_hex_identifier = tracked_flight();
+        pending_hex_identifier.identifier = FlightIdentifier::Hex("48C2A2".to_string());
+        pending_hex_identifier.hex = Some("48C2A2".to_string());
+
+        let mut state = FlightTrackerState {
+            flights: vec![pending_callsign, live_callsign, pending_hex_identifier],
+        };
+
+        assert_eq!(clear_pending_callsign_hexes(&mut state), 1);
+        assert_eq!(state.flights[0].hex, None);
+        assert_eq!(state.flights[1].hex.as_deref(), Some("3C6589"));
+        assert_eq!(state.flights[2].hex.as_deref(), Some("48C2A2"));
+    }
+
+    #[test]
+    fn aircraft_matches_tracked_callsign_rejects_reused_airframe() {
+        let mut flight = tracked_flight();
+        flight.identifier = FlightIdentifier::Callsign("FR196".to_string());
+        flight.callsign = Some("RYR196".to_string());
+        let matching = NearbyAircraft {
+            flight: Some(" RYR196 ".to_string()),
+            ..aircraft_at(34_000, 0)
+        };
+        let reused_airframe = NearbyAircraft {
+            flight: Some("RYR58JX ".to_string()),
+            ..aircraft_at(34_000, 0)
+        };
+        let missing_callsign = NearbyAircraft {
+            flight: None,
+            ..aircraft_at(34_000, 0)
+        };
+
+        assert!(aircraft_matches_tracked_callsign(&matching, &flight));
+        assert!(!aircraft_matches_tracked_callsign(
+            &reused_airframe,
+            &flight
+        ));
+        assert!(!aircraft_matches_tracked_callsign(
+            &missing_callsign,
+            &flight
+        ));
+    }
+
     fn aircraft_at(altitude_ft: i64, baro_rate: i64) -> NearbyAircraft {
         NearbyAircraft {
             hex: Some("4952c3".to_string()),
@@ -1749,7 +1855,7 @@ mod tests {
             Some(dt("2026-04-18T09:45:00Z"))
         );
         assert_eq!(flight.takeoff_at, Some(dt("2026-04-18T10:05:00Z")));
-        assert_eq!(flight.hex.as_deref(), Some("3C6589"));
+        assert_eq!(flight.hex.as_deref(), None);
         assert_eq!(flight.aircraft_type.as_deref(), Some("A320"));
     }
 

--- a/crates/core/src/aviation/tracker.rs
+++ b/crates/core/src/aviation/tracker.rs
@@ -717,9 +717,38 @@ fn live_poll_interval(flight: &TrackedFlight) -> Duration {
     }
 }
 
+fn pending_unknown_poll_schedule(
+    flight: &TrackedFlight,
+    now: DateTime<Utc>,
+) -> PendingPollSchedule {
+    let expires_at = flight.tracked_at + chrono_seconds(PENDING_UNKNOWN_EXPIRE_AFTER);
+    if now >= expires_at {
+        return PendingPollSchedule::Expired;
+    }
+
+    let age = now.signed_duration_since(flight.tracked_at);
+    let interval = if age < chrono_seconds(PENDING_UNKNOWN_FAST_AFTER_TRACK) {
+        PENDING_POLL_2_MIN
+    } else if age < chrono_seconds(PENDING_UNKNOWN_NORMAL_AFTER_TRACK) {
+        PENDING_POLL_10_MIN
+    } else {
+        PENDING_POLL_30_MIN
+    };
+
+    PendingPollSchedule::Active {
+        interval,
+        expires_at,
+    }
+}
+
 fn pending_poll_schedule(flight: &TrackedFlight, now: DateTime<Utc>) -> PendingPollSchedule {
     if let Some(scheduled_departure_at) = flight.scheduled_departure_at {
         let expires_at = scheduled_departure_at + chrono_seconds(PENDING_SCHEDULED_EXPIRE_AFTER);
+        // Aviationstack can return an older occurrence of a reused flight
+        // number. Do not let stale metadata expire a fresh pending track.
+        if flight.tracked_at >= expires_at {
+            return pending_unknown_poll_schedule(flight, now);
+        }
         if now >= expires_at {
             return PendingPollSchedule::Expired;
         }
@@ -744,24 +773,7 @@ fn pending_poll_schedule(flight: &TrackedFlight, now: DateTime<Utc>) -> PendingP
         };
     }
 
-    let expires_at = flight.tracked_at + chrono_seconds(PENDING_UNKNOWN_EXPIRE_AFTER);
-    if now >= expires_at {
-        return PendingPollSchedule::Expired;
-    }
-
-    let age = now.signed_duration_since(flight.tracked_at);
-    let interval = if age < chrono_seconds(PENDING_UNKNOWN_FAST_AFTER_TRACK) {
-        PENDING_POLL_2_MIN
-    } else if age < chrono_seconds(PENDING_UNKNOWN_NORMAL_AFTER_TRACK) {
-        PENDING_POLL_10_MIN
-    } else {
-        PENDING_POLL_30_MIN
-    };
-
-    PendingPollSchedule::Active {
-        interval,
-        expires_at,
-    }
+    pending_unknown_poll_schedule(flight, now)
 }
 
 fn next_due_after_last_poll(

--- a/crates/core/tests/flight_tracker.rs
+++ b/crates/core/tests/flight_tracker.rs
@@ -333,7 +333,7 @@ async fn track_command_keeps_pending_flight_with_stale_scheduled_departure() {
                     "actual": null
                 },
                 "aircraft": {
-                    "icao24": null,
+                    "icao24": "48c2a2",
                     "icao": "B38M"
                 }
             }]
@@ -355,6 +355,7 @@ async fn track_command_keeps_pending_flight_with_stale_scheduled_departure() {
         ron::from_str(&persisted).unwrap();
     let flight = state.flights.first().expect("persisted flight");
     assert_eq!(flight.callsign.as_deref(), Some("RYR196"));
+    assert_eq!(flight.hex.as_deref(), None);
     assert_eq!(flight.route, Some(("BER".to_string(), "BUD".to_string())));
     assert_eq!(flight.aircraft_type.as_deref(), Some("B38M"));
     assert_eq!(flight.last_seen, None);

--- a/crates/core/tests/flight_tracker.rs
+++ b/crates/core/tests/flight_tracker.rs
@@ -285,6 +285,106 @@ async fn track_command_accepts_aviationstack_flight_before_adsb_appears() {
 
 #[tokio::test]
 #[serial]
+async fn track_command_keeps_pending_flight_with_stale_scheduled_departure() {
+    let bot = TestBotBuilder::new()
+        .with_config(enable_aviationstack)
+        .spawn()
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/callsign/RYR196"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ac": [],
+            "ctime": 0,
+            "now": 0,
+            "total": 0
+        })))
+        .mount(&bot.adsb_mock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/flights"))
+        .and(query_param("access_key", "test-key"))
+        .and(query_param("flight_iata", "FR196"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{
+                "flight": {
+                    "iata": "FR196",
+                    "icao": "RYR196",
+                    "number": "196"
+                },
+                "airline": {
+                    "iata": "FR",
+                    "icao": "RYR",
+                    "name": "Ryanair"
+                },
+                "departure": {
+                    "iata": "BER",
+                    "icao": "EDDB",
+                    "scheduled": "2026-04-17T10:30:00+00:00",
+                    "actual": null,
+                    "actual_runway": null
+                },
+                "arrival": {
+                    "iata": "BUD",
+                    "icao": "LHBP",
+                    "estimated": "2026-04-17T12:00:00+00:00",
+                    "actual": null
+                },
+                "aircraft": {
+                    "icao24": null,
+                    "icao": "B38M"
+                }
+            }]
+        })))
+        .mount(&bot.adsb_mock)
+        .await;
+
+    let mut bot = bot;
+    bot.send("alice", "!track FR196").await;
+    let ack = bot.expect_say(Duration::from_secs(5)).await;
+    assert!(ack.contains("RYR196"), "got: {ack}");
+    assert!(ack.contains("BER") && ack.contains("BUD"), "got: {ack}");
+
+    bot.expect_silent(Duration::from_millis(200)).await;
+
+    let state_path = bot.data_dir.path().join("flights.ron");
+    let persisted = tokio::fs::read_to_string(state_path).await.unwrap();
+    let state: twitch_1337::aviation::tracker::FlightTrackerState =
+        ron::from_str(&persisted).unwrap();
+    let flight = state.flights.first().expect("persisted flight");
+    assert_eq!(flight.callsign.as_deref(), Some("RYR196"));
+    assert_eq!(flight.route, Some(("BER".to_string(), "BUD".to_string())));
+    assert_eq!(flight.aircraft_type.as_deref(), Some("B38M"));
+    assert_eq!(flight.last_seen, None);
+    assert_eq!(
+        flight.scheduled_departure_at.map(|dt| dt.timestamp()),
+        Some(
+            chrono::DateTime::parse_from_rfc3339("2026-04-17T10:30:00+00:00")
+                .unwrap()
+                .timestamp()
+        )
+    );
+
+    let callsign_requests = bot
+        .adsb_mock
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|request| request.url.path() == "/callsign/RYR196")
+        .count();
+    assert_eq!(
+        callsign_requests, 1,
+        "stale pending flight should not be repolled immediately"
+    );
+
+    bot.shutdown().await;
+}
+
+#[tokio::test]
+#[serial]
 async fn pending_flight_polls_when_due_and_becomes_visible() {
     let bot = TestBotBuilder::new()
         .with_config(enable_aviationstack)

--- a/docs/superpowers/specs/2026-04-06-flight-tracker-design.md
+++ b/docs/superpowers/specs/2026-04-06-flight-tracker-design.md
@@ -213,6 +213,8 @@ Flights accepted from metadata before ADS-B visibility are pending (`last_seen =
 Pending flights expire without another ADS-B call after 12h past scheduled
 departure, or after 24h when no scheduled departure is known.
 
+If the scheduled departure was already expired when tracking started, treat it as stale metadata and use the no-scheduled-departure pending schedule instead.
+
 ## Persistence
 
 **File:** `flights.ron` in the data directory (alongside `leaderboard.ron`, `feedback.txt`).


### PR DESCRIPTION
## Summary

- Keep callsign-tracked pending flights on callsign lookup instead of trusting Aviationstack `aircraft.icao24`
- Clear stale pending callsign hexes from persisted tracker state on load
- Reject ADS-B hex lookup results when the aircraft `flight` callsign does not match the tracked flight
- Add regression coverage for stale Aviationstack aircraft assignments and reused-airframe callsign mismatches

## Root Cause

Aviationstack can return aircraft assignment metadata for a reused flight number. The tracker treated that `icao24` as live ADS-B identity and switched future polls to `/hex/{icao24}`.

That allowed the tracker to follow the aircraft’s current or future assignment instead of the requested flight. Example: tracking `FR196` / `RYR196` could end up polling hex `48c2a2`, whose ADS-B `flight` was actually `RYR58JX`.

## Fix

Aviationstack metadata is now used only for schedule/route/type enrichment, not as live ADS-B identity. For callsign-tracked flights, a hex lookup result is accepted only when the ADS-B `flight` value matches the tracked callsign after trim/case-insensitive comparison.

## Validation

- `cargo +1.95.0-x86_64-unknown-linux-gnu fmt --check`
- `cargo +1.95.0-x86_64-unknown-linux-gnu test -p twitch-1337-core aviation::tracker::tests -- --nocapture`
- `cargo +1.95.0-x86_64-unknown-linux-gnu test -p twitch-1337-core --test flight_tracker -- --nocapture`

Refs #182
