### PR TITLE
feat: dönerpreisindex command + AI tool (#178)

### DIFF
--- a/crates/core/src/ai/command.rs
+++ b/crates/core/src/ai/command.rs
@@ -147,17 +147,22 @@ impl AiCommand {
 }
 
 /// Memory-v2 path executor that dispatches by tool name to the chat-turn
-/// executor (write_file/write_state/delete_state) or, when web tools are
-/// configured, the web search executor (web_search/read_url).
+/// executor (write_file/write_state/delete_state), the web search executor
+/// (web_search/read_url) when web tools are configured, or the always-on
+/// doener_index tool.
 struct V2Executor<'a> {
     chat: &'a ChatTurnExecutor,
     web: Option<&'a content::ContentToolExecutor>,
+    doener: &'a crate::doener::DoenerClient,
     trace: &'a TraceIds,
 }
 
 #[async_trait]
 impl ToolExecutor for V2Executor<'_> {
     async fn execute(&self, call: &ToolCall) -> ToolResultMessage {
+        if call.name == crate::ai::doener_tool::DOENER_TOOL_NAME {
+            return crate::ai::doener_tool::execute_doener_index(self.doener, call).await;
+        }
         if content::is_web_tool(&call.name) {
             match self.web {
                 Some(w) => w.execute_tool_call(call, self.trace).await,
@@ -408,6 +413,7 @@ where
         });
 
         let mut tools = chat_turn_tools();
+        tools.push(crate::ai::doener_tool::doener_tool());
         if self.web.is_some() {
             tools.extend(content::ai_tools());
         }
@@ -436,6 +442,7 @@ where
         let combined_exec = V2Executor {
             chat: &exec,
             web: self.web.as_ref().map(|w| w.executor.as_ref()),
+            doener: self.doener.as_ref(),
             trace: &trace,
         };
         let final_text = match run_agent(&*self.llm_client, req, &combined_exec, opts).await {

--- a/crates/core/src/ai/command.rs
+++ b/crates/core/src/ai/command.rs
@@ -91,6 +91,7 @@ pub struct AiCommand {
     web: Option<AiWeb>,
     emotes: Option<Arc<SevenTvEmoteProvider>>,
     bot_username: String,
+    doener: Arc<crate::doener::DoenerClient>,
 }
 
 pub struct AiCommandDeps {
@@ -103,6 +104,7 @@ pub struct AiCommandDeps {
     pub web: Option<AiWeb>,
     pub emotes: Option<Arc<SevenTvEmoteProvider>>,
     pub bot_username: String,
+    pub doener: Arc<crate::doener::DoenerClient>,
 }
 
 const GROK_ALIAS_TRIGGER: &str = "@grok";
@@ -139,6 +141,7 @@ impl AiCommand {
             web: deps.web,
             emotes: deps.emotes,
             bot_username: deps.bot_username,
+            doener: deps.doener,
         }
     }
 }

--- a/crates/core/src/ai/doener_tool.rs
+++ b/crates/core/src/ai/doener_tool.rs
@@ -1,10 +1,12 @@
-use llm::ToolDefinition;
+use llm::{ToolCall, ToolDefinition, ToolResultMessage};
 use serde::Deserialize;
+use serde_json::json;
+
+use crate::doener::DoenerClient;
 
 pub const DOENER_TOOL_NAME: &str = "doener_index";
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub(crate) struct DoenerArgs {
     #[serde(default)]
     pub city: Option<String>,
@@ -31,9 +33,75 @@ pub fn doener_tool() -> ToolDefinition {
     }
 }
 
+pub async fn execute_doener_index(
+    client: &DoenerClient,
+    call: &ToolCall,
+) -> ToolResultMessage {
+    let args = match call.parse_args::<DoenerArgs>() {
+        Ok(a) => a,
+        Err(e) => {
+            return ToolResultMessage::for_call(
+                call,
+                json!({
+                    "error": "invalid_arguments",
+                    "details": e.to_string(),
+                })
+                .to_string(),
+            );
+        }
+    };
+
+    let payload = match args.city.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => match client.stats().await {
+            Ok(stats) => json!({"scope": "global", "stats": stats}),
+            Err(e) => {
+                tracing::warn!(error = ?e, "doener_index global lookup failed");
+                json!({"error": "doener_index API unavailable"})
+            }
+        },
+        Some(q) => match client.search_cities(q).await {
+            Ok(hits) => {
+                let top: Vec<_> = hits.into_iter().take(5).collect();
+                json!({"scope": "city", "query": q, "hits": top})
+            }
+            Err(e) => {
+                tracing::warn!(error = ?e, query = q, "doener_index city lookup failed");
+                json!({"error": "doener_index API unavailable"})
+            }
+        },
+    };
+
+    ToolResultMessage::for_call(call, payload.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use llm::ToolResultMessage;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::doener::DoenerClient;
+
+    fn call(args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: "call_1".into(),
+            name: DOENER_TOOL_NAME.into(),
+            arguments: args,
+            arguments_parse_error: None,
+        }
+    }
+
+    fn test_client(server: &MockServer) -> DoenerClient {
+        crate::install_crypto_provider();
+        DoenerClient::with_base_url(reqwest::Client::new(), server.uri())
+    }
+
+    fn content(msg: &ToolResultMessage) -> String {
+        // ToolResultMessage.content is a public String field — see crates/llm/src/types.rs:74.
+        msg.content.clone()
+    }
 
     #[test]
     fn tool_def_has_expected_name() {
@@ -46,5 +114,100 @@ mod tests {
         // Regression guard: a future refactor must not gate this tool behind
         // [ai.web]. is_web_tool drives routing into ContentToolExecutor.
         assert!(!crate::ai::content::is_web_tool(DOENER_TOOL_NAME));
+    }
+
+    #[tokio::test]
+    async fn no_city_returns_global_scope() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(&client, &call(serde_json::json!({}))).await;
+        let body = content(&msg);
+        assert!(body.contains("\"scope\":\"global\""), "got: {body}");
+        assert!(body.contains("\"total_locations\":6092"), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn with_city_returns_city_scope_and_hits() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .and(wiremock::matchers::query_param("q", "Han"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"Han","count":1,"cities":[{"city":"Hannover","zip":"30459","location_count":51,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"}]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(
+            &client,
+            &call(serde_json::json!({"city": "Han"})),
+        )
+        .await;
+        let body = content(&msg);
+        assert!(body.contains("\"scope\":\"city\""), "got: {body}");
+        assert!(body.contains("Hannover"), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn zero_hits_returns_empty_array() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"zzz","count":0,"cities":[]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(
+            &client,
+            &call(serde_json::json!({"city": "zzz"})),
+        )
+        .await;
+        let body = content(&msg);
+        assert!(body.contains("\"hits\":[]"), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn upstream_failure_returns_error_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(&client, &call(serde_json::json!({}))).await;
+        let body = content(&msg);
+        assert!(body.contains("\"error\":\"doener_index API unavailable\""), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn malformed_args_returns_invalid_arguments_json() {
+        // city as integer should fail to deserialize as Option<String>.
+        let server = MockServer::start().await;
+        // No mock needed; the args parse error short-circuits before any HTTP.
+        let client = test_client(&server);
+        let msg = execute_doener_index(
+            &client,
+            &call(serde_json::json!({"city": 123})),
+        )
+        .await;
+        let body = content(&msg);
+        assert!(body.contains("\"error\":\"invalid_arguments\""), "got: {body}");
     }
 }

--- a/crates/core/src/ai/doener_tool.rs
+++ b/crates/core/src/ai/doener_tool.rs
@@ -33,10 +33,7 @@ pub fn doener_tool() -> ToolDefinition {
     }
 }
 
-pub async fn execute_doener_index(
-    client: &DoenerClient,
-    call: &ToolCall,
-) -> ToolResultMessage {
+pub async fn execute_doener_index(client: &DoenerClient, call: &ToolCall) -> ToolResultMessage {
     let args = match call.parse_args::<DoenerArgs>() {
         Ok(a) => a,
         Err(e) => {
@@ -51,7 +48,12 @@ pub async fn execute_doener_index(
         }
     };
 
-    let payload = match args.city.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+    let payload = match args
+        .city
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         None => match client.stats().await {
             Ok(stats) => json!({"scope": "global", "stats": stats}),
             Err(e) => {
@@ -149,11 +151,7 @@ mod tests {
             .await;
 
         let client = test_client(&server);
-        let msg = execute_doener_index(
-            &client,
-            &call(serde_json::json!({"city": "Han"})),
-        )
-        .await;
+        let msg = execute_doener_index(&client, &call(serde_json::json!({"city": "Han"}))).await;
         let body = content(&msg);
         assert!(body.contains("\"scope\":\"city\""), "got: {body}");
         assert!(body.contains("Hannover"), "got: {body}");
@@ -172,11 +170,7 @@ mod tests {
             .await;
 
         let client = test_client(&server);
-        let msg = execute_doener_index(
-            &client,
-            &call(serde_json::json!({"city": "zzz"})),
-        )
-        .await;
+        let msg = execute_doener_index(&client, &call(serde_json::json!({"city": "zzz"}))).await;
         let body = content(&msg);
         assert!(body.contains("\"hits\":[]"), "got: {body}");
     }
@@ -193,7 +187,10 @@ mod tests {
         let client = test_client(&server);
         let msg = execute_doener_index(&client, &call(serde_json::json!({}))).await;
         let body = content(&msg);
-        assert!(body.contains("\"error\":\"doener_index API unavailable\""), "got: {body}");
+        assert!(
+            body.contains("\"error\":\"doener_index API unavailable\""),
+            "got: {body}"
+        );
     }
 
     #[tokio::test]
@@ -202,12 +199,11 @@ mod tests {
         let server = MockServer::start().await;
         // No mock needed; the args parse error short-circuits before any HTTP.
         let client = test_client(&server);
-        let msg = execute_doener_index(
-            &client,
-            &call(serde_json::json!({"city": 123})),
-        )
-        .await;
+        let msg = execute_doener_index(&client, &call(serde_json::json!({"city": 123}))).await;
         let body = content(&msg);
-        assert!(body.contains("\"error\":\"invalid_arguments\""), "got: {body}");
+        assert!(
+            body.contains("\"error\":\"invalid_arguments\""),
+            "got: {body}"
+        );
     }
 }

--- a/crates/core/src/ai/doener_tool.rs
+++ b/crates/core/src/ai/doener_tool.rs
@@ -1,0 +1,50 @@
+use llm::ToolDefinition;
+use serde::Deserialize;
+
+pub const DOENER_TOOL_NAME: &str = "doener_index";
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct DoenerArgs {
+    #[serde(default)]
+    pub city: Option<String>,
+}
+
+pub fn doener_tool() -> ToolDefinition {
+    ToolDefinition {
+        name: DOENER_TOOL_NAME.into(),
+        description: "Look up the German Döner price index from dönerindex.com. \
+            Without `city`, returns the country-wide aggregate (location count, \
+            avg/min/max price). With `city` (free-form), returns the top matching \
+            cities and their per-city aggregate. Use this for any question about \
+            Döner prices, kebab prices, or how expensive Döner is in a German city."
+            .into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "Optional city name or prefix. German spelling preferred (e.g. 'Köln', 'München')."
+                }
+            }
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_def_has_expected_name() {
+        let t = doener_tool();
+        assert_eq!(t.name, "doener_index");
+    }
+
+    #[test]
+    fn doener_index_is_not_a_web_tool() {
+        // Regression guard: a future refactor must not gate this tool behind
+        // [ai.web]. is_web_tool drives routing into ContentToolExecutor.
+        assert!(!crate::ai::content::is_web_tool(DOENER_TOOL_NAME));
+    }
+}

--- a/crates/core/src/ai/mod.rs
+++ b/crates/core/src/ai/mod.rs
@@ -1,6 +1,7 @@
 pub mod chat_history;
 pub mod command;
 pub mod content;
+pub mod doener_tool;
 pub mod memory;
 pub mod prefill;
 pub mod session;

--- a/crates/core/src/commands/doener.rs
+++ b/crates/core/src/commands/doener.rs
@@ -144,9 +144,6 @@ mod tests {
             hit("Handewitt", 1, false),
         ];
         let out = decide_city_response("Han", hits);
-        assert_eq!(
-            out,
-            "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?"
-        );
+        assert_eq!(out, "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?");
     }
 }

--- a/crates/core/src/commands/doener.rs
+++ b/crates/core/src/commands/doener.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use tokio::time::Duration;
+use tracing::error;
+use twitch_irc::{login::LoginCredentials, transport::Transport};
+
+use super::{Command, CommandContext};
+use crate::cooldown::{PerUserCooldown, format_cooldown_remaining};
+use crate::doener::format::{
+    api_down_message, format_city, format_did_you_mean, format_global, format_not_found,
+};
+use crate::doener::{CityHit, DoenerClient};
+
+pub struct DoenerCommand {
+    client: Arc<DoenerClient>,
+    cooldown: PerUserCooldown,
+}
+
+impl DoenerCommand {
+    pub fn new(client: Arc<DoenerClient>, cooldown: Duration) -> Self {
+        Self {
+            client,
+            cooldown: PerUserCooldown::new(cooldown),
+        }
+    }
+}
+
+#[async_trait]
+impl<T, L> Command<T, L> for DoenerCommand
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    fn name(&self) -> &str {
+        "!dpi"
+    }
+
+    async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()> {
+        let user = &ctx.privmsg.sender.login;
+        if let Some(remaining) = self.cooldown.check(user).await {
+            send(
+                &ctx,
+                format!(
+                    "Bitte warte noch {} Waiting",
+                    format_cooldown_remaining(remaining)
+                ),
+            )
+            .await;
+            return Ok(());
+        }
+        self.cooldown.record(user).await;
+
+        let query = ctx.args.join(" ");
+        let query = query.trim();
+
+        let response = if query.is_empty() {
+            match self.client.stats().await {
+                Ok(s) => format_global(&s),
+                Err(e) => {
+                    error!(error = ?e, "doener stats lookup failed");
+                    api_down_message().to_string()
+                }
+            }
+        } else {
+            match self.client.search_cities(query).await {
+                Ok(hits) => decide_city_response(query, hits),
+                Err(e) => {
+                    error!(error = ?e, query, "doener city lookup failed");
+                    api_down_message().to_string()
+                }
+            }
+        };
+
+        send(&ctx, response).await;
+        Ok(())
+    }
+}
+
+fn decide_city_response(query: &str, hits: Vec<CityHit>) -> String {
+    if hits.is_empty() {
+        return format_not_found(query);
+    }
+    if hits.len() == 1 {
+        return format_city(&hits[0]);
+    }
+    if hits[0].city.eq_ignore_ascii_case(query) {
+        return format_city(&hits[0]);
+    }
+    format_did_you_mean(&hits)
+}
+
+async fn send<T, L>(ctx: &CommandContext<'_, T, L>, line: String)
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, line).await {
+        error!(error = ?e, "Failed to send !dpi response");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doener::CityHit;
+
+    fn hit(city: &str, n: u32, with_prices: bool) -> CityHit {
+        CityHit {
+            city: city.into(),
+            location_count: n,
+            min_price: with_prices.then_some(6.0),
+            max_price: with_prices.then_some(6.0),
+            avg_price: with_prices.then_some(6.0),
+        }
+    }
+
+    #[test]
+    fn city_response_empty_hits_is_not_found() {
+        let out = decide_city_response("xyz", vec![]);
+        assert_eq!(out, "FeelsDankMan keine Stadt für 'xyz' gefunden.");
+    }
+
+    #[test]
+    fn city_response_single_hit_uses_format_city() {
+        let out = decide_city_response("Hannover", vec![hit("Hannover", 51, true)]);
+        assert!(out.starts_with("Hannover: 51 Buden"));
+    }
+
+    #[test]
+    fn city_response_exact_match_short_circuits() {
+        // "Berlin" upstream returns Berlin + Berlingerode. Treat as single hit.
+        let hits = vec![hit("Berlin", 324, true), hit("Berlingerode", 1, false)];
+        let out = decide_city_response("berlin", hits);
+        assert!(out.starts_with("Berlin: 324 Buden"));
+    }
+
+    #[test]
+    fn city_response_multi_hit_no_exact_match_is_did_you_mean() {
+        let hits = vec![
+            hit("Hannover", 51, true),
+            hit("Hanau", 3, true),
+            hit("Handewitt", 1, false),
+        ];
+        let out = decide_city_response("Han", hits);
+        assert_eq!(
+            out,
+            "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?"
+        );
+    }
+}

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -6,6 +6,7 @@ use twitch_irc::{
     TwitchIRCClient, login::LoginCredentials, message::PrivmsgMessage, transport::Transport,
 };
 
+pub mod doener;
 pub mod feedback;
 pub mod leaderboard;
 pub mod news;

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -447,6 +447,10 @@ fn default_feedback_cooldown() -> u64 {
     300
 }
 
+fn default_doener_cooldown() -> u64 {
+    30
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct CooldownsConfig {
     #[serde(default = "default_ai_cooldown")]
@@ -457,6 +461,8 @@ pub struct CooldownsConfig {
     pub up: u64,
     #[serde(default = "default_feedback_cooldown")]
     pub feedback: u64,
+    #[serde(default = "default_doener_cooldown")]
+    pub doener: u64,
 }
 
 impl Default for CooldownsConfig {
@@ -466,6 +472,7 @@ impl Default for CooldownsConfig {
             news: default_news_cooldown(),
             up: default_up_cooldown(),
             feedback: default_feedback_cooldown(),
+            doener: default_doener_cooldown(),
         }
     }
 }
@@ -1319,5 +1326,17 @@ mod tests {
         assert_eq!(cfg.cap_for(Bucket::Audio), cfg.max_audio_size);
         assert_eq!(cfg.cap_for(Bucket::Video), cfg.max_video_size);
         assert_eq!(cfg.cap_for(Bucket::Text), cfg.max_text_size);
+    }
+
+    #[test]
+    fn cooldowns_doener_defaults_to_30() {
+        let c: CooldownsConfig = toml::from_str("").expect("empty cooldowns parses");
+        assert_eq!(c.doener, 30);
+    }
+
+    #[test]
+    fn cooldowns_doener_overrides_via_toml() {
+        let c: CooldownsConfig = toml::from_str("doener = 5").expect("parses");
+        assert_eq!(c.doener, 5);
     }
 }

--- a/crates/core/src/doener/client.rs
+++ b/crates/core/src/doener/client.rs
@@ -1,0 +1,1 @@
+// Filled in Task 4.

--- a/crates/core/src/doener/client.rs
+++ b/crates/core/src/doener/client.rs
@@ -34,4 +34,76 @@ impl DoenerClient {
             base_url: base_url.into(),
         }
     }
+
+    pub async fn stats(&self) -> Result<GlobalStats> {
+        let url = format!("{}/api/stats.php", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .wrap_err("doener stats: request failed")?
+            .error_for_status()
+            .wrap_err("doener stats: non-2xx")?;
+        resp.json::<GlobalStats>()
+            .await
+            .wrap_err("doener stats: parse JSON")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_client(server: &MockServer) -> DoenerClient {
+        crate::install_crypto_provider();
+        DoenerClient::with_base_url(reqwest::Client::new(), server.uri())
+    }
+
+    #[tokio::test]
+    async fn stats_parses_canonical_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let stats = client.stats().await.expect("stats ok");
+        assert_eq!(stats.total_locations, 6092);
+        assert_eq!(stats.total_cities, 2202);
+    }
+
+    #[tokio::test]
+    async fn stats_returns_err_on_500() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        assert!(client.stats().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn stats_returns_err_on_malformed_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        assert!(client.stats().await.is_err());
+    }
 }

--- a/crates/core/src/doener/client.rs
+++ b/crates/core/src/doener/client.rs
@@ -81,6 +81,15 @@ mod tests {
         DoenerClient::with_base_url(reqwest::Client::new(), server.uri())
     }
 
+    fn test_client_with_timeout(server: &MockServer, timeout: std::time::Duration) -> DoenerClient {
+        crate::install_crypto_provider();
+        let http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("build timeout test client");
+        DoenerClient::with_base_url(http, server.uri())
+    }
+
     #[tokio::test]
     async fn stats_parses_canonical_response() {
         let server = MockServer::start().await;
@@ -122,6 +131,23 @@ mod tests {
             .await;
 
         let client = test_client(&server);
+        assert!(client.stats().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn stats_returns_err_on_timeout() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(b"{}".as_slice(), "application/json")
+                    .set_delay(std::time::Duration::from_secs(2)),
+            )
+            .mount(&server)
+            .await;
+
+        let client = test_client_with_timeout(&server, std::time::Duration::from_millis(150));
         assert!(client.stats().await.is_err());
     }
 

--- a/crates/core/src/doener/client.rs
+++ b/crates/core/src/doener/client.rs
@@ -1,1 +1,37 @@
-// Filled in Task 4.
+use std::time::Duration;
+
+use eyre::{Result, WrapErr};
+
+use crate::APP_USER_AGENT;
+use crate::doener::types::{CitiesResponse, CityHit, GlobalStats};
+
+const BASE_URL: &str = "https://xn--dnerindex-07a.com";
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct DoenerClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl DoenerClient {
+    pub fn new() -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            .timeout(TIMEOUT)
+            .build()
+            .wrap_err("build doener HTTP client")?;
+        Ok(Self {
+            http,
+            base_url: BASE_URL.to_string(),
+        })
+    }
+
+    /// Test hook: inject an existing `reqwest::Client` (commonly with a short
+    /// timeout) and a custom base URL pointing at a wiremock server.
+    pub fn with_base_url(http: reqwest::Client, base_url: impl Into<String>) -> Self {
+        Self {
+            http,
+            base_url: base_url.into(),
+        }
+    }
+}

--- a/crates/core/src/doener/client.rs
+++ b/crates/core/src/doener/client.rs
@@ -49,6 +49,24 @@ impl DoenerClient {
             .await
             .wrap_err("doener stats: parse JSON")
     }
+
+    pub async fn search_cities(&self, q: &str) -> Result<Vec<CityHit>> {
+        let url = format!("{}/api/cities.php", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("q", q)])
+            .send()
+            .await
+            .wrap_err("doener cities: request failed")?
+            .error_for_status()
+            .wrap_err("doener cities: non-2xx")?;
+        let body = resp
+            .json::<CitiesResponse>()
+            .await
+            .wrap_err("doener cities: parse JSON")?;
+        Ok(body.cities)
+    }
 }
 
 #[cfg(test)]
@@ -105,5 +123,59 @@ mod tests {
 
         let client = test_client(&server);
         assert!(client.stats().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn search_cities_returns_hits_in_upstream_order() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .and(wiremock::matchers::query_param("q", "Han"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"Han","count":3,"cities":[
+                    {"city":"Hannover","zip":"30459","location_count":51,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"},
+                    {"city":"Hanau","zip":"63456","location_count":3,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"},
+                    {"city":"Handewitt","zip":"24983","location_count":1,"min_price":null,"max_price":null,"avg_price":null}
+                ]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let hits = client.search_cities("Han").await.expect("cities ok");
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].city, "Hannover");
+        assert_eq!(hits[2].avg_price, None);
+    }
+
+    #[tokio::test]
+    async fn search_cities_empty_array_is_ok_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"zzz","count":0,"cities":[]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let hits = client.search_cities("zzz").await.expect("ok");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_cities_returns_err_on_500() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        assert!(client.search_cities("x").await.is_err());
     }
 }

--- a/crates/core/src/doener/format.rs
+++ b/crates/core/src/doener/format.rs
@@ -1,0 +1,1 @@
+// Filled in Task 3.

--- a/crates/core/src/doener/format.rs
+++ b/crates/core/src/doener/format.rs
@@ -1,1 +1,137 @@
-// Filled in Task 3.
+use crate::doener::types::{CityHit, GlobalStats};
+
+const API_DOWN_MESSAGE: &str = "FeelsDankMan döner-index API down";
+
+pub fn format_global(s: &GlobalStats) -> String {
+    format!(
+        "Döner-Index DE: {locations} Buden in {cities} Städten, ⌀ {avg:.2}€ ({min:.2}–{max:.2}€). {no_price}% ohne Preis.",
+        locations = s.total_locations,
+        cities = s.total_cities,
+        avg = s.avg_price,
+        min = s.min_price,
+        max = s.max_price,
+        no_price = format_pct(s.locations_no_price_pct),
+    )
+}
+
+pub fn format_city(c: &CityHit) -> String {
+    let bude = if c.location_count == 1 { "Bude" } else { "Buden" };
+    match (c.avg_price, c.min_price, c.max_price) {
+        (Some(avg), Some(min), Some(max)) => format!(
+            "{name}: {count} {bude}, ⌀ {avg:.2}€ ({min:.2}–{max:.2}€).",
+            name = c.city,
+            count = c.location_count,
+        ),
+        _ => format!(
+            "{name}: {count} {bude}, noch keine Preise.",
+            name = c.city,
+            count = c.location_count,
+        ),
+    }
+}
+
+pub fn format_did_you_mean(hits: &[CityHit]) -> String {
+    let parts: Vec<String> = hits
+        .iter()
+        .take(3)
+        .map(|h| format!("{} ({})", h.city, h.location_count))
+        .collect();
+    format!("Meintest du: {}?", parts.join(", "))
+}
+
+pub fn format_not_found(query: &str) -> String {
+    format!("FeelsDankMan keine Stadt für '{query}' gefunden.")
+}
+
+pub fn api_down_message() -> &'static str {
+    API_DOWN_MESSAGE
+}
+
+fn format_pct(p: f64) -> String {
+    if (p.round() - p).abs() < f64::EPSILON {
+        format!("{}", p.round() as i64)
+    } else {
+        format!("{p:.1}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats() -> GlobalStats {
+        GlobalStats {
+            total_locations: 6092,
+            total_cities: 2202,
+            min_price: 5.5,
+            max_price: 9.0,
+            avg_price: 6.1,
+            locations_no_price_pct: 87.0,
+        }
+    }
+
+    fn hit(city: &str, n: u32, prices: Option<(f64, f64, f64)>) -> CityHit {
+        CityHit {
+            city: city.into(),
+            location_count: n,
+            min_price: prices.map(|(min, _, _)| min),
+            max_price: prices.map(|(_, _, max)| max),
+            avg_price: prices.map(|(_, avg, _)| avg),
+        }
+    }
+
+    #[test]
+    fn global_matches_golden_string() {
+        assert_eq!(
+            format_global(&stats()),
+            "Döner-Index DE: 6092 Buden in 2202 Städten, ⌀ 6.10€ (5.50–9.00€). 87% ohne Preis."
+        );
+    }
+
+    #[test]
+    fn global_keeps_decimal_in_no_price_pct_when_non_integer() {
+        let mut s = stats();
+        s.locations_no_price_pct = 87.1;
+        assert!(format_global(&s).contains("87.1% ohne Preis"));
+    }
+
+    #[test]
+    fn city_with_prices_uses_plural_buden() {
+        let c = hit("Hannover", 51, Some((6.0, 6.0, 6.0)));
+        assert_eq!(
+            format_city(&c),
+            "Hannover: 51 Buden, ⌀ 6.00€ (6.00–6.00€)."
+        );
+    }
+
+    #[test]
+    fn city_with_one_location_uses_singular_bude() {
+        let c = hit("Handewitt", 1, None);
+        assert_eq!(format_city(&c), "Handewitt: 1 Bude, noch keine Preise.");
+    }
+
+    #[test]
+    fn city_with_one_location_with_price_uses_singular_bude() {
+        let c = hit("X", 1, Some((7.0, 7.0, 7.0)));
+        assert_eq!(format_city(&c), "X: 1 Bude, ⌀ 7.00€ (7.00–7.00€).");
+    }
+
+    #[test]
+    fn did_you_mean_lists_top_three() {
+        let hits = vec![
+            hit("Hannover", 51, None),
+            hit("Hanau", 3, None),
+            hit("Handewitt", 1, None),
+            hit("Hannover-Land", 0, None),
+        ];
+        assert_eq!(
+            format_did_you_mean(&hits),
+            "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?"
+        );
+    }
+
+    #[test]
+    fn not_found_quotes_query() {
+        assert_eq!(format_not_found("xyz"), "FeelsDankMan keine Stadt für 'xyz' gefunden.");
+    }
+}

--- a/crates/core/src/doener/format.rs
+++ b/crates/core/src/doener/format.rs
@@ -15,7 +15,11 @@ pub fn format_global(s: &GlobalStats) -> String {
 }
 
 pub fn format_city(c: &CityHit) -> String {
-    let bude = if c.location_count == 1 { "Bude" } else { "Buden" };
+    let bude = if c.location_count == 1 {
+        "Bude"
+    } else {
+        "Buden"
+    };
     match (c.avg_price, c.min_price, c.max_price) {
         (Some(avg), Some(min), Some(max)) => format!(
             "{name}: {count} {bude}, ⌀ {avg:.2}€ ({min:.2}–{max:.2}€).",
@@ -98,10 +102,7 @@ mod tests {
     #[test]
     fn city_with_prices_uses_plural_buden() {
         let c = hit("Hannover", 51, Some((6.0, 6.0, 6.0)));
-        assert_eq!(
-            format_city(&c),
-            "Hannover: 51 Buden, ⌀ 6.00€ (6.00–6.00€)."
-        );
+        assert_eq!(format_city(&c), "Hannover: 51 Buden, ⌀ 6.00€ (6.00–6.00€).");
     }
 
     #[test]
@@ -132,6 +133,9 @@ mod tests {
 
     #[test]
     fn not_found_quotes_query() {
-        assert_eq!(format_not_found("xyz"), "FeelsDankMan keine Stadt für 'xyz' gefunden.");
+        assert_eq!(
+            format_not_found("xyz"),
+            "FeelsDankMan keine Stadt für 'xyz' gefunden."
+        );
     }
 }

--- a/crates/core/src/doener/mod.rs
+++ b/crates/core/src/doener/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod format;
+pub mod types;

--- a/crates/core/src/doener/mod.rs
+++ b/crates/core/src/doener/mod.rs
@@ -1,3 +1,5 @@
 pub mod client;
 pub mod format;
 pub mod types;
+
+pub use types::{CityHit, GlobalStats};

--- a/crates/core/src/doener/mod.rs
+++ b/crates/core/src/doener/mod.rs
@@ -2,4 +2,5 @@ pub mod client;
 pub mod format;
 pub mod types;
 
+pub use client::DoenerClient;
 pub use types::{CityHit, GlobalStats};

--- a/crates/core/src/doener/types.rs
+++ b/crates/core/src/doener/types.rs
@@ -1,0 +1,1 @@
+// Filled in Task 2.

--- a/crates/core/src/doener/types.rs
+++ b/crates/core/src/doener/types.rs
@@ -1,1 +1,94 @@
-// Filled in Task 2.
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct GlobalStats {
+    pub total_locations: u32,
+    pub total_cities: u32,
+    pub min_price: f64,
+    pub max_price: f64,
+    pub avg_price: f64,
+    pub locations_no_price_pct: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct CityHit {
+    pub city: String,
+    pub location_count: u32,
+    #[serde(deserialize_with = "deserialize_optional_price")]
+    pub min_price: Option<f64>,
+    #[serde(deserialize_with = "deserialize_optional_price")]
+    pub max_price: Option<f64>,
+    #[serde(deserialize_with = "deserialize_optional_price")]
+    pub avg_price: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CitiesResponse {
+    pub cities: Vec<CityHit>,
+}
+
+fn deserialize_optional_price<'de, D>(de: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+        Number(f64),
+        Text(String),
+        Null,
+    }
+    Ok(match Option::<Raw>::deserialize(de)? {
+        None | Some(Raw::Null) => None,
+        Some(Raw::Number(n)) => Some(n),
+        Some(Raw::Text(s)) => s.trim().parse::<f64>().ok(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_stats_parses_canonical_payload() {
+        let raw = r#"{"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#;
+        let s: GlobalStats = serde_json::from_str(raw).unwrap();
+        assert_eq!(s.total_locations, 6092);
+        assert_eq!(s.total_cities, 2202);
+        assert!((s.avg_price - 6.1).abs() < 1e-9);
+        assert!((s.locations_no_price_pct - 87.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn city_hit_parses_string_prices() {
+        let raw = r#"{"city":"Hannover","location_count":51,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.city, "Hannover");
+        assert_eq!(c.location_count, 51);
+        assert_eq!(c.avg_price, Some(6.0));
+    }
+
+    #[test]
+    fn city_hit_treats_null_prices_as_none() {
+        let raw = r#"{"city":"Handewitt","location_count":1,"min_price":null,"max_price":null,"avg_price":null}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert!(c.min_price.is_none());
+        assert!(c.max_price.is_none());
+        assert!(c.avg_price.is_none());
+    }
+
+    #[test]
+    fn city_hit_accepts_numeric_prices() {
+        let raw = r#"{"city":"Berlin","location_count":324,"min_price":6.0,"max_price":7.5,"avg_price":6.2}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.min_price, Some(6.0));
+        assert_eq!(c.max_price, Some(7.5));
+    }
+
+    #[test]
+    fn city_hit_unparseable_price_string_becomes_none() {
+        let raw = r#"{"city":"X","location_count":0,"min_price":"abc","max_price":null,"avg_price":null}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert!(c.min_price.is_none());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -141,8 +141,6 @@ where
         memory_store,
     } = services;
 
-    let _ = doener; // consumed in Task 10
-
     let schedules_enabled = !config.schedules.is_empty();
 
     let leaderboard = Arc::new(tokio::sync::RwLock::new(load_leaderboard(&data_dir).await));
@@ -184,6 +182,7 @@ where
         config,
         clock,
         data_dir,
+        doener,
         leaderboard,
         ping_manager,
         suspension_manager,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -75,6 +75,7 @@ pub struct Services {
     pub clock: Arc<dyn Clock>,
     pub llm: Option<Arc<dyn LlmClient>>,
     pub aviation: Option<AviationClient>,
+    pub doener: Arc<crate::doener::DoenerClient>,
     pub whisper: Option<Arc<dyn WhisperSender>>,
     pub data_dir: PathBuf,
     /// Optional override for the 7TV emote glossary TOML. Production leaves
@@ -130,6 +131,7 @@ where
         clock,
         llm,
         aviation,
+        doener,
         whisper,
         data_dir,
         emote_glossary_override,
@@ -138,6 +140,8 @@ where
         ping_manager,
         memory_store,
     } = services;
+
+    let _ = doener; // consumed in Task 10
 
     let schedules_enabled = !config.schedules.is_empty();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod commands;
 pub mod config;
 pub mod cooldown;
 pub mod database;
+pub mod doener;
 pub mod llm_factory;
 pub mod ping;
 pub mod suspend;

--- a/crates/core/src/twitch/handlers/commands.rs
+++ b/crates/core/src/twitch/handlers/commands.rs
@@ -87,8 +87,6 @@ where
         emote_provider,
     } = cfg;
 
-    let _ = doener; // consumed in Task 11
-
     let default_suspend_duration = Duration::from_secs(suspend.default_duration_secs);
 
     let broadcast_rx = broadcast_tx.subscribe();
@@ -161,6 +159,10 @@ where
         Box::new(commands::feedback::FeedbackCommand::new(
             data_dir.clone(),
             Duration::from_secs(cooldowns.feedback),
+        )),
+        Box::new(commands::doener::DoenerCommand::new(
+            doener.clone(),
+            Duration::from_secs(cooldowns.doener),
         )),
     ];
 

--- a/crates/core/src/twitch/handlers/commands.rs
+++ b/crates/core/src/twitch/handlers/commands.rs
@@ -46,6 +46,7 @@ pub struct CommandHandlerConfig<T: Transport, L: LoginCredentials> {
     pub bot_username: String,
     pub channel: String,
     pub data_dir: std::path::PathBuf,
+    pub doener: Arc<crate::doener::DoenerClient>,
     pub suspension_manager: Arc<SuspensionManager>,
     pub suspend: SuspendConfig,
     /// Pre-built 7TV emote provider. `None` disables emote grounding for `!ai`.
@@ -80,10 +81,13 @@ where
         bot_username,
         channel,
         data_dir,
+        doener,
         suspension_manager,
         suspend,
         emote_provider,
     } = cfg;
+
+    let _ = doener; // consumed in Task 11
 
     let default_suspend_duration = Duration::from_secs(suspend.default_duration_secs);
 

--- a/crates/core/src/twitch/handlers/commands.rs
+++ b/crates/core/src/twitch/handlers/commands.rs
@@ -244,6 +244,7 @@ where
                 web: web.clone(),
                 emotes: emote_provider,
                 bot_username: bot_username.clone(),
+                doener: doener.clone(),
             },
         )));
         cmd_list.push(Box::new(commands::news::NewsCommand::new(

--- a/crates/core/src/twitch/handlers/spawn.rs
+++ b/crates/core/src/twitch/handlers/spawn.rs
@@ -69,6 +69,7 @@ pub(crate) struct SpawnDeps<T: Transport, L: LoginCredentials> {
     pub config: Configuration,
     pub clock: Arc<dyn Clock>,
     pub data_dir: PathBuf,
+    pub doener: Arc<crate::doener::DoenerClient>,
 
     // 1337 tracker.
     pub leaderboard: Arc<RwLock<HashMap<String, PersonalBest>>>,
@@ -106,6 +107,7 @@ where
         config,
         clock,
         data_dir,
+        doener,
         leaderboard,
         ping_manager,
         suspension_manager,
@@ -245,6 +247,7 @@ where
                 bot_username: config.twitch.username.clone(),
                 channel: config.twitch.channel.clone(),
                 data_dir: data_dir.clone(),
+                doener: doener.clone(),
                 suspension_manager: suspension_manager.clone(),
                 suspend: config.suspend.clone(),
                 emote_provider,

--- a/crates/core/tests/common/test_bot.rs
+++ b/crates/core/tests/common/test_bot.rs
@@ -56,6 +56,7 @@ pub struct TestBotBuilder {
     seeded_leaderboard: Option<HashMap<String, PersonalBest>>,
     whisper_failure: bool,
     emote_glossary_override: Option<String>,
+    doener_base_url: Option<String>,
 }
 
 impl TestBotBuilder {
@@ -66,6 +67,7 @@ impl TestBotBuilder {
             seeded_leaderboard: None,
             whisper_failure: false,
             emote_glossary_override: None,
+            doener_base_url: None,
         }
     }
 
@@ -129,6 +131,12 @@ impl TestBotBuilder {
         self.config.web.bind_addr = bind.into();
         self.config.web.session_secret = secrecy::SecretString::new("0".repeat(64).into());
         self.config.web.public_url = "https://test.invalid".into();
+        self
+    }
+
+    /// Override the doener service base URL to point at a mock server.
+    pub fn with_doener_base_url(mut self, base: impl Into<String>) -> Self {
+        self.doener_base_url = Some(base.into());
         self
     }
 
@@ -250,7 +258,9 @@ impl TestBotBuilder {
             aviation: Some(aviation),
             doener: Arc::new(twitch_1337::doener::DoenerClient::with_base_url(
                 reqwest::Client::new(),
-                "http://127.0.0.1:1".to_string(),
+                self.doener_base_url
+                    .clone()
+                    .unwrap_or_else(|| "http://127.0.0.1:1".to_string()),
             )),
             whisper: Some(whisper.clone() as Arc<dyn WhisperSender>),
             data_dir: data_dir.path().to_path_buf(),

--- a/crates/core/tests/common/test_bot.rs
+++ b/crates/core/tests/common/test_bot.rs
@@ -248,6 +248,10 @@ impl TestBotBuilder {
                 .is_some()
                 .then(|| llm.clone() as Arc<dyn LlmClient>),
             aviation: Some(aviation),
+            doener: Arc::new(twitch_1337::doener::DoenerClient::with_base_url(
+                reqwest::Client::new(),
+                "http://127.0.0.1:1".to_string(),
+            )),
             whisper: Some(whisper.clone() as Arc<dyn WhisperSender>),
             data_dir: data_dir.path().to_path_buf(),
             emote_glossary_override: self.emote_glossary_override,

--- a/crates/core/tests/doener.rs
+++ b/crates/core/tests/doener.rs
@@ -1,0 +1,36 @@
+mod common;
+
+use std::time::Duration;
+
+use common::TestBotBuilder;
+use serial_test::serial;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+#[serial]
+async fn dpi_global_returns_summary_from_upstream() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/stats.php"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            br#"{"ok":true,"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#.as_slice(),
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    let mut bot = TestBotBuilder::new()
+        .with_doener_base_url(server.uri())
+        .spawn()
+        .await;
+
+    bot.send("alice", "!dpi").await;
+    let reply = bot.expect_say(Duration::from_secs(2)).await;
+    assert!(
+        reply.contains("Döner-Index DE:") && reply.contains("6092 Buden"),
+        "expected global summary, got: {reply}"
+    );
+
+    bot.shutdown().await;
+}

--- a/crates/twitch-1337/config.toml.example
+++ b/crates/twitch-1337/config.toml.example
@@ -43,6 +43,7 @@ client_secret = "your_client_secret"
 # news = 60      # !news command (default: 60)
 # up = 30        # !up command (default: 30)
 # feedback = 300 # !fb command (default: 300)
+# doener = 30    # !dpi command (default: 30)
 
 # Optional: Aviationstack metadata enrichment for !track.
 # The bot uses this at most once per newly tracked flight to fetch route,

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -11,7 +11,7 @@ use tracing::info;
 use twitch_1337_core::{
     AuthenticatedLoginCredentials, Services,
     ai::{command::memory_caps_from_config, memory::store::MemoryStore},
-    aviation, ensure_data_dir, get_data_dir, install_crypto_provider, install_tracing, llm_factory,
+    aviation, doener, ensure_data_dir, get_data_dir, install_crypto_provider, install_tracing, llm_factory,
     load_configuration,
     ping::PingManager,
     run_bot, setup_and_verify_twitch_client,
@@ -72,6 +72,10 @@ pub async fn main() -> Result<()> {
         }
     };
 
+    let doener_client = Arc::new(
+        doener::DoenerClient::new().wrap_err("Failed to initialize Döner-index client")?,
+    );
+
     let whisper_credentials = credentials.clone();
     let whisper = whisper::HelixWhisperSender::new(
         whisper_credentials,
@@ -116,6 +120,7 @@ pub async fn main() -> Result<()> {
         clock: Arc::new(SystemClock),
         llm: llm_client,
         aviation: aviation_client,
+        doener: doener_client,
         whisper: Some(whisper),
         data_dir: get_data_dir(),
         emote_glossary_override: None,

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -11,8 +11,8 @@ use tracing::info;
 use twitch_1337_core::{
     AuthenticatedLoginCredentials, Services,
     ai::{command::memory_caps_from_config, memory::store::MemoryStore},
-    aviation, doener, ensure_data_dir, get_data_dir, install_crypto_provider, install_tracing, llm_factory,
-    load_configuration,
+    aviation, doener, ensure_data_dir, get_data_dir, install_crypto_provider, install_tracing,
+    llm_factory, load_configuration,
     ping::PingManager,
     run_bot, setup_and_verify_twitch_client,
     twitch::whisper,
@@ -72,9 +72,8 @@ pub async fn main() -> Result<()> {
         }
     };
 
-    let doener_client = Arc::new(
-        doener::DoenerClient::new().wrap_err("Failed to initialize Döner-index client")?,
-    );
+    let doener_client =
+        Arc::new(doener::DoenerClient::new().wrap_err("Failed to initialize Döner-index client")?);
 
     let whisper_credentials = credentials.clone();
     let whisper = whisper::HelixWhisperSender::new(

--- a/docs/superpowers/plans/2026-05-11-donerpreisindex.md
+++ b/docs/superpowers/plans/2026-05-11-donerpreisindex.md
@@ -1,0 +1,1763 @@
+# Dönerpreisindex Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `!dpi` chat command and `doener_index` AI tool, both backed by a shared `DoenerClient` against https://xn--dnerindex-07a.com (`stats.php` + `cities.php`). Fixes issue #178.
+
+**Architecture:** New `crates/core/src/doener/` module holds the HTTP client, deserializable types, and chat formatters. A thin `DoenerCommand` consumes the client via the existing `Command` trait. A new `crates/core/src/ai/doener_tool.rs` module exposes the same client to `!ai` through `V2Executor`, routed unconditionally so the tool ships even when `[ai.web]` is disabled.
+
+**Tech Stack:** Rust async (tokio), reqwest, serde, eyre, wiremock for tests, async-trait. All deps already in tree.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-donerpreisindex-design.md` — read it before starting if you have not.
+
+---
+
+## File structure
+
+New:
+- `crates/core/src/doener/mod.rs`
+- `crates/core/src/doener/client.rs`
+- `crates/core/src/doener/types.rs`
+- `crates/core/src/doener/format.rs`
+- `crates/core/src/commands/doener.rs`
+- `crates/core/src/ai/doener_tool.rs`
+
+Modified:
+- `crates/core/src/lib.rs`
+- `crates/core/src/ai/mod.rs`
+- `crates/core/src/commands/mod.rs`
+- `crates/core/src/config.rs`
+- `crates/core/src/twitch/handlers/commands.rs`
+- `crates/core/src/twitch/handlers/spawn.rs`
+- `crates/core/src/ai/command.rs`
+- `crates/twitch-1337/src/main.rs`
+- `crates/twitch-1337/config.toml.example`
+
+No new Cargo dependencies. Use `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail` per project memory.
+
+---
+
+## Task 1: Module skeleton + `pub mod doener;`
+
+Stand up the module hierarchy with empty files so later tasks compile incrementally.
+
+**Files:**
+- Create: `crates/core/src/doener/mod.rs`
+- Create: `crates/core/src/doener/types.rs`
+- Create: `crates/core/src/doener/format.rs`
+- Create: `crates/core/src/doener/client.rs`
+- Modify: `crates/core/src/lib.rs`
+
+- [ ] **Step 1: Create `crates/core/src/doener/mod.rs`**
+
+```rust
+pub mod client;
+pub mod format;
+pub mod types;
+
+pub use client::DoenerClient;
+pub use types::{CityHit, GlobalStats};
+```
+
+- [ ] **Step 2: Create the three sub-files as empty placeholders**
+
+`crates/core/src/doener/types.rs`:
+
+```rust
+// Filled in Task 2.
+```
+
+`crates/core/src/doener/format.rs`:
+
+```rust
+// Filled in Task 3.
+```
+
+`crates/core/src/doener/client.rs`:
+
+```rust
+// Filled in Task 4.
+```
+
+- [ ] **Step 3: Register the module in `crates/core/src/lib.rs`**
+
+Find the existing `pub mod` block (currently `pub mod ai; pub mod aviation; pub mod commands; ...`) and insert `pub mod doener;` alphabetically between `database` and `llm_factory`:
+
+```rust
+pub mod database;
+pub mod doener;
+pub mod llm_factory;
+```
+
+- [ ] **Step 4: Verify compile**
+
+Run: `cargo check -p core --quiet`
+Expected: success (warnings about empty modules are fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/doener crates/core/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): scaffold doener module
+
+Empty types/format/client placeholders; lib.rs export.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Types + price deserializer
+
+The upstream API returns prices as either JSON strings (`"6.00"`) or `null`. Encode the conversion in one place.
+
+**Files:**
+- Modify: `crates/core/src/doener/types.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `crates/core/src/doener/types.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct GlobalStats {
+    pub total_locations: u32,
+    pub total_cities: u32,
+    pub min_price: f64,
+    pub max_price: f64,
+    pub avg_price: f64,
+    pub locations_no_price_pct: f64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct CityHit {
+    pub city: String,
+    pub location_count: u32,
+    #[serde(deserialize_with = "deserialize_optional_price")]
+    pub min_price: Option<f64>,
+    #[serde(deserialize_with = "deserialize_optional_price")]
+    pub max_price: Option<f64>,
+    #[serde(deserialize_with = "deserialize_optional_price")]
+    pub avg_price: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CitiesResponse {
+    pub cities: Vec<CityHit>,
+}
+
+fn deserialize_optional_price<'de, D>(de: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+        Number(f64),
+        Text(String),
+        Null,
+    }
+    Ok(match Option::<Raw>::deserialize(de)? {
+        None | Some(Raw::Null) => None,
+        Some(Raw::Number(n)) => Some(n),
+        Some(Raw::Text(s)) => s.trim().parse::<f64>().ok(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_stats_parses_canonical_payload() {
+        let raw = r#"{"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#;
+        let s: GlobalStats = serde_json::from_str(raw).unwrap();
+        assert_eq!(s.total_locations, 6092);
+        assert_eq!(s.total_cities, 2202);
+        assert!((s.avg_price - 6.1).abs() < 1e-9);
+        assert!((s.locations_no_price_pct - 87.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn city_hit_parses_string_prices() {
+        let raw = r#"{"city":"Hannover","location_count":51,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.city, "Hannover");
+        assert_eq!(c.location_count, 51);
+        assert_eq!(c.avg_price, Some(6.0));
+    }
+
+    #[test]
+    fn city_hit_treats_null_prices_as_none() {
+        let raw = r#"{"city":"Handewitt","location_count":1,"min_price":null,"max_price":null,"avg_price":null}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert!(c.min_price.is_none());
+        assert!(c.max_price.is_none());
+        assert!(c.avg_price.is_none());
+    }
+
+    #[test]
+    fn city_hit_accepts_numeric_prices() {
+        let raw = r#"{"city":"Berlin","location_count":324,"min_price":6.0,"max_price":7.5,"avg_price":6.2}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.min_price, Some(6.0));
+        assert_eq!(c.max_price, Some(7.5));
+    }
+
+    #[test]
+    fn city_hit_unparseable_price_string_becomes_none() {
+        let raw = r#"{"city":"X","location_count":0,"min_price":"abc","max_price":null,"avg_price":null}"#;
+        let c: CityHit = serde_json::from_str(raw).unwrap();
+        assert!(c.min_price.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail doener::types`
+Expected: 5 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/src/doener/types.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): GlobalStats + CityHit with optional-price deserializer
+
+Upstream encodes prices as either JSON strings or null. One custom
+deserializer normalises both forms (plus tolerates numeric and malformed
+strings) so callers get Option<f64>.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Chat formatters
+
+Pure functions that turn data into German chat strings. Tests freeze the exact output for each branch so future edits cannot silently change what users see.
+
+**Files:**
+- Modify: `crates/core/src/doener/format.rs`
+
+- [ ] **Step 1: Write the failing tests + implementation**
+
+Replace the placeholder in `crates/core/src/doener/format.rs`:
+
+```rust
+use crate::doener::types::{CityHit, GlobalStats};
+
+const API_DOWN_MESSAGE: &str = "FeelsDankMan döner-index API down";
+
+pub fn format_global(s: &GlobalStats) -> String {
+    format!(
+        "Döner-Index DE: {locations} Buden in {cities} Städten, ⌀ {avg:.2}€ ({min:.2}–{max:.2}€). {no_price}% ohne Preis.",
+        locations = s.total_locations,
+        cities = s.total_cities,
+        avg = s.avg_price,
+        min = s.min_price,
+        max = s.max_price,
+        no_price = format_pct(s.locations_no_price_pct),
+    )
+}
+
+pub fn format_city(c: &CityHit) -> String {
+    let bude = if c.location_count == 1 { "Bude" } else { "Buden" };
+    match (c.avg_price, c.min_price, c.max_price) {
+        (Some(avg), Some(min), Some(max)) => format!(
+            "{name}: {count} {bude}, ⌀ {avg:.2}€ ({min:.2}–{max:.2}€).",
+            name = c.city,
+            count = c.location_count,
+        ),
+        _ => format!(
+            "{name}: {count} {bude}, noch keine Preise.",
+            name = c.city,
+            count = c.location_count,
+        ),
+    }
+}
+
+pub fn format_did_you_mean(hits: &[CityHit]) -> String {
+    let parts: Vec<String> = hits
+        .iter()
+        .take(3)
+        .map(|h| format!("{} ({})", h.city, h.location_count))
+        .collect();
+    format!("Meintest du: {}?", parts.join(", "))
+}
+
+pub fn format_not_found(query: &str) -> String {
+    format!("FeelsDankMan keine Stadt für '{query}' gefunden.")
+}
+
+pub fn api_down_message() -> &'static str {
+    API_DOWN_MESSAGE
+}
+
+fn format_pct(p: f64) -> String {
+    if (p.round() - p).abs() < f64::EPSILON {
+        format!("{}", p.round() as i64)
+    } else {
+        format!("{p:.1}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats() -> GlobalStats {
+        GlobalStats {
+            total_locations: 6092,
+            total_cities: 2202,
+            min_price: 5.5,
+            max_price: 9.0,
+            avg_price: 6.1,
+            locations_no_price_pct: 87.0,
+        }
+    }
+
+    fn hit(city: &str, n: u32, prices: Option<(f64, f64, f64)>) -> CityHit {
+        CityHit {
+            city: city.into(),
+            location_count: n,
+            min_price: prices.map(|(min, _, _)| min),
+            max_price: prices.map(|(_, _, max)| max),
+            avg_price: prices.map(|(_, avg, _)| avg),
+        }
+    }
+
+    #[test]
+    fn global_matches_golden_string() {
+        assert_eq!(
+            format_global(&stats()),
+            "Döner-Index DE: 6092 Buden in 2202 Städten, ⌀ 6.10€ (5.50–9.00€). 87% ohne Preis."
+        );
+    }
+
+    #[test]
+    fn global_keeps_decimal_in_no_price_pct_when_non_integer() {
+        let mut s = stats();
+        s.locations_no_price_pct = 87.1;
+        assert!(format_global(&s).contains("87.1% ohne Preis"));
+    }
+
+    #[test]
+    fn city_with_prices_uses_plural_buden() {
+        let c = hit("Hannover", 51, Some((6.0, 6.0, 6.0)));
+        assert_eq!(
+            format_city(&c),
+            "Hannover: 51 Buden, ⌀ 6.00€ (6.00–6.00€)."
+        );
+    }
+
+    #[test]
+    fn city_with_one_location_uses_singular_bude() {
+        let c = hit("Handewitt", 1, None);
+        assert_eq!(format_city(&c), "Handewitt: 1 Bude, noch keine Preise.");
+    }
+
+    #[test]
+    fn city_with_one_location_with_price_uses_singular_bude() {
+        let c = hit("X", 1, Some((7.0, 7.0, 7.0)));
+        assert_eq!(format_city(&c), "X: 1 Bude, ⌀ 7.00€ (7.00–7.00€).");
+    }
+
+    #[test]
+    fn did_you_mean_lists_top_three() {
+        let hits = vec![
+            hit("Hannover", 51, None),
+            hit("Hanau", 3, None),
+            hit("Handewitt", 1, None),
+            hit("Hannover-Land", 0, None),
+        ];
+        assert_eq!(
+            format_did_you_mean(&hits),
+            "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?"
+        );
+    }
+
+    #[test]
+    fn not_found_quotes_query() {
+        assert_eq!(format_not_found("xyz"), "FeelsDankMan keine Stadt für 'xyz' gefunden.");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail doener::format`
+Expected: 7 tests passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/src/doener/format.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): chat formatters with golden-string tests
+
+Pure German formatters for global/city/did-you-mean/not-found responses.
+Singular Bude vs plural Buden, percent without trailing .0 — frozen in
+tests so cosmetic regressions are caught at compile time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `DoenerClient` skeleton
+
+Set up the struct, constants, and constructors before adding methods. Keep tests compiling.
+
+**Files:**
+- Modify: `crates/core/src/doener/client.rs`
+
+- [ ] **Step 1: Replace the placeholder with the skeleton**
+
+```rust
+use std::time::Duration;
+
+use eyre::{Result, WrapErr};
+
+use crate::APP_USER_AGENT;
+use crate::doener::types::{CitiesResponse, CityHit, GlobalStats};
+
+const BASE_URL: &str = "https://xn--dnerindex-07a.com";
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct DoenerClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl DoenerClient {
+    pub fn new() -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            .timeout(TIMEOUT)
+            .build()
+            .wrap_err("build doener HTTP client")?;
+        Ok(Self {
+            http,
+            base_url: BASE_URL.to_string(),
+        })
+    }
+
+    /// Test hook: inject an existing `reqwest::Client` (commonly with a short
+    /// timeout) and a custom base URL pointing at a wiremock server.
+    pub fn with_base_url(http: reqwest::Client, base_url: impl Into<String>) -> Self {
+        Self {
+            http,
+            base_url: base_url.into(),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cargo check -p core --quiet`
+Expected: success. Unused-import warnings for `CityHit`, `CitiesResponse`, `GlobalStats` are fine — methods land in Tasks 5–6.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/src/doener/client.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): DoenerClient skeleton
+
+Constants + constructors only. Methods land in follow-up commits with
+their wiremock tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `DoenerClient::stats`
+
+**Files:**
+- Modify: `crates/core/src/doener/client.rs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `crates/core/src/doener/client.rs` (inside a new `#[cfg(test)] mod tests`):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_client(server: &MockServer) -> DoenerClient {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_millis(500))
+            .build()
+            .expect("build test client");
+        DoenerClient::with_base_url(http, server.uri())
+    }
+
+    #[tokio::test]
+    async fn stats_parses_canonical_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let stats = client.stats().await.expect("stats ok");
+        assert_eq!(stats.total_locations, 6092);
+        assert_eq!(stats.total_cities, 2202);
+    }
+
+    #[tokio::test]
+    async fn stats_returns_err_on_500() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        assert!(client.stats().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn stats_returns_err_on_malformed_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        assert!(client.stats().await.is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails to compile**
+
+Run: `cargo check -p core --tests --quiet`
+Expected: error `no method named 'stats' found for struct 'DoenerClient'`.
+
+- [ ] **Step 3: Implement `stats`**
+
+Add to the `impl DoenerClient` block in the same file:
+
+```rust
+    pub async fn stats(&self) -> Result<GlobalStats> {
+        let url = format!("{}/api/stats.php", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .wrap_err("doener stats: request failed")?
+            .error_for_status()
+            .wrap_err("doener stats: non-2xx")?;
+        resp.json::<GlobalStats>()
+            .await
+            .wrap_err("doener stats: parse JSON")
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail doener::client::tests::stats`
+Expected: 3 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/doener/client.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): client.stats() against /api/stats.php
+
+Reqwest GET with project-wide UA and 5s timeout; wiremock-tested for
+200, 500 and malformed JSON paths.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `DoenerClient::search_cities`
+
+**Files:**
+- Modify: `crates/core/src/doener/client.rs`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to the existing `mod tests` block:
+
+```rust
+    #[tokio::test]
+    async fn search_cities_returns_hits_in_upstream_order() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .and(wiremock::matchers::query_param("q", "Han"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"Han","count":3,"cities":[
+                    {"city":"Hannover","zip":"30459","location_count":51,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"},
+                    {"city":"Hanau","zip":"63456","location_count":3,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"},
+                    {"city":"Handewitt","zip":"24983","location_count":1,"min_price":null,"max_price":null,"avg_price":null}
+                ]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let hits = client.search_cities("Han").await.expect("cities ok");
+        assert_eq!(hits.len(), 3);
+        assert_eq!(hits[0].city, "Hannover");
+        assert_eq!(hits[2].avg_price, None);
+    }
+
+    #[tokio::test]
+    async fn search_cities_empty_array_is_ok_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"zzz","count":0,"cities":[]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let hits = client.search_cities("zzz").await.expect("ok");
+        assert!(hits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_cities_returns_err_on_500() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        assert!(client.search_cities("x").await.is_err());
+    }
+```
+
+- [ ] **Step 2: Implement `search_cities`**
+
+Add to `impl DoenerClient`:
+
+```rust
+    pub async fn search_cities(&self, q: &str) -> Result<Vec<CityHit>> {
+        let url = format!("{}/api/cities.php", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("q", q)])
+            .send()
+            .await
+            .wrap_err("doener cities: request failed")?
+            .error_for_status()
+            .wrap_err("doener cities: non-2xx")?;
+        let body = resp
+            .json::<CitiesResponse>()
+            .await
+            .wrap_err("doener cities: parse JSON")?;
+        Ok(body.cities)
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail doener::client`
+Expected: 6 tests passed (3 from Task 5 + 3 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/doener/client.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): client.search_cities() against /api/cities.php
+
+Returns hits in upstream order. Wiremock-tested for non-empty, empty and
+5xx paths.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `cooldowns.doener` config field
+
+**Files:**
+- Modify: `crates/core/src/config.rs`
+- Modify: `crates/twitch-1337/config.toml.example`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `#[cfg(test)] mod tests` in `crates/core/src/config.rs` (any spot near the other `CooldownsConfig`-touching tests, or append at end of the module):
+
+```rust
+    #[test]
+    fn cooldowns_doener_defaults_to_30() {
+        let c: CooldownsConfig = toml::from_str("").expect("empty cooldowns parses");
+        assert_eq!(c.doener, 30);
+    }
+
+    #[test]
+    fn cooldowns_doener_overrides_via_toml() {
+        let c: CooldownsConfig = toml::from_str("doener = 5").expect("parses");
+        assert_eq!(c.doener, 5);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo check -p core --tests --quiet`
+Expected: error `no field 'doener' on type 'CooldownsConfig'`.
+
+- [ ] **Step 3: Add the field + default**
+
+In `crates/core/src/config.rs`, near the existing default fns (~line 446):
+
+```rust
+fn default_doener_cooldown() -> u64 {
+    30
+}
+```
+
+Extend `CooldownsConfig` (currently lines 450–460):
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct CooldownsConfig {
+    #[serde(default = "default_ai_cooldown")]
+    pub ai: u64,
+    #[serde(default = "default_news_cooldown")]
+    pub news: u64,
+    #[serde(default = "default_up_cooldown")]
+    pub up: u64,
+    #[serde(default = "default_feedback_cooldown")]
+    pub feedback: u64,
+    #[serde(default = "default_doener_cooldown")]
+    pub doener: u64,
+}
+```
+
+Extend the `Default` impl (currently lines 462–471):
+
+```rust
+impl Default for CooldownsConfig {
+    fn default() -> Self {
+        Self {
+            ai: default_ai_cooldown(),
+            news: default_news_cooldown(),
+            up: default_up_cooldown(),
+            feedback: default_feedback_cooldown(),
+            doener: default_doener_cooldown(),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Document in the example config**
+
+In `crates/twitch-1337/config.toml.example`, find the `[cooldowns]` block and add a `doener` line:
+
+```toml
+# Optional: Command cooldowns in seconds
+# [cooldowns]
+# ai = 30        # !ai command (default: 30)
+# news = 60      # !news command (default: 60)
+# up = 30        # !up command (default: 30)
+# feedback = 300 # !fb command (default: 300)
+# doener = 30    # !dpi command (default: 30)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail config::tests::cooldowns_doener`
+Expected: 2 tests passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/core/src/config.rs crates/twitch-1337/config.toml.example
+git commit -m "$(cat <<'EOF'
+feat(config): cooldowns.doener for !dpi (default 30s)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `DoenerCommand` (chat) + `pub mod doener;` in commands
+
+The chat command. Branching logic lives here; formatting and HTTP are already covered.
+
+**Files:**
+- Create: `crates/core/src/commands/doener.rs`
+- Modify: `crates/core/src/commands/mod.rs`
+
+- [ ] **Step 1: Add the module declaration**
+
+In `crates/core/src/commands/mod.rs`, in the `pub mod` block (after `feedback`):
+
+```rust
+pub mod doener;
+pub mod feedback;
+```
+
+(Maintain alphabetical order; `doener` precedes `feedback`.)
+
+- [ ] **Step 2: Create the command with its branching tests**
+
+`crates/core/src/commands/doener.rs`:
+
+```rust
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use tokio::time::Duration;
+use tracing::error;
+use twitch_irc::{login::LoginCredentials, transport::Transport};
+
+use super::{Command, CommandContext};
+use crate::cooldown::{PerUserCooldown, format_cooldown_remaining};
+use crate::doener::format::{
+    api_down_message, format_city, format_did_you_mean, format_global, format_not_found,
+};
+use crate::doener::{CityHit, DoenerClient};
+
+pub struct DoenerCommand {
+    client: Arc<DoenerClient>,
+    cooldown: PerUserCooldown,
+}
+
+impl DoenerCommand {
+    pub fn new(client: Arc<DoenerClient>, cooldown: Duration) -> Self {
+        Self {
+            client,
+            cooldown: PerUserCooldown::new(cooldown),
+        }
+    }
+}
+
+#[async_trait]
+impl<T, L> Command<T, L> for DoenerCommand
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    fn name(&self) -> &str {
+        "!dpi"
+    }
+
+    async fn execute(&self, ctx: CommandContext<'_, T, L>) -> Result<()> {
+        let user = &ctx.privmsg.sender.login;
+        if let Some(remaining) = self.cooldown.check(user).await {
+            send(
+                &ctx,
+                format!(
+                    "Bitte warte noch {} Waiting",
+                    format_cooldown_remaining(remaining)
+                ),
+            )
+            .await;
+            return Ok(());
+        }
+        self.cooldown.record(user).await;
+
+        let query = ctx.args.join(" ");
+        let query = query.trim();
+
+        let response = if query.is_empty() {
+            match self.client.stats().await {
+                Ok(s) => format_global(&s),
+                Err(e) => {
+                    error!(error = ?e, "doener stats lookup failed");
+                    api_down_message().to_string()
+                }
+            }
+        } else {
+            match self.client.search_cities(query).await {
+                Ok(hits) => decide_city_response(query, hits),
+                Err(e) => {
+                    error!(error = ?e, query, "doener city lookup failed");
+                    api_down_message().to_string()
+                }
+            }
+        };
+
+        send(&ctx, response).await;
+        Ok(())
+    }
+}
+
+fn decide_city_response(query: &str, hits: Vec<CityHit>) -> String {
+    if hits.is_empty() {
+        return format_not_found(query);
+    }
+    if hits.len() == 1 {
+        return format_city(&hits[0]);
+    }
+    if hits[0].city.eq_ignore_ascii_case(query) {
+        return format_city(&hits[0]);
+    }
+    format_did_you_mean(&hits)
+}
+
+async fn send<T, L>(ctx: &CommandContext<'_, T, L>, line: String)
+where
+    T: Transport,
+    L: LoginCredentials,
+{
+    if let Err(e) = ctx.client.say_in_reply_to(ctx.privmsg, line).await {
+        error!(error = ?e, "Failed to send !dpi response");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doener::CityHit;
+
+    fn hit(city: &str, n: u32, with_prices: bool) -> CityHit {
+        CityHit {
+            city: city.into(),
+            location_count: n,
+            min_price: with_prices.then_some(6.0),
+            max_price: with_prices.then_some(6.0),
+            avg_price: with_prices.then_some(6.0),
+        }
+    }
+
+    #[test]
+    fn city_response_empty_hits_is_not_found() {
+        let out = decide_city_response("xyz", vec![]);
+        assert_eq!(out, "FeelsDankMan keine Stadt für 'xyz' gefunden.");
+    }
+
+    #[test]
+    fn city_response_single_hit_uses_format_city() {
+        let out = decide_city_response("Hannover", vec![hit("Hannover", 51, true)]);
+        assert!(out.starts_with("Hannover: 51 Buden"));
+    }
+
+    #[test]
+    fn city_response_exact_match_short_circuits() {
+        // "Berlin" → upstream returns Berlin + Berlingerode. Treat as single hit.
+        let hits = vec![hit("Berlin", 324, true), hit("Berlingerode", 1, false)];
+        let out = decide_city_response("berlin", hits);
+        assert!(out.starts_with("Berlin: 324 Buden"));
+    }
+
+    #[test]
+    fn city_response_multi_hit_no_exact_match_is_did_you_mean() {
+        let hits = vec![
+            hit("Hannover", 51, true),
+            hit("Hanau", 3, true),
+            hit("Handewitt", 1, false),
+        ];
+        let out = decide_city_response("Han", hits);
+        assert_eq!(
+            out,
+            "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?"
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail commands::doener`
+Expected: 4 tests passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/commands/doener.rs crates/core/src/commands/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): DoenerCommand (!dpi) with all branches covered
+
+Empty arg → global stats. Arg → cities.php fuzzy; 0/1/exact-match/many
+each map to a distinct chat string. Exact case-insensitive match on the
+first hit short-circuits did-you-mean so '!dpi Berlin' doesn't suggest
+'Berlin (324), Berlingerode (1)'.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Plumb `DoenerClient` through `Services` + `main.rs`
+
+**Files:**
+- Modify: `crates/core/src/lib.rs`
+- Modify: `crates/twitch-1337/src/main.rs`
+
+- [ ] **Step 1: Add the field to `Services`**
+
+In `crates/core/src/lib.rs`, in `pub struct Services` (currently ~line 73), add after `aviation`:
+
+```rust
+    pub aviation: Option<AviationClient>,
+    pub doener: Arc<crate::doener::DoenerClient>,
+```
+
+- [ ] **Step 2: Destructure it in `run_bot`**
+
+In `crates/core/src/lib.rs`, in `run_bot` (currently ~line 128, `let Services { ... }`), add `doener,` to the destructure pattern next to `aviation,`.
+
+- [ ] **Step 3: Import the module in `main.rs`**
+
+In `crates/twitch-1337/src/main.rs`, in the existing `use twitch_1337_core::{ ... }` block (currently ~lines 11–20), add `doener` next to `aviation`:
+
+```rust
+use twitch_1337_core::{
+    AuthenticatedLoginCredentials, Services,
+    ai::{command::memory_caps_from_config, memory::store::MemoryStore},
+    aviation, doener, ensure_data_dir, get_data_dir, install_crypto_provider, install_tracing, llm_factory,
+    load_configuration,
+    ping::PingManager,
+    run_bot, setup_and_verify_twitch_client,
+    twitch::whisper,
+    util::clock::SystemClock,
+};
+```
+
+- [ ] **Step 4: Construct the client and place it in `Services`**
+
+In `crates/twitch-1337/src/main.rs`, after the aviation block (currently ~line 73), add:
+
+```rust
+    let doener_client = Arc::new(
+        doener::DoenerClient::new().wrap_err("Failed to initialize Döner-index client")?,
+    );
+```
+
+Then add the field to the `Services { ... }` literal (currently ~line 115):
+
+```rust
+    let services = Services {
+        clock: Arc::new(SystemClock),
+        llm: llm_client,
+        aviation: aviation_client,
+        doener: doener_client,
+        whisper: Some(whisper),
+        ...
+```
+
+- [ ] **Step 5: Verify compile**
+
+Run: `cargo check --workspace --quiet`
+Expected: success. Plumbing through the rest of the chain (SpawnDeps, CommandHandlerConfig) happens in Task 10. `Services.doener` is constructed but not yet read — that is fine (no field-unused warning because `Services` is `pub`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/core/src/lib.rs crates/twitch-1337/src/main.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): plumb DoenerClient into Services
+
+Constructed once in main.rs (Arc-shared). Consumers wired in
+follow-up commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Thread doener through `SpawnDeps` → `CommandHandlerConfig`
+
+**Files:**
+- Modify: `crates/core/src/lib.rs`
+- Modify: `crates/core/src/twitch/handlers/spawn.rs`
+- Modify: `crates/core/src/twitch/handlers/commands.rs`
+
+- [ ] **Step 1: Add the field to `SpawnDeps`**
+
+In `crates/core/src/twitch/handlers/spawn.rs`, in `pub(crate) struct SpawnDeps`, add next to the shared section (after `data_dir: PathBuf,` ~line 71):
+
+```rust
+    pub data_dir: PathBuf,
+    pub doener: Arc<crate::doener::DoenerClient>,
+```
+
+Destructure it in `spawn_handlers` (~line 103) by adding `doener,` to the pattern.
+
+Add it to the `CommandHandlerConfig { ... }` literal built inside the `generic_commands` spawn (~line 228) — see Step 3 below for the corresponding `CommandHandlerConfig` field.
+
+- [ ] **Step 2: Pass it from `run_bot` into `SpawnDeps`**
+
+In `crates/core/src/lib.rs`, in `run_bot` after destructuring `services`, locate the `spawn_handlers(SpawnDeps { ... })` call (or wherever `SpawnDeps` is constructed) and add `doener: doener.clone(),` (or `doener,` if not used afterwards).
+
+- [ ] **Step 3: Add the field to `CommandHandlerConfig`**
+
+In `crates/core/src/twitch/handlers/commands.rs`, in `pub struct CommandHandlerConfig<T,L>` (currently ~line 25), add next to `data_dir`:
+
+```rust
+    pub data_dir: std::path::PathBuf,
+    pub doener: Arc<crate::doener::DoenerClient>,
+```
+
+Add `doener,` to the destructure pattern in `run_generic_command_handler` (~line 63).
+
+In the `spawn.rs` `generic_commands` block where `CommandHandlerConfig { ... }` is built, add `doener: doener.clone(),` (or `doener,` if last use).
+
+- [ ] **Step 4: Verify compile**
+
+Run: `cargo check --workspace --quiet`
+Expected: success. `doener` may produce a `field is never read` warning until Task 11 — that is acceptable for this transient state, but prefer to combine Step 5 of Task 11 into this commit if convenient. The cleanest split: commit Task 10 with the new field marked `#[allow(dead_code)]` if needed, then drop the allow in Task 11. The simpler choice is to register the command immediately in Task 11 and treat them as a single deploy unit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/lib.rs crates/core/src/twitch/handlers/spawn.rs crates/core/src/twitch/handlers/commands.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): thread DoenerClient through SpawnDeps + CommandHandlerConfig
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Register `DoenerCommand` in the dispatcher
+
+**Files:**
+- Modify: `crates/core/src/twitch/handlers/commands.rs`
+
+- [ ] **Step 1: Push the command into `cmd_list`**
+
+In `crates/core/src/twitch/handlers/commands.rs`, in the `cmd_list` `vec![...]` (currently ~line 134), add an entry alongside the other simple commands (after `FeedbackCommand` is fine):
+
+```rust
+        Box::new(commands::feedback::FeedbackCommand::new(
+            data_dir.clone(),
+            Duration::from_secs(cooldowns.feedback),
+        )),
+        Box::new(commands::doener::DoenerCommand::new(
+            doener.clone(),
+            Duration::from_secs(cooldowns.doener),
+        )),
+    ];
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `cargo check --workspace --quiet`
+Expected: success, no `field is never read` warnings on `doener`.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail`
+Expected: full pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/twitch/handlers/commands.rs
+git commit -m "$(cat <<'EOF'
+feat(doener): register !dpi in the command dispatcher
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: AI tool definition + `is_web_tool` regression test
+
+**Files:**
+- Create: `crates/core/src/ai/doener_tool.rs`
+- Modify: `crates/core/src/ai/mod.rs`
+
+- [ ] **Step 1: Add the module declaration**
+
+In `crates/core/src/ai/mod.rs`:
+
+```rust
+pub mod chat_history;
+pub mod command;
+pub mod content;
+pub mod doener_tool;
+pub mod memory;
+pub mod prefill;
+pub mod session;
+```
+
+- [ ] **Step 2: Create the module with the tool def only (no execute fn yet)**
+
+`crates/core/src/ai/doener_tool.rs`:
+
+```rust
+use llm::ToolDefinition;
+use serde::Deserialize;
+
+pub const DOENER_TOOL_NAME: &str = "doener_index";
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DoenerArgs {
+    #[serde(default)]
+    pub city: Option<String>,
+}
+
+pub fn doener_tool() -> ToolDefinition {
+    ToolDefinition {
+        name: DOENER_TOOL_NAME.into(),
+        description: "Look up the German Döner price index from dönerindex.com. \
+            Without `city`, returns the country-wide aggregate (location count, \
+            avg/min/max price). With `city` (free-form), returns the top matching \
+            cities and their per-city aggregate. Use this for any question about \
+            Döner prices, kebab prices, or how expensive Döner is in a German city."
+            .into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "Optional city name or prefix. German spelling preferred (e.g. 'Köln', 'München')."
+                }
+            }
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_def_has_expected_name() {
+        let t = doener_tool();
+        assert_eq!(t.name, "doener_index");
+    }
+
+    #[test]
+    fn doener_index_is_not_a_web_tool() {
+        // Regression guard: a future refactor must not gate this tool behind
+        // [ai.web]. is_web_tool drives routing into ContentToolExecutor.
+        assert!(!crate::ai::content::is_web_tool(DOENER_TOOL_NAME));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail ai::doener_tool`
+Expected: 2 tests passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/ai/mod.rs crates/core/src/ai/doener_tool.rs
+git commit -m "$(cat <<'EOF'
+feat(ai): doener_index tool definition
+
+Standalone module so the tool is not gated by [ai.web]. Regression test
+asserts is_web_tool(\"doener_index\") stays false.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: `execute_doener_index` + wiremock tests
+
+**Files:**
+- Modify: `crates/core/src/ai/doener_tool.rs`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to the existing `#[cfg(test)] mod tests` in `crates/core/src/ai/doener_tool.rs`:
+
+```rust
+    use std::time::Duration;
+
+    use llm::{ToolCall, ToolResultMessage};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::doener::DoenerClient;
+
+    fn call(args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: "call_1".into(),
+            name: DOENER_TOOL_NAME.into(),
+            arguments: args,
+            arguments_parse_error: None,
+        }
+    }
+
+    fn test_client(server: &MockServer) -> DoenerClient {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_millis(500))
+            .build()
+            .unwrap();
+        DoenerClient::with_base_url(http, server.uri())
+    }
+
+    fn content(msg: &ToolResultMessage) -> String {
+        // ToolResultMessage.content is a public String field — see crates/llm/src/types.rs:74.
+        msg.content.clone()
+    }
+
+    #[tokio::test]
+    async fn no_city_returns_global_scope() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"total_locations":6092,"total_cities":2202,"min_price":5.5,"max_price":9,"avg_price":6.1,"locations_no_price":5304,"locations_no_price_pct":87.1}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(&client, &call(serde_json::json!({}))).await;
+        let body = content(&msg);
+        assert!(body.contains("\"scope\":\"global\""), "got: {body}");
+        assert!(body.contains("\"total_locations\":6092"), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn with_city_returns_city_scope_and_hits() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .and(wiremock::matchers::query_param("q", "Han"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"Han","count":1,"cities":[{"city":"Hannover","zip":"30459","location_count":51,"min_price":"6.00","max_price":"6.00","avg_price":"6.00"}]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(
+            &client,
+            &call(serde_json::json!({"city": "Han"})),
+        )
+        .await;
+        let body = content(&msg);
+        assert!(body.contains("\"scope\":\"city\""), "got: {body}");
+        assert!(body.contains("Hannover"), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn zero_hits_returns_empty_array() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/cities.php"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                br#"{"ok":true,"query":"zzz","count":0,"cities":[]}"#.as_slice(),
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(
+            &client,
+            &call(serde_json::json!({"city": "zzz"})),
+        )
+        .await;
+        let body = content(&msg);
+        assert!(body.contains("\"hits\":[]"), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn upstream_failure_returns_error_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/stats.php"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server);
+        let msg = execute_doener_index(&client, &call(serde_json::json!({}))).await;
+        let body = content(&msg);
+        assert!(body.contains("\"error\":\"doener_index API unavailable\""), "got: {body}");
+    }
+
+    #[tokio::test]
+    async fn malformed_args_returns_invalid_arguments_json() {
+        // city as integer should fail to deserialize as Option<String>.
+        let server = MockServer::start().await;
+        // No mock needed; the args parse error short-circuits before any HTTP.
+        let client = test_client(&server);
+        let msg = execute_doener_index(
+            &client,
+            &call(serde_json::json!({"city": 123})),
+        )
+        .await;
+        let body = content(&msg);
+        assert!(body.contains("\"error\":\"invalid_arguments\""), "got: {body}");
+    }
+```
+
+- [ ] **Step 2: Implement `execute_doener_index`**
+
+Append to `crates/core/src/ai/doener_tool.rs` (before the `#[cfg(test)]` block):
+
+```rust
+use llm::{ToolCall, ToolResultMessage};
+use serde_json::json;
+
+use crate::doener::DoenerClient;
+
+pub async fn execute_doener_index(
+    client: &DoenerClient,
+    call: &ToolCall,
+) -> ToolResultMessage {
+    let args = match call.parse_args::<DoenerArgs>() {
+        Ok(a) => a,
+        Err(e) => {
+            return ToolResultMessage::for_call(
+                call,
+                json!({
+                    "error": "invalid_arguments",
+                    "details": e.to_string(),
+                })
+                .to_string(),
+            );
+        }
+    };
+
+    let payload = match args.city.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => match client.stats().await {
+            Ok(stats) => json!({"scope": "global", "stats": stats}),
+            Err(e) => {
+                tracing::warn!(error = ?e, "doener_index global lookup failed");
+                json!({"error": "doener_index API unavailable"})
+            }
+        },
+        Some(q) => match client.search_cities(q).await {
+            Ok(hits) => {
+                let top: Vec<_> = hits.into_iter().take(5).collect();
+                json!({"scope": "city", "query": q, "hits": top})
+            }
+            Err(e) => {
+                tracing::warn!(error = ?e, query = q, "doener_index city lookup failed");
+                json!({"error": "doener_index API unavailable"})
+            }
+        },
+    };
+
+    ToolResultMessage::for_call(call, payload.to_string())
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p core --show-progress=none --cargo-quiet --status-level=fail ai::doener_tool`
+Expected: 7 tests passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/ai/doener_tool.rs
+git commit -m "$(cat <<'EOF'
+feat(ai): execute_doener_index returns JSON payload
+
+Global vs city scopes, top-5 hits cap, transparent error surface so the
+model can decide how to phrase failures.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Plumb `DoenerClient` into `AiCommandDeps` + `AiCommand`
+
+**Files:**
+- Modify: `crates/core/src/ai/command.rs`
+- Modify: `crates/core/src/twitch/handlers/commands.rs`
+
+- [ ] **Step 1: Add the field to `AiCommandDeps`**
+
+In `crates/core/src/ai/command.rs`, in `pub struct AiCommandDeps` (currently ~line 90–110 region), add:
+
+```rust
+    pub doener: std::sync::Arc<crate::doener::DoenerClient>,
+```
+
+Add the matching field to `pub struct AiCommand` (in the same file, near `web: Option<AiWeb>` at line 91):
+
+```rust
+    doener: std::sync::Arc<crate::doener::DoenerClient>,
+```
+
+In the `AiCommand::new` builder (line 135ish, the `Self { ... }` literal), add:
+
+```rust
+            doener: deps.doener,
+```
+
+- [ ] **Step 2: Pass it at the call site**
+
+In `crates/core/src/twitch/handlers/commands.rs`, in the `cmd_list.push(Box::new(ai::command::AiCommand::new(...)))` block (~line 230), add `doener: doener.clone(),` to the `AiCommandDeps { ... }` literal alongside the other fields.
+
+- [ ] **Step 3: Verify compile**
+
+Run: `cargo check --workspace --quiet`
+Expected: success. `self.doener` field unused warning is acceptable here — fixed in Task 15.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/ai/command.rs crates/core/src/twitch/handlers/commands.rs
+git commit -m "$(cat <<'EOF'
+feat(ai): plumb DoenerClient into AiCommand
+
+Field threaded through AiCommandDeps; used in the next commit by
+V2Executor.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Route `doener_index` in `V2Executor`, push tool unconditionally
+
+This is the wiring that makes the tool actually reachable from the model.
+
+**Files:**
+- Modify: `crates/core/src/ai/command.rs`
+
+- [ ] **Step 1: Extend `V2Executor` with the doener field**
+
+In `crates/core/src/ai/command.rs`, in `struct V2Executor<'a>` (currently ~line 149):
+
+```rust
+struct V2Executor<'a> {
+    chat: &'a ChatTurnExecutor,
+    web: Option<&'a content::ContentToolExecutor>,
+    doener: &'a crate::doener::DoenerClient,
+    trace: &'a TraceIds,
+}
+```
+
+In the `impl ToolExecutor for V2Executor<'_>` `execute` method (currently ~line 157), route the doener call BEFORE the web branch (so it works even when `web` is `None`):
+
+```rust
+#[async_trait]
+impl ToolExecutor for V2Executor<'_> {
+    async fn execute(&self, call: &ToolCall) -> ToolResultMessage {
+        if call.name == crate::ai::doener_tool::DOENER_TOOL_NAME {
+            return crate::ai::doener_tool::execute_doener_index(self.doener, call).await;
+        }
+        if content::is_web_tool(&call.name) {
+            match self.web {
+                Some(w) => w.execute_tool_call(call, self.trace).await,
+                None => ToolResultMessage::for_call(call, "unknown_tool".to_string()),
+            }
+        } else {
+            self.chat.execute(call).await
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update the `V2Executor` construction**
+
+Find the `let combined_exec = V2Executor { ... }` (currently ~line 433):
+
+```rust
+        let combined_exec = V2Executor {
+            chat: &exec,
+            web: self.web.as_ref().map(|w| w.executor.as_ref()),
+            doener: self.doener.as_ref(),
+            trace: &trace,
+        };
+```
+
+- [ ] **Step 3: Push `doener_tool()` into the tools list unconditionally**
+
+Find the tools-assembly block (currently ~line 407):
+
+```rust
+        let mut tools = chat_turn_tools();
+        tools.push(crate::ai::doener_tool::doener_tool());
+        if self.web.is_some() {
+            tools.extend(content::ai_tools());
+        }
+```
+
+- [ ] **Step 4: Verify compile + run all tests**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail`
+Expected: full pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/ai/command.rs
+git commit -m "$(cat <<'EOF'
+feat(ai): V2Executor routes doener_index unconditionally
+
+Adds DOENER_TOOL_NAME as the first dispatch branch so the model can call
+it even when [ai.web] is disabled. The tool def is now always present in
+the chat turn's tools list.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Full pre-commit gate
+
+The CI gate (`fmt + clippy + test`) blocks merges to `main`. Run it now so anything that slipped through nextest surfaces here, not in CI.
+
+**Files:** none.
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --all`
+Expected: silent. If files change, stage them in the same commit as Step 2 of this task.
+
+- [ ] **Step 2: Clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: silent (no warnings).
+
+If clippy fires on the new code, fix in place. Avoid `#[allow]` without a one-line reason — the repo enforces this.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail`
+Expected: full pass.
+
+- [ ] **Step 4: Cargo audit (optional but recommended locally)**
+
+Run: `cargo audit`
+Expected: 0 vulnerabilities. (No new deps added by this work, so the lockfile is unchanged — there should be nothing new to audit.)
+
+- [ ] **Step 5: Commit any formatting changes**
+
+```bash
+git diff --name-only
+# if non-empty:
+git add -A
+git commit -m "$(cat <<'EOF'
+chore(doener): cargo fmt fallout
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Otherwise skip the commit.
+
+---
+
+## Task 17: Manual smoke check (optional, recommended)
+
+Run the bot locally against the real upstream once to confirm end-to-end behavior, then revert any local config tweaks before pushing.
+
+- [ ] **Step 1: Quick endpoint sanity**
+
+Run: `curl -s 'https://xn--dnerindex-07a.com/api/stats.php' | jq .`
+Expected: a `{"ok": true, ...}` payload (no auth).
+
+- [ ] **Step 2: Build the bot**
+
+Run: `cargo build --quiet`
+Expected: success.
+
+- [ ] **Step 3 (optional): Run the bot in a dev channel and try four message variants**
+
+Manual: invoke `!dpi`, `!dpi Berlin`, `!dpi Han`, `!dpi NichtExistenteStadtXYZ` and confirm the responses match the formats from Task 3.
+
+This step is optional because the unit + wiremock tests already cover every branch. Skip if the dev environment is not set up.
+
+---
+
+## Task 18: PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+
+```bash
+git push -u origin worktree-feature+donerpreisindex:feature/donerpreisindex
+```
+
+(The worktree's branch is named `worktree-feature+donerpreisindex` locally, but the project convention is `feature/donerpreisindex` on origin.)
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "feat: dönerpreisindex command + AI tool (#178)" --body "$(cat <<'EOF'
+## Summary
+- !dpi chat command: global aggregate (no arg) and fuzzy city lookup with did-you-mean fallback.
+- doener_index AI tool: exposes the same data to !ai; routed unconditionally so it works even when [ai.web] is disabled.
+- Shared DoenerClient against https://xn--dnerindex-07a.com (stats.php + cities.php).
+
+Closes #178.
+
+## Test plan
+- [ ] Wait for CI: fmt + clippy + test, cargo audit, hadolint, trivy, actionlint, zizmor, gitleaks.
+- [ ] Manual: !dpi (global), !dpi Berlin (single hit short-circuit), !dpi Han (did-you-mean), !dpi xyz (not found), !ai "Wie teuer ist Döner in Hamburg?".
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report the PR URL back to the user.**

--- a/docs/superpowers/specs/2026-05-11-donerpreisindex-design.md
+++ b/docs/superpowers/specs/2026-05-11-donerpreisindex-design.md
@@ -192,83 +192,131 @@ No `[doener]` config block. Base URL and timeout are consts.
 
 ## AI tool
 
-Registered in `crates/core/src/ai/content/tools.rs::ai_tools()` (always
-present when `[ai]` is configured — not gated by `[ai.web]`, since this is a
-first-party data tool, not generic web access).
+The existing `ai_tools()` in `crates/core/src/ai/content/tools.rs` is only
+pushed when `[ai.web]` is enabled (see `crates/core/src/ai/command.rs` near
+line 408: `if self.web.is_some() { tools.extend(content::ai_tools()); }`).
+The doener tool must work even when web is disabled, so it does not live
+inside `ContentToolExecutor`. Instead it gets its own thin module.
+
+New module `crates/core/src/ai/doener_tool.rs`:
 
 ```rust
-ToolDefinition {
-    name: "doener_index".into(),
-    description: "Look up the German Döner price index from dönerindex.com. \
-        Without `city`, returns the country-wide aggregate (location count, \
-        avg/min/max price). With `city` (free-form), returns the top matching \
-        cities and their per-city aggregate. Use this for any question about \
-        Döner prices, kebab prices, or how expensive Döner is in a German city.".into(),
-    parameters: serde_json::json!({
-        "type": "object",
-        "properties": {
-            "city": {
-                "type": "string",
-                "description": "Optional city name or prefix. German spelling preferred (e.g. 'Köln', 'München')."
+use std::sync::Arc;
+use llm::{ToolCall, ToolDefinition, ToolResultMessage};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::doener::DoenerClient;
+
+pub const DOENER_TOOL_NAME: &str = "doener_index";
+
+#[derive(Debug, Deserialize)]
+struct DoenerArgs {
+    #[serde(default)]
+    city: Option<String>,
+}
+
+pub fn doener_tool() -> ToolDefinition {
+    ToolDefinition {
+        name: DOENER_TOOL_NAME.into(),
+        description: "Look up the German Döner price index from dönerindex.com. \
+            Without `city`, returns the country-wide aggregate (location count, \
+            avg/min/max price). With `city` (free-form), returns the top matching \
+            cities and their per-city aggregate. Use this for any question about \
+            Döner prices, kebab prices, or how expensive Döner is in a German city.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "Optional city name or prefix. German spelling preferred (e.g. 'Köln', 'München')."
+                }
             }
+        }),
+    }
+}
+
+pub async fn execute_doener_index(
+    client: &DoenerClient,
+    call: &ToolCall,
+) -> ToolResultMessage {
+    let args = match call.parse_args::<DoenerArgs>() {
+        Ok(a) => a,
+        Err(e) => {
+            return ToolResultMessage::for_call(
+                call,
+                json!({"error": "invalid_arguments", "details": e.to_string()}).to_string(),
+            );
         }
-    }),
+    };
+
+    let payload = match args.city.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => match client.stats().await {
+            Ok(stats) => json!({"scope": "global", "stats": stats}),
+            Err(_) => json!({"error": "doener_index API unavailable"}),
+        },
+        Some(q) => match client.search_cities(q).await {
+            Ok(hits) => {
+                let top: Vec<_> = hits.into_iter().take(5).collect();
+                json!({"scope": "city", "query": q, "hits": top})
+            }
+            Err(_) => json!({"error": "doener_index API unavailable"}),
+        },
+    };
+    ToolResultMessage::for_call(call, payload.to_string())
 }
 ```
 
-Dispatch added to `crates/core/src/ai/content/executor.rs::execute_tool_call`:
+`GlobalStats` and `CityHit` derive `Serialize` (in addition to `Deserialize`)
+so the `serde_json::json!` macro can embed them. They contain no secrets, so
+the project's "no Serialize on config" rule does not apply.
 
-```rust
-"doener_index" => match call.parse_args::<DoenerIndexArgs>() {
-    Ok(args) => self.execute_doener_index(args).await,
-    Err(err) => format_args_error(...),
-},
-```
+`AiCommand` is wired to receive the client and dispatch the tool:
 
-`DoenerIndexArgs { city: Option<String> }`.
+- `AiCommandDeps` grows `pub doener: Arc<DoenerClient>`.
+- `AiCommand` stores it in a `doener: Arc<DoenerClient>` field.
+- `V2Executor` grows `doener: &'a DoenerClient` and routes
+  `DOENER_TOOL_NAME` calls to `execute_doener_index`, regardless of whether
+  `web` is `Some`.
+- `command.rs` push site (line 407–410) becomes:
 
-`execute_doener_index` returns JSON (not formatted chat strings — the model
-phrases it):
+  ```rust
+  let mut tools = chat_turn_tools();
+  tools.push(crate::ai::doener_tool::doener_tool());
+  if self.web.is_some() {
+      tools.extend(content::ai_tools());
+  }
+  ```
 
-```jsonc
-// no city
-{"scope": "global", "stats": { /* GlobalStats */ }}
+- `is_web_tool` is **not** modified. `doener_index` is dispatched by an
+  explicit name check inside `V2Executor::execute` placed before the
+  `is_web_tool` branch.
 
-// city given, 0 hits
-{"scope": "city", "query": "xyz", "hits": []}
-
-// city given, N hits (top 5, raw aggregate)
-{"scope": "city", "query": "Han", "hits": [
-  {"city": "Hannover", "location_count": 51, "avg_price": 6.0, "min_price": 6.0, "max_price": 6.0},
-  ...
-]}
-
-// API failure
-{"error": "doener_index API unavailable"}
-```
-
-The `Executor` gains an `Arc<DoenerClient>` field; constructed in
-`Services` alongside the other shared clients.
-
-`is_web_tool` does not include `doener_index`. The tool is allowed even when
-`[ai.web]` is disabled.
+The tool ships any time `[ai]` is configured, regardless of `[ai.web]`.
 
 ## Wiring
 
-`Services` (the struct holding shared deps in `crates/core/src/lib.rs`) grows:
+`Services` (`crates/core/src/lib.rs`) grows:
 
 ```rust
 pub doener: Arc<DoenerClient>,
 ```
 
-Constructed once at startup with `DoenerClient::new()`. If construction fails
-(reqwest builder), bot startup fails — same posture as the aviation client's
-historical behavior wasn't quite this, but `DoenerClient::new` only fails on
-an invalid TLS root store / OS-level reqwest error, which is fatal anyway.
+Constructed once at startup in `crates/twitch-1337/src/main.rs` with
+`Arc::new(DoenerClient::new()?)`. `DoenerClient::new()` only fails on an
+invalid reqwest builder (OS-level TLS issue), which is fatal anyway, so the
+`?` propagation aborts startup the same way as other infrastructure-level
+errors.
 
-The doener client is consumed by:
-- the `!dpi` command handler (`crates/core/src/commands/doener.rs`)
-- the AI executor (`crates/core/src/ai/content/executor.rs`)
+`run_bot` destructures the new field. `CommandHandlerConfig` and
+`AiCommandDeps` both grow `pub doener: Arc<DoenerClient>`. The
+`run_generic_command_handler` body clones it once for the chat command and
+once for `AiCommandDeps`.
+
+Consumers:
+- `!dpi` command (`crates/core/src/commands/doener.rs`)
+- `V2Executor` inside `AiCommand` (`crates/core/src/ai/command.rs`) routes
+  `doener_index` to `crate::ai::doener_tool::execute_doener_index`.
 
 ## Error handling
 
@@ -305,26 +353,36 @@ model decides how to surface this; existing executor pattern.
   `with_base_url` + a low-timeout test-only `reqwest::Client` to keep the
   test fast.
 
-### Executor
+### Doener tool
 
-`crates/core/src/ai/content/executor.rs` — add tests beside existing ones:
+`crates/core/src/ai/doener_tool.rs#[cfg(test)] mod tests`:
 
-- `doener_index` with no city → JSON contains `"scope":"global"`.
-- `doener_index` with city → JSON contains `"scope":"city"` and hits.
-- Args parse error path covered (model passes a non-string `city`).
+- `doener_tool()` returns a definition named `"doener_index"`.
+- `execute_doener_index` with empty/missing `city` → JSON contains
+  `"scope":"global"` and the parsed stats.
+- `execute_doener_index` with a matching city → JSON contains
+  `"scope":"city"` and a non-empty `hits` array.
+- `execute_doener_index` with a query that returns 0 hits → `"hits":[]`.
+- Args parse error path (model passes `{"city": 123}`) → returned JSON
+  contains `"error":"invalid_arguments"`.
 
 Use wiremock with a base URL injected into the test `DoenerClient`.
 
 ### Command
 
-`crates/core/src/commands/doener.rs` — wiremock for the upstream, fake IRC
-client, assert the bot says the expected string for each branch.
+`crates/core/src/commands/doener.rs` — unit-test the branches via the
+`format::*` helpers (already tested) plus a wiremock-backed test using
+`TestBotBuilder` from `crates/core/tests/common/` for the global branch.
+Single happy-path integration test is enough — per-branch coverage lives in
+the format and client tests.
 
-### `ai_tools_surface_contains_search_and_read`
+### `ai_tools()` test
 
-Existing test in `tools.rs` asserts exact tool order. Update to include
-`doener_index`. Add a separate assertion that `doener_index` is **not** in
-`WEB_TOOL_NAMES`.
+Existing `ai_tools_surface_contains_search_and_read` test asserts exact tool
+order from `ai_tools()`. Do not modify it — the doener tool is not added by
+`ai_tools()`. Add a separate test in `crates/core/src/ai/doener_tool.rs`
+asserting that `is_web_tool(DOENER_TOOL_NAME)` is `false`, so a future
+refactor cannot silently regress by gating the doener tool behind `[ai.web]`.
 
 ## Out of scope
 
@@ -342,16 +400,31 @@ New:
 - `crates/core/src/doener/types.rs`
 - `crates/core/src/doener/format.rs`
 - `crates/core/src/commands/doener.rs`
+- `crates/core/src/ai/doener_tool.rs`
 - `docs/superpowers/specs/2026-05-11-donerpreisindex-design.md` (this file)
 
 Modified:
-- `crates/core/src/lib.rs` — add `pub mod doener;`, `Services.doener`, wire.
-- `crates/core/src/commands/mod.rs` — register `!dpi`.
-- `crates/core/src/config.rs` — `CooldownsConfig.doener` (default 30).
-- `crates/core/src/ai/content/tools.rs` — register `doener_index` tool def.
-- `crates/core/src/ai/content/executor.rs` — `execute_doener_index`, dispatch
-  arm, `Executor.doener` field, executor constructor sites.
+- `crates/core/src/lib.rs` — `pub mod doener;`, `Services.doener`, destructure
+  the new field, thread it through `SpawnDeps`/`spawn_handlers` to the
+  command handler.
+- `crates/core/src/ai/mod.rs` — `pub mod doener_tool;`.
+- `crates/core/src/commands/mod.rs` — `pub mod doener;`.
+- `crates/core/src/twitch/handlers/commands.rs` — `CommandHandlerConfig.doener`,
+  destructure it, push `DoenerCommand` into `cmd_list`, pass into
+  `AiCommandDeps`.
+- `crates/core/src/twitch/handlers/spawn.rs` — `SpawnDeps.doener`, plumb to
+  `CommandHandlerConfig`.
+- `crates/core/src/ai/command.rs` — `AiCommandDeps.doener`,
+  `AiCommand.doener`, push `doener_tool()` unconditionally, route the call
+  in `V2Executor::execute`.
+- `crates/core/src/config.rs` — `CooldownsConfig.doener` with
+  `default_doener_cooldown() -> 30`.
+- `crates/twitch-1337/src/main.rs` — construct `DoenerClient`, place in
+  `Services`.
 - `crates/twitch-1337/config.toml.example` — `# doener = 30` line.
+
+Cargo: no new dependencies (reqwest, serde, eyre, wiremock, async-trait
+already in tree).
 
 Cargo: no new dependencies (reqwest, serde, eyre, wiremock, async-trait
 already in tree).

--- a/docs/superpowers/specs/2026-05-11-donerpreisindex-design.md
+++ b/docs/superpowers/specs/2026-05-11-donerpreisindex-design.md
@@ -1,0 +1,357 @@
+# Dönerpreisindex command + AI tool
+
+Issue: [#178](https://github.com/Chronophylos/twitch-1337/issues/178)
+
+## Goal
+
+Expose the public dönerpreisindex dataset (https://xn--dnerindex-07a.com) to chat
+as `!dpi [city]` and to the AI as a `doener_index(city?)` tool. Single
+implementation, two surfaces.
+
+## Upstream API
+
+Two endpoints used. Both return `application/json`, no auth, public site.
+
+### `GET /api/stats.php`
+
+Global aggregate. Example response:
+
+```json
+{
+  "ok": true,
+  "total_locations": 6092,
+  "total_cities": 2202,
+  "min_price": 5.5,
+  "max_price": 9,
+  "avg_price": 6.1,
+  "locations_no_price": 5304,
+  "locations_no_price_pct": 87.1
+}
+```
+
+### `GET /api/cities.php?q=<prefix>`
+
+Fuzzy/prefix city search. Returns matched cities sorted (empirically by
+`location_count` descending). Example for `q=Han`:
+
+```json
+{
+  "ok": true,
+  "query": "Han",
+  "count": 5,
+  "cities": [
+    {"city": "Hannover",  "zip": "30459", "location_count": 51, "min_price": "6.00", "max_price": "6.00", "avg_price": "6.00"},
+    {"city": "Hanau",     "zip": "63456", "location_count": 3,  "min_price": "6.00", "max_price": "6.00", "avg_price": "6.00"},
+    {"city": "Handewitt", "zip": "24983", "location_count": 1,  "min_price": null,   "max_price": null,   "avg_price": null}
+  ]
+}
+```
+
+Prices are quoted strings; `null` when no location in the city has a price.
+`zip` is one representative postcode (not a list).
+
+### Not used
+
+- `/api/city.php?q=<exact>` — would return the full location array (324 entries
+  for Berlin). Same aggregate fields are already in `cities.php`. No reason to
+  call it.
+- `/api/locations.php` — full dump. Too large.
+
+## Module layout
+
+```
+crates/core/src/doener/
+  mod.rs        # re-exports
+  client.rs     # DoenerClient
+  types.rs      # GlobalStats, CityHit, CitiesResponse
+  format.rs     # chat formatters
+```
+
+`DoenerClient` is constructed once in `Services` (`crates/core/src/lib.rs` /
+wherever services are wired) and shared as `Arc<DoenerClient>` between the chat
+command and the AI tool executor.
+
+### `client.rs`
+
+```rust
+pub struct DoenerClient {
+    http: reqwest::Client,
+    base_url: String, // injected for tests; defaults to BASE_URL const
+}
+
+impl DoenerClient {
+    pub fn new() -> Result<Self>;                       // 5s timeout, UA "twitch-1337/<pkg_version>"
+    pub fn with_base_url(http: reqwest::Client, base_url: impl Into<String>) -> Self; // tests
+    pub async fn stats(&self) -> Result<GlobalStats>;
+    pub async fn search_cities(&self, q: &str) -> Result<Vec<CityHit>>;
+}
+```
+
+Constants in `client.rs`:
+
+```rust
+const BASE_URL: &str = "https://xn--dnerindex-07a.com";
+const TIMEOUT: Duration = Duration::from_secs(5);
+```
+
+Errors bubble up as `eyre::Result`. Caller logs with `?error` and falls back to
+a user-visible "API down" message.
+
+### `types.rs`
+
+`Deserialize`-only structs. Subset of upstream fields — drop anything the bot
+does not display.
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+pub struct GlobalStats {
+    pub total_locations: u32,
+    pub total_cities: u32,
+    pub min_price: f64,
+    pub max_price: f64,
+    pub avg_price: f64,
+    pub locations_no_price_pct: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CityHit {
+    pub city: String,
+    pub location_count: u32,
+    #[serde(deserialize_with = "deser_optional_f64_str")]
+    pub min_price: Option<f64>,
+    #[serde(deserialize_with = "deser_optional_f64_str")]
+    pub max_price: Option<f64>,
+    #[serde(deserialize_with = "deser_optional_f64_str")]
+    pub avg_price: Option<f64>,
+}
+```
+
+Prices are strings upstream (`"6.00"`) or `null`. Custom deserializer parses
+both forms; unparseable strings become `None`.
+
+`CitiesResponse` is a thin envelope with `cities: Vec<CityHit>`. The client
+returns `Vec<CityHit>` to callers — envelope stays internal.
+
+### `format.rs`
+
+Pure functions, return `String`. No I/O. Easy unit tests against fixtures.
+
+```rust
+pub fn format_global(s: &GlobalStats) -> String;
+pub fn format_city(c: &CityHit) -> String;             // for single best match
+pub fn format_did_you_mean(hits: &[CityHit]) -> String; // 2..N matches, top 3
+pub fn format_not_found(query: &str) -> String;
+```
+
+Output (German, matches `news.rs` tone, no Markdown):
+
+| Case | Output |
+|---|---|
+| global | `Döner-Index DE: 6092 Buden in 2202 Städten, ⌀ 6.10€ (5.50–9.00€). 87% ohne Preis.` |
+| city with price | `Hannover: 51 Buden, ⌀ 6.00€ (6.00–6.00€).` |
+| city no price | `Handewitt: 1 Bude, noch keine Preise.` |
+| 2–3 hits | `Meintest du: Hannover (51), Hanau (3), Handewitt (1)?` |
+| 0 hits | `FeelsDankMan keine Stadt für 'xyz' gefunden.` |
+| API down | `FeelsDankMan döner-index API down` |
+
+Numbers: avg/min/max formatted as `{:.2}€`. `location_count == 1` → `"Bude"`,
+else `"Buden"`.
+
+## Chat command
+
+`crates/core/src/commands/doener.rs` — implements the `Command` trait used by
+the existing dispatcher in `crates/core/src/commands/mod.rs`. Registered next
+to the other commands in the command-handler wiring.
+
+Trigger: `!dpi`.
+
+Behavior:
+
+1. Strip trigger, trim arg.
+2. Empty arg → `client.stats()` → `format_global`.
+3. Non-empty arg → `client.search_cities(arg)`.
+   - 0 hits → `format_not_found`.
+   - exactly 1 hit → `format_city`.
+   - 2+ hits, but the first hit's city name equals the query case-insensitively
+     → treat as 1 hit (`format_city` on the first). Avoids `!dpi Berlin`
+     returning "Meintest du: Berlin (324), Berlingerode (1)?".
+   - otherwise → `format_did_you_mean` (top 3).
+
+Cooldown: per-user, default 30s, via existing `PerUserCooldown` like `!up`.
+Add `pub doener: u64` to `CooldownsConfig` in `crates/core/src/config.rs`
+with `default_doener_cooldown() -> 30` and update the `Default` impl and the
+TOML example.
+
+`config.toml.example` `[cooldowns]` block gains:
+
+```toml
+# doener = 30   # !dpi command (default: 30)
+```
+
+No `[doener]` config block. Base URL and timeout are consts.
+
+## AI tool
+
+Registered in `crates/core/src/ai/content/tools.rs::ai_tools()` (always
+present when `[ai]` is configured — not gated by `[ai.web]`, since this is a
+first-party data tool, not generic web access).
+
+```rust
+ToolDefinition {
+    name: "doener_index".into(),
+    description: "Look up the German Döner price index from dönerindex.com. \
+        Without `city`, returns the country-wide aggregate (location count, \
+        avg/min/max price). With `city` (free-form), returns the top matching \
+        cities and their per-city aggregate. Use this for any question about \
+        Döner prices, kebab prices, or how expensive Döner is in a German city.".into(),
+    parameters: serde_json::json!({
+        "type": "object",
+        "properties": {
+            "city": {
+                "type": "string",
+                "description": "Optional city name or prefix. German spelling preferred (e.g. 'Köln', 'München')."
+            }
+        }
+    }),
+}
+```
+
+Dispatch added to `crates/core/src/ai/content/executor.rs::execute_tool_call`:
+
+```rust
+"doener_index" => match call.parse_args::<DoenerIndexArgs>() {
+    Ok(args) => self.execute_doener_index(args).await,
+    Err(err) => format_args_error(...),
+},
+```
+
+`DoenerIndexArgs { city: Option<String> }`.
+
+`execute_doener_index` returns JSON (not formatted chat strings — the model
+phrases it):
+
+```jsonc
+// no city
+{"scope": "global", "stats": { /* GlobalStats */ }}
+
+// city given, 0 hits
+{"scope": "city", "query": "xyz", "hits": []}
+
+// city given, N hits (top 5, raw aggregate)
+{"scope": "city", "query": "Han", "hits": [
+  {"city": "Hannover", "location_count": 51, "avg_price": 6.0, "min_price": 6.0, "max_price": 6.0},
+  ...
+]}
+
+// API failure
+{"error": "doener_index API unavailable"}
+```
+
+The `Executor` gains an `Arc<DoenerClient>` field; constructed in
+`Services` alongside the other shared clients.
+
+`is_web_tool` does not include `doener_index`. The tool is allowed even when
+`[ai.web]` is disabled.
+
+## Wiring
+
+`Services` (the struct holding shared deps in `crates/core/src/lib.rs`) grows:
+
+```rust
+pub doener: Arc<DoenerClient>,
+```
+
+Constructed once at startup with `DoenerClient::new()`. If construction fails
+(reqwest builder), bot startup fails — same posture as the aviation client's
+historical behavior wasn't quite this, but `DoenerClient::new` only fails on
+an invalid TLS root store / OS-level reqwest error, which is fatal anyway.
+
+The doener client is consumed by:
+- the `!dpi` command handler (`crates/core/src/commands/doener.rs`)
+- the AI executor (`crates/core/src/ai/content/executor.rs`)
+
+## Error handling
+
+Single best-effort HTTP call per invocation. No retries, no fallback host.
+
+- reqwest error / timeout / non-2xx → `Err(eyre!(...))`, logged with `?error`
+  and `endpoint = "stats"|"cities"`, query (if present).
+- `ok: false` in response body (defensive — never observed) → treated as
+  failure.
+- JSON parse failure → failure.
+
+Chat: `"FeelsDankMan döner-index API down"`. AI tool: `{"error": "..."}` — the
+model decides how to surface this; existing executor pattern.
+
+## Tests
+
+### Unit
+
+- `format.rs` against hand-written `GlobalStats` / `CityHit` fixtures, all
+  branches (global, single, plural-hits, no-hits, missing prices, singular vs
+  plural "Bude/Buden").
+- `types.rs` deserializer: stringy `"6.00"`, `null`, and a malformed string
+  all yield expected `Option<f64>`.
+
+### Client (wiremock)
+
+`crates/core/src/doener/client.rs#[cfg(test)] mod tests`:
+
+- `stats` 200 → struct populated correctly.
+- `stats` 500 → `Err`.
+- `cities` 200 with three hits → struct populated, order preserved.
+- `cities` 200 with empty `cities` → `Ok(vec![])`.
+- timeout (delayed response > 5s) → `Err`. Use a shorter test timeout via
+  `with_base_url` + a low-timeout test-only `reqwest::Client` to keep the
+  test fast.
+
+### Executor
+
+`crates/core/src/ai/content/executor.rs` — add tests beside existing ones:
+
+- `doener_index` with no city → JSON contains `"scope":"global"`.
+- `doener_index` with city → JSON contains `"scope":"city"` and hits.
+- Args parse error path covered (model passes a non-string `city`).
+
+Use wiremock with a base URL injected into the test `DoenerClient`.
+
+### Command
+
+`crates/core/src/commands/doener.rs` — wiremock for the upstream, fake IRC
+client, assert the bot says the expected string for each branch.
+
+### `ai_tools_surface_contains_search_and_read`
+
+Existing test in `tools.rs` asserts exact tool order. Update to include
+`doener_index`. Add a separate assertion that `doener_index` is **not** in
+`WEB_TOOL_NAMES`.
+
+## Out of scope
+
+- Submitting prices (`/api/submit.php` exists, would need auth/captcha).
+- Map / location-level detail (would need `city.php` + truncation logic).
+- Caching / TTL. Upstream is cheap and small; revisit if rate-limited.
+- Localization. Output is German; bot is German.
+- A `[doener]` config block. Not needed today.
+
+## Files touched
+
+New:
+- `crates/core/src/doener/mod.rs`
+- `crates/core/src/doener/client.rs`
+- `crates/core/src/doener/types.rs`
+- `crates/core/src/doener/format.rs`
+- `crates/core/src/commands/doener.rs`
+- `docs/superpowers/specs/2026-05-11-donerpreisindex-design.md` (this file)
+
+Modified:
+- `crates/core/src/lib.rs` — add `pub mod doener;`, `Services.doener`, wire.
+- `crates/core/src/commands/mod.rs` — register `!dpi`.
+- `crates/core/src/config.rs` — `CooldownsConfig.doener` (default 30).
+- `crates/core/src/ai/content/tools.rs` — register `doener_index` tool def.
+- `crates/core/src/ai/content/executor.rs` — `execute_doener_index`, dispatch
+  arm, `Executor.doener` field, executor constructor sites.
+- `crates/twitch-1337/config.toml.example` — `# doener = 30` line.
+
+Cargo: no new dependencies (reqwest, serde, eyre, wiremock, async-trait
+already in tree).


### PR DESCRIPTION
## Summary
- `!dpi` chat command: global aggregate (no arg) and fuzzy city lookup with did-you-mean fallback; exact case-insensitive match on the first hit short-circuits so `!dpi Berlin` doesn't suggest "Berlin (324), Berlingerode (1)".
- `doener_index` AI tool: exposes the same data to `!ai`; routed unconditionally so it works even when `[ai.web]` is disabled.
- Shared `DoenerClient` against https://xn--dnerindex-07a.com (`/api/stats.php` + `/api/cities.php`). No new dependencies.

Spec: `docs/superpowers/specs/2026-05-11-donerpreisindex-design.md`
Plan: `docs/superpowers/plans/2026-05-11-donerpreisindex.md`

Closes #178.

## Test plan
- [ ] CI green: fmt + clippy + nextest, cargo audit, hadolint, trivy, actionlint, zizmor, gitleaks.
- [ ] Manual smoke against real upstream:
  - `!dpi` returns the global summary.
  - `!dpi Berlin` returns the Berlin single-city line (exact-match short-circuit).
  - `!dpi Han` returns "Meintest du: Hannover (51), Hanau (3), Handewitt (1)?".
  - `!dpi nichtexistierende-stadt-xyz` returns the not-found line.
  - `!ai Wie teuer ist Döner in Hamburg?` triggers the `doener_index` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)