### PR TITLE
feat(web): follower-gated viewer tier for dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,14 @@ Others pinned to major tags; Dependabot keeps them current.
 
 `config.toml` (copy `config.toml.example`). Sections: `[twitch]`, `[pings]`, `[ai]` (optional), `[cooldowns]`, `[[schedules]]` (optional, repeatable). Schema + defaults in `config.toml.example` — treat as source of truth.
 
+**Dashboard viewer tier (added 2026-05-12):** the bot's Twitch token must
+carry `moderator:read:followers` in addition to its existing scopes — the
+web dashboard uses it to gate read-only access for followers via a sliding
+recheck. The Twitch developer-console OAuth app must additionally allow
+`user:read:follows` as a requestable scope on user logins (no
+broadcaster-token configuration is required). Startup logs a `warn` if the
+`/channels/followers` probe fails.
+
 Schedules hot-reload on save (2s debounce via notify-debouncer-mini). No restart.
 
 `twitch.ai_channel` (optional): bot also joins this channel; only `!ai` is reachable there. Every other command, the 1337 tracker, and chat-history recording skip messages from it. AI memory and chat history remain global / primary-only.

--- a/crates/core/src/aviation/tracker.rs
+++ b/crates/core/src/aviation/tracker.rs
@@ -294,10 +294,7 @@ pub struct TrackedFlightView {
 ///
 /// Pure function — no I/O, safe to call from tests without a full tracker
 /// harness.
-pub fn build_flight_view(
-    state: &FlightTrackerState,
-    now: DateTime<Utc>,
-) -> Vec<TrackedFlightView> {
+pub fn build_flight_view(state: &FlightTrackerState, now: DateTime<Utc>) -> Vec<TrackedFlightView> {
     state
         .flights
         .iter()

--- a/crates/core/src/aviation/tracker.rs
+++ b/crates/core/src/aviation/tracker.rs
@@ -270,6 +270,55 @@ pub(crate) async fn save_tracker_state(data_dir: &Path, state: &FlightTrackerSta
     }
 }
 
+/// Read projection of [`TrackedFlight`] for the web dashboard.
+///
+/// Mirrors only the fields the dashboard renders so the IRC-side struct can
+/// evolve without breaking the wire shape. Serde-ready so future callers (or
+/// JSON endpoints) can reuse it without re-projecting.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TrackedFlightView {
+    /// Human label: callsign, hex, or stringified [`FlightIdentifier`].
+    pub identifier: String,
+    pub callsign: Option<String>,
+    /// Twitch login of the user who requested tracking.
+    pub owner_login: String,
+    /// Display string of the current [`FlightPhase`].
+    pub phase: String,
+    pub altitude_ft: Option<i64>,
+    pub ground_speed_kts: Option<f64>,
+    /// Seconds since the last ADS-B update, or `None` if never seen.
+    pub last_seen_secs_ago: Option<u64>,
+}
+
+/// Converts the tracked flights in `state` into a snapshot of [`TrackedFlightView`]s.
+///
+/// Pure function — no I/O, safe to call from tests without a full tracker
+/// harness.
+pub fn build_flight_view(
+    state: &FlightTrackerState,
+    now: DateTime<Utc>,
+) -> Vec<TrackedFlightView> {
+    state
+        .flights
+        .iter()
+        .map(|f| TrackedFlightView {
+            identifier: f
+                .callsign
+                .clone()
+                .or_else(|| f.hex.clone())
+                .unwrap_or_else(|| format!("{}", f.identifier)),
+            callsign: f.callsign.clone(),
+            owner_login: f.tracked_by.clone(),
+            phase: format!("{}", f.phase),
+            altitude_ft: f.altitude_ft,
+            ground_speed_kts: f.ground_speed_kts,
+            last_seen_secs_ago: f
+                .last_seen
+                .map(|seen| (now - seen).num_seconds().max(0) as u64),
+        })
+        .collect()
+}
+
 /// Commands sent from chat command handlers to the flight tracker task.
 pub enum TrackerCommand {
     Track {
@@ -286,6 +335,14 @@ pub enum TrackerCommand {
     Status {
         identifier: Option<String>,
         reply_to: PrivmsgMessage,
+    },
+    /// Request a snapshot of all currently tracked flights.
+    ///
+    /// The handler projects [`FlightTrackerState::flights`] into
+    /// [`TrackedFlightView`] values and sends them back through `reply`.
+    /// Dropped receivers (e.g. timed-out web requests) are silently ignored.
+    Snapshot {
+        reply: tokio::sync::oneshot::Sender<Vec<TrackedFlightView>>,
     },
 }
 
@@ -1032,6 +1089,11 @@ async fn process_command<T, L>(
             reply_to,
         } => {
             handle_status(identifier.as_deref(), &reply_to, state, client, clock).await;
+        }
+        TrackerCommand::Snapshot { reply } => {
+            let now = clock.now_utc();
+            // Receiver may have dropped (web request timed out); ignore send failure.
+            let _ = reply.send(build_flight_view(state, now));
         }
     }
 }
@@ -2052,5 +2114,94 @@ mod tests {
     fn parse_rejects_empty() {
         assert!(FlightIdentifier::parse("").is_err());
         assert!(FlightIdentifier::parse("   ").is_err());
+    }
+
+    // --- build_flight_view tests ---
+
+    #[test]
+    fn build_flight_view_returns_one_entry_per_flight() {
+        let flight_a = TrackedFlight {
+            identifier: FlightIdentifier::Callsign("EZY100".to_string()),
+            callsign: Some("EZY100".to_string()),
+            phase: FlightPhase::Cruise,
+            altitude_ft: Some(35_000),
+            ground_speed_kts: Some(480.0),
+            tracked_by: "alice".to_string(),
+            last_seen: None,
+            ..tracked_flight()
+        };
+        let flight_b = TrackedFlight {
+            identifier: FlightIdentifier::Hex("4CA87D".to_string()),
+            callsign: None,
+            hex: Some("4CA87D".to_string()),
+            phase: FlightPhase::Ground,
+            altitude_ft: Some(0),
+            ground_speed_kts: Some(0.0),
+            tracked_by: "bob".to_string(),
+            last_seen: None,
+            ..tracked_flight()
+        };
+
+        let state = FlightTrackerState {
+            flights: vec![flight_a, flight_b],
+        };
+        let now = dt("2026-05-12T10:00:00Z");
+
+        let views = build_flight_view(&state, now);
+
+        assert_eq!(views.len(), 2);
+
+        assert_eq!(views[0].identifier, "EZY100");
+        assert_eq!(views[0].owner_login, "alice");
+        assert_eq!(views[0].phase, "Cruise");
+        assert_eq!(views[0].altitude_ft, Some(35_000));
+        assert!(views[0].last_seen_secs_ago.is_none());
+
+        // Hex flight: identifier falls back to hex string
+        assert_eq!(views[1].identifier, "4CA87D");
+        assert_eq!(views[1].owner_login, "bob");
+        assert_eq!(views[1].phase, "Ground");
+        assert!(views[1].callsign.is_none());
+    }
+
+    #[test]
+    fn build_flight_view_computes_last_seen_secs_ago() {
+        let seen_at = dt("2026-05-12T09:59:00Z");
+        let now = dt("2026-05-12T10:00:00Z");
+
+        let flight = TrackedFlight {
+            last_seen: Some(seen_at),
+            ..tracked_flight()
+        };
+
+        let state = FlightTrackerState {
+            flights: vec![flight],
+        };
+
+        let views = build_flight_view(&state, now);
+
+        assert_eq!(views[0].last_seen_secs_ago, Some(60));
+    }
+
+    #[test]
+    fn build_flight_view_falls_back_identifier_to_flight_identifier_display() {
+        // A flight with no callsign and no hex override — identifier comes from
+        // the FlightIdentifier Display impl.
+        let flight = TrackedFlight {
+            identifier: FlightIdentifier::Callsign("RYR42".to_string()),
+            callsign: None,
+            hex: None,
+            ..tracked_flight()
+        };
+
+        let state = FlightTrackerState {
+            flights: vec![flight],
+        };
+        let now = dt("2026-05-12T10:00:00Z");
+
+        let views = build_flight_view(&state, now);
+
+        // FlightIdentifier::Display outputs the inner string (as_str)
+        assert_eq!(views[0].identifier, "RYR42");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,7 +36,7 @@ use crate::{
     config::Configuration,
     twitch::handlers::{
         spawn::{SpawnDeps, spawn_handlers},
-        tracker_1337::{TARGET_HOUR, TARGET_MINUTE, load_leaderboard},
+        tracker_1337::{TARGET_HOUR, TARGET_MINUTE},
     },
     twitch::whisper::WhisperSender,
     util::clock::Clock,
@@ -58,7 +58,7 @@ pub use ai::chat_history::{
 };
 pub use config::{load_configuration, validate_config};
 pub use twitch::{
-    handlers::tracker_1337::PersonalBest,
+    handlers::tracker_1337::{PersonalBest, load_leaderboard},
     setup::{setup_and_verify_twitch_client, setup_twitch_client},
     token_storage::FileBasedTokenStorage,
 };
@@ -106,6 +106,24 @@ pub struct Services {
     /// the *same* per-path mutex map. Two independent stores against the
     /// same on-disk tree would silently race past each other's locks.
     pub memory_store: crate::ai::memory::store::MemoryStore,
+    /// Shared 1337 leaderboard. Created by the bin before the web spawner so
+    /// the same `Arc` is handed to both `WebState` and the IRC tracker handler
+    /// (via `SpawnDeps`). `run_bot` moves this into `SpawnDeps`; tests pass an
+    /// empty map.
+    pub leaderboard: Arc<
+        tokio::sync::RwLock<
+            std::collections::HashMap<String, crate::twitch::handlers::tracker_1337::PersonalBest>,
+        >,
+    >,
+    /// Sender half of the flight-tracker mpsc channel, wrapped in `Arc` so it
+    /// can be cheaply cloned into `WebState`. `None` when aviation is disabled.
+    /// The matching receiver lives in `aviation_tracker_rx` and is consumed by
+    /// `spawn_handlers` to start the flight-tracker task.
+    pub aviation_tracker_tx:
+        Option<Arc<tokio::sync::mpsc::Sender<crate::aviation::TrackerCommand>>>,
+    /// Receiver half of the flight-tracker mpsc channel. `None` when aviation
+    /// is disabled. Consumed exactly once by `spawn_handlers`.
+    pub aviation_tracker_rx: Option<tokio::sync::mpsc::Receiver<crate::aviation::TrackerCommand>>,
 }
 
 pub type WebSpawner =
@@ -139,11 +157,16 @@ where
         web_spawner,
         ping_manager,
         memory_store,
+        leaderboard,
+        aviation_tracker_tx,
+        aviation_tracker_rx,
     } = services;
 
-    let schedules_enabled = !config.schedules.is_empty();
+    // Clone the sender out of the Arc for SpawnDeps (which holds a plain mpsc::Sender).
+    // `tokio::sync::mpsc::Sender<T>` is `Clone`, so this is a cheap reference-count bump.
+    let aviation_tracker_tx_inner = aviation_tracker_tx.as_ref().map(|a| (**a).clone());
 
-    let leaderboard = Arc::new(tokio::sync::RwLock::new(load_leaderboard(&data_dir).await));
+    let schedules_enabled = !config.schedules.is_empty();
 
     let suspension_manager = Arc::new(suspend::SuspensionManager::new());
 
@@ -192,6 +215,8 @@ where
         whisper,
         aviation,
         aviation_for_commands,
+        aviation_tracker_tx: aviation_tracker_tx_inner,
+        aviation_tracker_rx,
         emote_provider,
         irc_connected: irc_connected.clone(),
     });

--- a/crates/core/src/twitch/handlers/spawn.rs
+++ b/crates/core/src/twitch/handlers/spawn.rs
@@ -85,6 +85,13 @@ pub(crate) struct SpawnDeps<T: Transport, L: LoginCredentials> {
     // Flight tracker.
     pub aviation: Option<AviationClient>,
     pub aviation_for_commands: Option<AviationClient>,
+    /// Pre-created sender half of the flight-tracker channel. Must be `Some`
+    /// when `aviation` is `Some`, and `None` otherwise.
+    pub aviation_tracker_tx: Option<mpsc::Sender<aviation::TrackerCommand>>,
+    /// Pre-created receiver half of the flight-tracker channel. Consumed by
+    /// `spawn_handlers` to start the flight-tracker task. Must be `Some` when
+    /// `aviation` is `Some`, and `None` otherwise.
+    pub aviation_tracker_rx: Option<mpsc::Receiver<aviation::TrackerCommand>>,
 
     // AI emote grounding.
     pub emote_provider: Option<Arc<crate::twitch::seventv::SevenTvEmoteProvider>>,
@@ -117,6 +124,8 @@ where
         whisper,
         aviation,
         aviation_for_commands,
+        aviation_tracker_tx,
+        aviation_tracker_rx,
         emote_provider,
         irc_connected,
     } = deps;
@@ -124,9 +133,11 @@ where
     let schedules_enabled = !config.schedules.is_empty();
 
     // Flight tracker: spawned first so `tracker_tx` exists for the command handler.
-    let (tracker_tx, flight_tracker) = match aviation {
-        Some(av) => {
-            let (tx, rx) = mpsc::channel::<aviation::TrackerCommand>(32);
+    // The channel is pre-created by the caller (production: main.rs; tests: TestBotBuilder)
+    // so the sender Arc can be shared with WebState before handlers are spawned.
+    let (tracker_tx, flight_tracker) = match (aviation, aviation_tracker_rx) {
+        (Some(av), Some(rx)) => {
+            let tx = aviation_tracker_tx.expect("tracker_tx must be Some when aviation is Some");
             let handle = tokio::spawn({
                 let client = client.clone();
                 let channel = config.twitch.channel.clone();
@@ -138,7 +149,7 @@ where
             });
             (Some(tx), handle)
         }
-        None => (None, tokio::spawn(std::future::pending::<()>())),
+        _ => (None, tokio::spawn(std::future::pending::<()>())),
     };
 
     let (broadcast_tx, _) = broadcast::channel::<ServerMessage>(100);

--- a/crates/core/tests/common/test_bot.rs
+++ b/crates/core/tests/common/test_bot.rs
@@ -21,7 +21,7 @@ use twitch_1337::{
     PersonalBest, Services,
     aviation::AviationClient,
     config::{AiConfig, Configuration},
-    run_bot,
+    load_leaderboard, run_bot,
     twitch::whisper::{self, WhisperError, WhisperSender},
 };
 use twitch_irc::login::StaticLoginCredentials;
@@ -248,6 +248,11 @@ impl TestBotBuilder {
             None
         };
 
+        let (aviation_tracker_tx, aviation_tracker_rx) = {
+            let (tx, rx) = tokio::sync::mpsc::channel::<twitch_1337::aviation::TrackerCommand>(32);
+            (Some(Arc::new(tx)), Some(rx))
+        };
+
         let services = Services {
             clock: clock.clone(),
             llm: self
@@ -269,6 +274,11 @@ impl TestBotBuilder {
             web_spawner,
             ping_manager,
             memory_store,
+            leaderboard: Arc::new(tokio::sync::RwLock::new(
+                load_leaderboard(data_dir.path()).await,
+            )),
+            aviation_tracker_tx,
+            aviation_tracker_rx,
         };
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -658,5 +668,7 @@ fn build_test_web_state(
         ping_manager,
         memory_store,
         signed_key,
+        leaderboard: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+        tracker_tx: None,
     }
 }

--- a/crates/core/tests/common/test_bot.rs
+++ b/crates/core/tests/common/test_bot.rs
@@ -621,6 +621,9 @@ fn build_test_web_state(
         async fn is_moderator(&self, _b: &str, _u: &str) -> eyre::Result<bool> {
             Ok(false)
         }
+        async fn is_follower(&self, _b: &str, _u: &str) -> eyre::Result<bool> {
+            Ok(false)
+        }
     }
 
     let web_clock = Arc::new(WebSystemClock);

--- a/crates/core/tests/common/test_bot.rs
+++ b/crates/core/tests/common/test_bot.rs
@@ -638,7 +638,7 @@ fn build_test_web_state(
         public_url: config.web.public_url.clone(),
         session_secret: config.web.session_secret.clone(),
         session_ttl: config.web.session_ttl,
-        mod_check_refresh: config.web.mod_check_refresh,
+        role_check_refresh: config.web.mod_check_refresh,
     });
     let signed_key = tower_cookies::Key::from(&[0x42u8; 64]);
     twitch_1337_web::WebState {

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -201,7 +201,11 @@ async fn build_web_spawner(
     // (broadcaster_id, broadcaster_id) — a benign self-probe that returns 200
     // with `total=0` when scoped correctly, and 401/403 when the scope is
     // missing. Log a warn so a deployer sees the failure before viewers do.
-    match helix.as_ref().is_follower(&broadcaster.id, &broadcaster.id).await {
+    match helix
+        .as_ref()
+        .is_follower(&broadcaster.id, &broadcaster.id)
+        .await
+    {
         Ok(_) => tracing::info!(
             target: "twitch_1337",
             "helix /channels/followers reachable with current bot scopes",

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -190,7 +190,7 @@ async fn build_web_spawner(
         public_url: config.web.public_url.clone(),
         session_secret: config.web.session_secret.clone(),
         session_ttl: config.web.session_ttl,
-        mod_check_refresh: config.web.mod_check_refresh,
+        role_check_refresh: config.web.mod_check_refresh,
     });
 
     let signed_key = twitch_1337_web::state::derive_session_key(&config.web.session_secret)?;

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -9,10 +10,10 @@ use secrecy::ExposeSecret as _;
 use tokio::sync::oneshot;
 use tracing::info;
 use twitch_1337_core::{
-    AuthenticatedLoginCredentials, Services,
+    AuthenticatedLoginCredentials, PersonalBest, Services,
     ai::{command::memory_caps_from_config, memory::store::MemoryStore},
     aviation, doener, ensure_data_dir, get_data_dir, install_crypto_provider, install_tracing,
-    llm_factory, load_configuration,
+    llm_factory, load_configuration, load_leaderboard,
     ping::PingManager,
     run_bot, setup_and_verify_twitch_client,
     twitch::whisper,
@@ -99,6 +100,21 @@ pub async fn main() -> Result<()> {
             .await
             .wrap_err("open memory store")?;
 
+    // Load the leaderboard before building the web spawner so the same Arc
+    // can be shared with WebState (dashboard read) and the IRC tracker (writes).
+    let leaderboard: Arc<tokio::sync::RwLock<HashMap<String, PersonalBest>>> = Arc::new(
+        tokio::sync::RwLock::new(load_leaderboard(&get_data_dir()).await),
+    );
+
+    // Pre-create the flight-tracker mpsc channel when aviation is enabled so
+    // the sender Arc can be wired into WebState before the handlers are spawned.
+    let (aviation_tracker_tx, aviation_tracker_rx) = if aviation_client.is_some() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<aviation::TrackerCommand>(32);
+        (Some(Arc::new(tx)), Some(rx))
+    } else {
+        (None, None)
+    };
+
     let web_spawner = if config.web.enabled {
         let credentials_for_web = credentials.clone();
         Some(
@@ -108,6 +124,8 @@ pub async fn main() -> Result<()> {
                 irc_connected.clone(),
                 ping_manager.clone(),
                 memory_store.clone(),
+                leaderboard.clone(),
+                aviation_tracker_tx.clone(),
             )
             .await?,
         )
@@ -127,6 +145,9 @@ pub async fn main() -> Result<()> {
         web_spawner,
         ping_manager,
         memory_store,
+        leaderboard,
+        aviation_tracker_tx,
+        aviation_tracker_rx,
     };
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -148,6 +169,8 @@ async fn build_web_spawner(
     irc_connected: Arc<AtomicBool>,
     ping_manager: Arc<tokio::sync::RwLock<PingManager>>,
     memory_store: MemoryStore,
+    leaderboard: Arc<tokio::sync::RwLock<HashMap<String, PersonalBest>>>,
+    tracker_tx: Option<Arc<tokio::sync::mpsc::Sender<aviation::TrackerCommand>>>,
 ) -> Result<twitch_1337::WebSpawner> {
     let bind_addr: std::net::SocketAddr = config
         .web
@@ -220,6 +243,8 @@ async fn build_web_spawner(
         ping_manager,
         memory_store,
         signed_key,
+        leaderboard,
+        tracker_tx,
     };
 
     Ok(Box::new(move |shutdown| {

--- a/crates/twitch-1337/src/main.rs
+++ b/crates/twitch-1337/src/main.rs
@@ -196,6 +196,24 @@ async fn build_web_spawner(
         .wrap_err("resolve broadcaster id")?
         .ok_or_else(|| eyre!("channel `{}` not found on twitch", config.twitch.channel))?;
 
+    // One-shot scope probe. The bot token needs `moderator:read:followers` for
+    // the viewer-tier sliding follower recheck. Call /channels/followers with
+    // (broadcaster_id, broadcaster_id) — a benign self-probe that returns 200
+    // with `total=0` when scoped correctly, and 401/403 when the scope is
+    // missing. Log a warn so a deployer sees the failure before viewers do.
+    match helix.as_ref().is_follower(&broadcaster.id, &broadcaster.id).await {
+        Ok(_) => tracing::info!(
+            target: "twitch_1337",
+            "helix /channels/followers reachable with current bot scopes",
+        ),
+        Err(e) => tracing::warn!(
+            target: "twitch_1337",
+            error = ?e,
+            "helix /channels/followers probe failed — viewer-tier sliding rechecks \
+             will degrade. Reissue the bot token with `moderator:read:followers`.",
+        ),
+    }
+
     let oauth = Arc::new(twitch_1337_web::auth::OAuthCtx::new(
         config.twitch.client_id.expose_secret(),
         &config.twitch.client_secret,

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -475,6 +475,12 @@ kbd {
 .table.state .thead, .table.state .tr {
   grid-template-columns: 1.6fr 1.4fr 1.4fr 1.2fr 80px;
 }
+.table.leaderboard .thead, .table.leaderboard .tr {
+  grid-template-columns: 60px 1.6fr 1fr 1fr;
+}
+.table.flights .thead, .table.flights .tr {
+  grid-template-columns: 1fr 1fr 1.2fr 1fr 1fr 1fr 0.8fr;
+}
 .thead {
   padding: 10px 18px;
   border-bottom: 1px solid var(--line);

--- a/crates/web/src/auth/mod.rs
+++ b/crates/web/src/auth/mod.rs
@@ -18,4 +18,4 @@ pub(crate) mod routes;
 // silently admit form-only POSTs by design, so exporting it would mislead
 // callers into thinking it provides blanket protection.
 pub use role::Role;
-pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod};
+pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod, viewer_method_guard};

--- a/crates/web/src/auth/mod.rs
+++ b/crates/web/src/auth/mod.rs
@@ -1,14 +1,14 @@
-//! Web auth: OAuth + session + CSRF + mod-gate plumbing.
+//! Web auth: OAuth + session + CSRF + role-gate plumbing.
 //!
 //! Module map:
 //! - [`session`]: in-memory session table (TTL + sliding refresh)
 //! - [`csrf`]: hex-encoded double-submit token helpers
-//! - [`mod_check`]: hidden_admins → broadcaster → helix moderators
+//! - [`role_check`]: hidden_admins → broadcaster → helix moderators
 //! - [`routes`]: login / callback / logout handlers + middleware
 
 pub mod csrf;
-pub mod mod_check;
 pub mod role;
+pub mod role_check;
 pub mod session;
 
 pub(crate) mod routes;

--- a/crates/web/src/auth/mod.rs
+++ b/crates/web/src/auth/mod.rs
@@ -18,4 +18,4 @@ pub(crate) mod routes;
 // silently admit form-only POSTs by design, so exporting it would mislead
 // callers into thinking it provides blanket protection.
 pub use role::Role;
-pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod, viewer_method_guard};
+pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod, require_role, viewer_method_guard};

--- a/crates/web/src/auth/mod.rs
+++ b/crates/web/src/auth/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod csrf;
 pub mod mod_check;
+pub mod role;
 pub mod session;
 
 pub(crate) mod routes;
@@ -16,4 +17,5 @@ pub(crate) mod routes;
 // per-handler (form-field `_csrf` path); the header-path middleware would
 // silently admit form-only POSTs by design, so exporting it would mislead
 // callers into thinking it provides blanket protection.
+pub use role::Role;
 pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod};

--- a/crates/web/src/auth/mod.rs
+++ b/crates/web/src/auth/mod.rs
@@ -18,4 +18,6 @@ pub(crate) mod routes;
 // silently admit form-only POSTs by design, so exporting it would mislead
 // callers into thinking it provides blanket protection.
 pub use role::Role;
-pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod, require_role, viewer_method_guard};
+pub use routes::{
+    CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod, require_role, viewer_method_guard,
+};

--- a/crates/web/src/auth/role.rs
+++ b/crates/web/src/auth/role.rs
@@ -1,0 +1,37 @@
+//! Authenticated dashboard tier.
+//!
+//! Ordered so `session.role >= required` is the gate predicate; inserting
+//! a new tier later means slotting it in at the right ordinal.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Role {
+    Viewer,
+    Mod,
+}
+
+impl Role {
+    pub fn label(self) -> &'static str {
+        match self {
+            Role::Viewer => "viewer",
+            Role::Mod => "mod",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Role;
+
+    #[test]
+    fn viewer_is_lower_than_mod() {
+        assert!(Role::Viewer < Role::Mod);
+        assert!(Role::Mod >= Role::Viewer);
+        assert!(Role::Viewer >= Role::Viewer);
+    }
+
+    #[test]
+    fn labels_match_tracing_fields() {
+        assert_eq!(Role::Viewer.label(), "viewer");
+        assert_eq!(Role::Mod.label(), "mod");
+    }
+}

--- a/crates/web/src/auth/role_check.rs
+++ b/crates/web/src/auth/role_check.rs
@@ -85,6 +85,18 @@ async fn is_moderator_with_user_token(
     .await
 }
 
+pub async fn check_is_follower(
+    helix: &dyn HelixClient,
+    broadcaster_id: &str,
+    user_id: &str,
+) -> eyre::Result<GateOutcome> {
+    if helix.is_follower(broadcaster_id, user_id).await? {
+        Ok(GateOutcome::Allow)
+    } else {
+        Ok(GateOutcome::Deny)
+    }
+}
+
 /// Variant used during the OAuth callback to check follower status using the
 /// viewer's own user token. Calls `GET /helix/channels/followed` (scope
 /// `user:read:follows`) and returns `Allow` iff `total > 0`.

--- a/crates/web/src/auth/role_check.rs
+++ b/crates/web/src/auth/role_check.rs
@@ -17,11 +17,7 @@ pub enum GateOutcome {
 
 /// Hidden_admins / broadcaster shortcuts shared by both check variants. Returns
 /// `Some(Allow)` iff a shortcut applies; `None` means the helix lookup runs.
-fn shortcut(
-    user_id: &str,
-    broadcaster_id: &str,
-    hidden_admins: &[String],
-) -> Option<GateOutcome> {
+fn shortcut(user_id: &str, broadcaster_id: &str, hidden_admins: &[String]) -> Option<GateOutcome> {
     if hidden_admins.iter().any(|s| s == user_id) || user_id == broadcaster_id {
         Some(GateOutcome::Allow)
     } else {

--- a/crates/web/src/auth/role_check.rs
+++ b/crates/web/src/auth/role_check.rs
@@ -84,3 +84,29 @@ async fn is_moderator_with_user_token(
     )
     .await
 }
+
+/// Variant used during the OAuth callback to check follower status using the
+/// viewer's own user token. Calls `GET /helix/channels/followed` (scope
+/// `user:read:follows`) and returns `Allow` iff `total > 0`.
+pub async fn check_is_follower_with_token(
+    state: &WebState,
+    user_id: &str,
+    user_access_token: &str,
+    broadcaster_id: &str,
+) -> eyre::Result<GateOutcome> {
+    if crate::helix::user_follows_channel(
+        &state.oauth.http,
+        "https://api.twitch.tv",
+        state.client_id.expose_secret(),
+        user_access_token,
+        user_id,
+        broadcaster_id,
+        "helix channels/followed (user token)",
+    )
+    .await?
+    {
+        Ok(GateOutcome::Allow)
+    } else {
+        Ok(GateOutcome::Deny)
+    }
+}

--- a/crates/web/src/auth/role_check.rs
+++ b/crates/web/src/auth/role_check.rs
@@ -1,4 +1,4 @@
-//! Mod-gate decision: hidden_admins → broadcaster → helix moderators.
+//! Role-gate decision: hidden_admins → broadcaster → helix moderators.
 //!
 //! Hidden admins (configured in `[twitch].hidden_admins`) short-circuit the
 //! helix lookup so a debugging account always retains access. The broadcaster
@@ -10,7 +10,7 @@ use crate::helix::HelixClient;
 use crate::state::WebState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ModCheckOutcome {
+pub enum GateOutcome {
     Allow,
     Deny,
 }
@@ -21,9 +21,9 @@ fn shortcut(
     user_id: &str,
     broadcaster_id: &str,
     hidden_admins: &[String],
-) -> Option<ModCheckOutcome> {
+) -> Option<GateOutcome> {
     if hidden_admins.iter().any(|s| s == user_id) || user_id == broadcaster_id {
-        Some(ModCheckOutcome::Allow)
+        Some(GateOutcome::Allow)
     } else {
         None
     }
@@ -34,14 +34,14 @@ pub async fn check_is_mod(
     user_id: &str,
     broadcaster_id: &str,
     hidden_admins: &[String],
-) -> eyre::Result<ModCheckOutcome> {
+) -> eyre::Result<GateOutcome> {
     if let Some(o) = shortcut(user_id, broadcaster_id, hidden_admins) {
         return Ok(o);
     }
     if helix.is_moderator(broadcaster_id, user_id).await? {
-        Ok(ModCheckOutcome::Allow)
+        Ok(GateOutcome::Allow)
     } else {
-        Ok(ModCheckOutcome::Deny)
+        Ok(GateOutcome::Deny)
     }
 }
 
@@ -56,14 +56,14 @@ pub async fn check_is_mod_with_token(
     user_access_token: &str,
     broadcaster_id: &str,
     hidden_admins: &[String],
-) -> eyre::Result<ModCheckOutcome> {
+) -> eyre::Result<GateOutcome> {
     if let Some(o) = shortcut(user_id, broadcaster_id, hidden_admins) {
         return Ok(o);
     }
     if is_moderator_with_user_token(user_id, user_access_token, broadcaster_id, state).await? {
-        Ok(ModCheckOutcome::Allow)
+        Ok(GateOutcome::Allow)
     } else {
-        Ok(ModCheckOutcome::Deny)
+        Ok(GateOutcome::Deny)
     }
 }
 

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -424,6 +424,17 @@ async fn fetch_caller_user(
         .ok_or_else(|| eyre!("helix /users returned empty data array"))
 }
 
+pub async fn viewer_method_guard(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<axum::response::Response, WebError> {
+    use axum::http::Method;
+    match *req.method() {
+        Method::GET | Method::HEAD => Ok(next.run(req).await),
+        _ => Err(WebError::MethodNotAllowed),
+    }
+}
+
 pub async fn require_mod(
     State(state): State<WebState>,
     cookies: Cookies,

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -267,6 +267,7 @@ async fn auth_start(
         .authorize_url(move || csrf_for_url.clone())
         .add_scope(Scope::new("user:read:email".to_owned()))
         .add_scope(Scope::new("user:read:moderated_channels".to_owned()))
+        .add_scope(Scope::new("user:read:follows".to_owned()))
         .url();
     Redirect::to(auth_url.as_ref()).into_response()
 }
@@ -320,12 +321,10 @@ async fn callback(
         .await
         .map_err(|e| WebError::OAuthExchange(e.wrap_err("user lookup")))?;
 
-    // Initial mod check uses the user's own access token (granted
-    // `user:read:moderated_channels` via OAuth scope), so the bot's IRC
-    // token does not need extra scopes. The require_mod middleware
-    // re-checks via the bot token; on failure there it log+admits to
-    // avoid lockout.
-    match crate::auth::role_check::check_is_mod_with_token(
+    // Initial role check uses the user's own access token (granted
+    // `user:read:moderated_channels` and `user:read:follows` via OAuth
+    // scopes). Try mod first, then follower, then deny.
+    let role = match crate::auth::role_check::check_is_mod_with_token(
         &state,
         &me.id,
         &user_token,
@@ -335,16 +334,33 @@ async fn callback(
     .await
     .map_err(|e| WebError::OAuthExchange(e.wrap_err("mod check")))?
     {
-        GateOutcome::Allow => {}
-        GateOutcome::Deny => {
-            tracing::info!(target: "twitch_1337_web", user_id=%me.id, user_login=%me.login, action="login", result="denied");
-            return Err(WebError::Forbidden);
-        }
-    }
+        GateOutcome::Allow => crate::auth::role::Role::Mod,
+        GateOutcome::Deny => match crate::auth::role_check::check_is_follower_with_token(
+            &state,
+            &me.id,
+            &user_token,
+            &state.broadcaster_id,
+        )
+        .await
+        .map_err(|e| WebError::OAuthExchange(e.wrap_err("follower check")))?
+        {
+            GateOutcome::Allow => crate::auth::role::Role::Viewer,
+            GateOutcome::Deny => {
+                tracing::info!(
+                    target: "twitch_1337_web",
+                    user_id = %me.id,
+                    user_login = %me.login,
+                    action = "login",
+                    result = "denied",
+                );
+                return Err(WebError::Forbidden);
+            }
+        },
+    };
 
     let (sid, csrf_value) = state
         .sessions
-        .insert(me.id.clone(), me.login.clone(), crate::auth::role::Role::Mod)
+        .insert(me.id.clone(), me.login.clone(), role)
         .map_err(WebError::Internal)?;
     issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_value, true);
 
@@ -359,6 +375,7 @@ async fn callback(
         target: "twitch_1337_web",
         user_id = %me.id,
         user_login = %me.login,
+        role = role.label(),
         next_path = %next_path,
         action = "login",
         result = "ok",

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -27,7 +27,7 @@ use serde::Deserialize;
 use tower_cookies::cookie::SameSite;
 use tower_cookies::{Cookie, Cookies, Key};
 
-use crate::auth::mod_check::{ModCheckOutcome, check_is_mod};
+use crate::auth::role_check::{GateOutcome, check_is_mod};
 use crate::error::WebError;
 use crate::state::WebState;
 
@@ -325,7 +325,7 @@ async fn callback(
     // token does not need extra scopes. The require_mod middleware
     // re-checks via the bot token; on failure there it log+admits to
     // avoid lockout.
-    match crate::auth::mod_check::check_is_mod_with_token(
+    match crate::auth::role_check::check_is_mod_with_token(
         &state,
         &me.id,
         &user_token,
@@ -335,8 +335,8 @@ async fn callback(
     .await
     .map_err(|e| WebError::OAuthExchange(e.wrap_err("mod check")))?
     {
-        ModCheckOutcome::Allow => {}
-        ModCheckOutcome::Deny => {
+        GateOutcome::Allow => {}
+        GateOutcome::Deny => {
             tracing::info!(target: "twitch_1337_web", user_id=%me.id, user_login=%me.login, action="login", result="denied");
             return Err(WebError::Forbidden);
         }
@@ -458,8 +458,8 @@ pub async fn require_mod(
         )
         .await
         {
-            Ok(ModCheckOutcome::Allow) => state.sessions.record_role_check(sid_cookie.value()),
-            Ok(ModCheckOutcome::Deny) => {
+            Ok(GateOutcome::Allow) => state.sessions.record_role_check(sid_cookie.value()),
+            Ok(GateOutcome::Deny) => {
                 state.sessions.drop_session(sid_cookie.value());
                 tracing::info!(target: "twitch_1337_web", user_id=%session.user_id, action="mod_recheck", result="denied");
                 return Err(WebError::Forbidden);

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -344,7 +344,7 @@ async fn callback(
 
     let (sid, csrf_value) = state
         .sessions
-        .insert(me.id.clone(), me.login.clone())
+        .insert(me.id.clone(), me.login.clone(), crate::auth::role::Role::Mod)
         .map_err(WebError::Internal)?;
     issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_value, true);
 
@@ -446,10 +446,10 @@ pub async fn require_mod(
 
     let now = state.clock.now();
     let elapsed = now
-        .signed_duration_since(session.last_mod_check)
+        .signed_duration_since(session.last_role_check)
         .to_std()
         .unwrap_or_default();
-    if elapsed > state.config.mod_check_refresh {
+    if elapsed > state.config.role_check_refresh {
         match check_is_mod(
             state.helix.as_ref(),
             &session.user_id,
@@ -458,7 +458,7 @@ pub async fn require_mod(
         )
         .await
         {
-            Ok(ModCheckOutcome::Allow) => state.sessions.record_mod_check(sid_cookie.value()),
+            Ok(ModCheckOutcome::Allow) => state.sessions.record_role_check(sid_cookie.value()),
             Ok(ModCheckOutcome::Deny) => {
                 state.sessions.drop_session(sid_cookie.value());
                 tracing::info!(target: "twitch_1337_web", user_id=%session.user_id, action="mod_recheck", result="denied");

--- a/crates/web/src/auth/routes.rs
+++ b/crates/web/src/auth/routes.rs
@@ -27,7 +27,7 @@ use serde::Deserialize;
 use tower_cookies::cookie::SameSite;
 use tower_cookies::{Cookie, Cookies, Key};
 
-use crate::auth::role_check::{GateOutcome, check_is_mod};
+use crate::auth::role_check::{GateOutcome, check_is_follower, check_is_mod};
 use crate::error::WebError;
 use crate::state::WebState;
 
@@ -435,7 +435,8 @@ pub async fn viewer_method_guard(
     }
 }
 
-pub async fn require_mod(
+pub async fn require_role(
+    min: crate::auth::role::Role,
     State(state): State<WebState>,
     cookies: Cookies,
     mut req: Request,
@@ -455,31 +456,53 @@ pub async fn require_mod(
         .get_and_touch(sid_cookie.value())
         .ok_or_else(unauth)?;
 
+    if session.role < min {
+        return Err(WebError::Forbidden);
+    }
+
     let now = state.clock.now();
     let elapsed = now
         .signed_duration_since(session.last_role_check)
         .to_std()
         .unwrap_or_default();
     if elapsed > state.config.role_check_refresh {
-        match check_is_mod(
-            state.helix.as_ref(),
-            &session.user_id,
-            &state.broadcaster_id,
-            &state.hidden_admins,
-        )
-        .await
-        {
+        let outcome = match session.role {
+            crate::auth::role::Role::Mod => {
+                check_is_mod(
+                    state.helix.as_ref(),
+                    &session.user_id,
+                    &state.broadcaster_id,
+                    state.hidden_admins.as_ref(),
+                )
+                .await
+            }
+            crate::auth::role::Role::Viewer => {
+                check_is_follower(
+                    state.helix.as_ref(),
+                    &state.broadcaster_id,
+                    &session.user_id,
+                )
+                .await
+            }
+        };
+        match outcome {
             Ok(GateOutcome::Allow) => state.sessions.record_role_check(sid_cookie.value()),
             Ok(GateOutcome::Deny) => {
                 state.sessions.drop_session(sid_cookie.value());
-                tracing::info!(target: "twitch_1337_web", user_id=%session.user_id, action="mod_recheck", result="denied");
+                tracing::info!(
+                    target: "twitch_1337_web",
+                    user_id = %session.user_id,
+                    role = session.role.label(),
+                    action = "role_recheck",
+                    result = "denied",
+                );
                 return Err(WebError::Forbidden);
             }
             Err(e) => {
                 tracing::warn!(
                     target: "twitch_1337_web",
                     error = ?e,
-                    "mod refresh failed; admitting on stale check"
+                    "role refresh failed; admitting on stale check"
                 );
             }
         }
@@ -487,6 +510,15 @@ pub async fn require_mod(
 
     req.extensions_mut().insert(session);
     Ok(next.run(req).await)
+}
+
+pub async fn require_mod(
+    state: State<WebState>,
+    cookies: Cookies,
+    req: Request,
+    next: Next,
+) -> Result<Response, WebError> {
+    require_role(crate::auth::role::Role::Mod, state, cookies, req, next).await
 }
 
 #[cfg(test)]

--- a/crates/web/src/auth/session.rs
+++ b/crates/web/src/auth/session.rs
@@ -30,6 +30,12 @@ pub struct Session {
     pub csrf_value: [u8; 32],
 }
 
+impl Session {
+    pub fn is_mod(&self) -> bool {
+        self.role == Role::Mod
+    }
+}
+
 pub struct SessionTable {
     inner: RwLock<HashMap<SessionId, Session>>,
     ttl: Duration,

--- a/crates/web/src/auth/session.rs
+++ b/crates/web/src/auth/session.rs
@@ -2,8 +2,8 @@
 //!
 //! Sessions sit behind a `RwLock<HashMap>` keyed by a 64-hex-char random
 //! id. TTL is sliding: every successful `get_and_touch` bumps `last_seen`,
-//! so an active user stays logged in indefinitely. The mod-gate middleware
-//! also stamps `last_mod_check` so it knows when to re-verify the helix
+//! so an active user stays logged in indefinitely. The role-gate middleware
+//! also stamps `last_role_check` so it knows when to re-verify the helix
 //! moderator list.
 
 use std::collections::HashMap;
@@ -14,6 +14,7 @@ use chrono::{DateTime, Utc};
 use eyre::Result;
 use rand::Rng as _;
 
+use crate::auth::role::Role;
 use crate::clock::Clock;
 
 pub type SessionId = String;
@@ -22,9 +23,10 @@ pub type SessionId = String;
 pub struct Session {
     pub user_id: String,
     pub user_login: String,
+    pub role: Role,
     pub issued_at: DateTime<Utc>,
     pub last_seen: DateTime<Utc>,
-    pub last_mod_check: DateTime<Utc>,
+    pub last_role_check: DateTime<Utc>,
     pub csrf_value: [u8; 32],
 }
 
@@ -46,7 +48,12 @@ impl SessionTable {
     /// Returns the new session id together with the freshly-generated csrf
     /// value so the OAuth callback can set both cookies without a second
     /// lookup against the table.
-    pub fn insert(&self, user_id: String, user_login: String) -> Result<(SessionId, [u8; 32])> {
+    pub fn insert(
+        &self,
+        user_id: String,
+        user_login: String,
+        role: Role,
+    ) -> Result<(SessionId, [u8; 32])> {
         let now = self.clock.now();
         let mut rng = rand::rng();
         let mut id_bytes = [0u8; 32];
@@ -59,9 +66,10 @@ impl SessionTable {
             Session {
                 user_id,
                 user_login,
+                role,
                 issued_at: now,
                 last_seen: now,
-                last_mod_check: now,
+                last_role_check: now,
                 csrf_value: csrf,
             },
         );
@@ -85,10 +93,10 @@ impl SessionTable {
         self.inner.write().unwrap().remove(id);
     }
 
-    pub fn record_mod_check(&self, id: &str) {
+    pub fn record_role_check(&self, id: &str) {
         let now = self.clock.now();
         if let Some(s) = self.inner.write().unwrap().get_mut(id) {
-            s.last_mod_check = now;
+            s.last_role_check = now;
         }
     }
 }

--- a/crates/web/src/bin/web_dev.rs
+++ b/crates/web/src/bin/web_dev.rs
@@ -17,6 +17,7 @@
 //! against the same dev-data the production bot is actively writing to
 //! unless you're aware of that.
 
+use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -103,6 +104,8 @@ async fn main() -> Result<()> {
         ping_manager: Arc::new(RwLock::new(pings)),
         memory_store,
         signed_key,
+        leaderboard: Arc::new(RwLock::new(HashMap::new())),
+        tracker_tx: None,
     };
 
     let listener = bind(bind_addr).await?;

--- a/crates/web/src/bin/web_dev.rs
+++ b/crates/web/src/bin/web_dev.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
         public_url,
         session_secret,
         session_ttl,
-        mod_check_refresh: Duration::from_secs(300),
+        role_check_refresh: Duration::from_secs(300),
     });
 
     let helix: Arc<dyn HelixClient> = Arc::new(StubHelix);

--- a/crates/web/src/config.rs
+++ b/crates/web/src/config.rs
@@ -14,5 +14,5 @@ pub struct WebConfig {
     pub public_url: String,
     pub session_secret: SecretString,
     pub session_ttl: Duration,
-    pub mod_check_refresh: Duration,
+    pub role_check_refresh: Duration,
 }

--- a/crates/web/src/dev.rs
+++ b/crates/web/src/dev.rs
@@ -50,7 +50,11 @@ async fn login(
 ) -> Redirect {
     let (sid, csrf_bytes) = state
         .sessions
-        .insert(DEV_USER_ID.to_owned(), DEV_USER_LOGIN.to_owned())
+        .insert(
+            DEV_USER_ID.to_owned(),
+            DEV_USER_LOGIN.to_owned(),
+            crate::auth::role::Role::Mod,
+        )
         .expect("insert dev session");
     issue_session_cookies(&cookies, &state.signed_key, sid, &csrf_bytes, false);
     let target = q

--- a/crates/web/src/dev.rs
+++ b/crates/web/src/dev.rs
@@ -90,4 +90,7 @@ impl HelixClient for StubHelix {
     async fn is_moderator(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
         Ok(user_id == DEV_USER_ID)
     }
+    async fn is_follower(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
+        Ok(user_id == DEV_USER_ID)
+    }
 }

--- a/crates/web/src/error.rs
+++ b/crates/web/src/error.rs
@@ -54,6 +54,9 @@ pub struct ConflictPayload {
     pub csrf: String,
     /// Logged-in user's login, threaded through to the sidebar.
     pub user_login: String,
+    /// Whether the session user holds a Mod role. Forwarded to the
+    /// conflict template so the sidebar gates correctly.
+    pub is_mod: bool,
     /// Sidebar highlight key matching the originating editor's section.
     pub current_page: &'static str,
     pub cancel_url: &'static str,
@@ -78,6 +81,7 @@ struct ConflictTpl<'a> {
     draft: &'a str,
     csrf: &'a str,
     user_login: &'a str,
+    is_mod: bool,
     current_page: &'static str,
     cancel_url: &'static str,
 }
@@ -141,6 +145,7 @@ impl IntoResponse for WebError {
                     draft: &payload.draft,
                     csrf: &payload.csrf,
                     user_login: &payload.user_login,
+                    is_mod: payload.is_mod,
                     current_page: payload.current_page,
                     cancel_url: payload.cancel_url,
                 },

--- a/crates/web/src/error.rs
+++ b/crates/web/src/error.rs
@@ -32,6 +32,8 @@ pub enum WebError {
     /// 502 has a matching server-side trace.
     #[error("oauth exchange: {0}")]
     OAuthExchange(eyre::Report),
+    #[error("method not allowed")]
+    MethodNotAllowed,
     #[error("internal: {0}")]
     Internal(#[from] eyre::Report),
 }
@@ -151,6 +153,9 @@ impl IntoResponse for WebError {
                 );
                 // Almost always a stale/reused auth code (refresh, double-tab); offer retry instead of bare 502.
                 render(StatusCode::BAD_GATEWAY, &OAuthFailedTpl)
+            }
+            WebError::MethodNotAllowed => {
+                (StatusCode::METHOD_NOT_ALLOWED, "method not allowed").into_response()
             }
             WebError::Internal(err) => {
                 tracing::error!(

--- a/crates/web/src/helix.rs
+++ b/crates/web/src/helix.rs
@@ -190,6 +190,37 @@ pub async fn helix_moderator_check(
     Ok(!resp.data.is_empty())
 }
 
+/// Used during OAuth callback to check follows using the viewer's own user token.
+///
+/// `GET /helix/channels/followed?user_id=…&broadcaster_id=…` requires the
+/// `user:read:follows` scope on the **user token** (not the broadcaster's).
+/// Returns `true` iff `total > 0`.
+pub async fn user_follows_channel(
+    http: &reqwest::Client,
+    helix_base: &str,
+    client_id: &str,
+    user_access_token: &str,
+    user_id: &str,
+    broadcaster_id: &str,
+    context: &'static str,
+) -> Result<bool> {
+    #[derive(Deserialize)]
+    struct Resp {
+        total: u64,
+    }
+    let resp: Resp = helix_get(
+        http,
+        helix_base,
+        "/helix/channels/followed",
+        &[("user_id", user_id), ("broadcaster_id", broadcaster_id)],
+        user_access_token,
+        client_id,
+        context,
+    )
+    .await?;
+    Ok(resp.total > 0)
+}
+
 /// Used during OAuth callback because `helix/moderation/moderators`
 /// requires the bearer's user id to match `broadcaster_id` (i.e. only
 /// the broadcaster can list their own mods), so a logging-in mod cannot

--- a/crates/web/src/helix.rs
+++ b/crates/web/src/helix.rs
@@ -19,6 +19,8 @@ pub trait HelixClient: Send + Sync {
     async fn fetch_user_by_login(&self, login: &str) -> Result<Option<HelixUser>>;
     /// Single helix call filtered by `user_id`; returns true iff the user is in the moderator list.
     async fn is_moderator(&self, broadcaster_id: &str, user_id: &str) -> Result<bool>;
+    /// Single helix call filtered by `user_id`; returns true iff the user follows the broadcaster.
+    async fn is_follower(&self, broadcaster_id: &str, user_id: &str) -> Result<bool>;
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -135,6 +137,25 @@ impl HelixClient for ReqwestHelixClient {
             "helix moderators (bot token)",
         )
         .await
+    }
+
+    async fn is_follower(&self, broadcaster_id: &str, user_id: &str) -> Result<bool> {
+        #[derive(Deserialize)]
+        struct Resp {
+            total: u64,
+        }
+        let token = self.access_token_provider.current_access_token().await?;
+        let resp: Resp = helix_get(
+            &self.http,
+            &self.helix_base,
+            "/helix/channels/followers",
+            &[("broadcaster_id", broadcaster_id), ("user_id", user_id)],
+            &token,
+            self.client_id.expose_secret(),
+            "helix /channels/followers",
+        )
+        .await?;
+        Ok(resp.total > 0)
     }
 }
 

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -5,10 +5,11 @@
 //! - `/login`, `/auth/callback`, `/logout` (OAuth + post-login `?next=` deep-link)
 //! - `/assets/*` (embedded htmx + pico bundles, immutable cache)
 //!
-//! Mod-gated surfaces (sliding helix re-check via `require_mod`):
-//! - `/pings` — ping CRUD against the bot's `PingManager`
-//! - `/memory/{soul,lore,users,state}` — AI memory browse + edit with
-//!   `MemoryStore::write_with_guard` for mtime-aware conflict UX
+//! Auth tiers:
+//! - **Viewer** (follower): `/`, `/pings` (read), `/leaderboard`, `/flights`.
+//!   Read-only — non-GET/HEAD methods are rejected by `viewer_method_guard`.
+//! - **Mod** (broadcaster / hidden admins / helix moderators): pings mutations,
+//!   `/memory/{soul,lore,users,state}` CRUD, stubs.
 
 pub mod auth;
 pub mod clock;
@@ -69,6 +70,15 @@ pub async fn run_web(listener: TcpListener, deps: WebDeps, shutdown: Arc<Notify>
     Ok(())
 }
 
+async fn root_redirect(
+    axum::extract::Extension(session): axum::extract::Extension<auth::session::Session>,
+) -> axum::response::Redirect {
+    match session.role {
+        auth::role::Role::Mod => axum::response::Redirect::to("/pings"),
+        auth::role::Role::Viewer => axum::response::Redirect::to("/leaderboard"),
+    }
+}
+
 pub fn build_router(state: WebState) -> Router {
     #[allow(unused_mut)]
     let mut public = Router::new()
@@ -80,22 +90,33 @@ pub fn build_router(state: WebState) -> Router {
         public = public.merge(dev::router(state.clone()));
     }
 
-    let authed = Router::new()
-        .route(
-            "/",
-            axum::routing::get(|| async { axum::response::Redirect::to("/pings") }),
-        )
-        .merge(routes::pings::router())
+    let viewer_state = state.clone();
+    let viewer = Router::new()
+        .route("/", axum::routing::get(root_redirect))
+        .merge(routes::pings::viewer_router())
+        .merge(routes::leaderboard::router())
+        .merge(routes::flights::router())
+        .layer(axum::middleware::from_fn(auth::viewer_method_guard))
+        .route_layer(axum::middleware::from_fn_with_state(
+            viewer_state.clone(),
+            |s, c, r, n| auth::require_role(auth::role::Role::Viewer, s, c, r, n),
+        ))
+        .with_state(viewer_state);
+
+    let mod_state = state.clone();
+    let mod_only = Router::new()
+        .merge(routes::pings::mod_router())
         .merge(routes::memory::router())
         .merge(routes::stubs::router())
         .route_layer(axum::middleware::from_fn_with_state(
-            state.clone(),
+            mod_state.clone(),
             auth::require_mod,
         ))
-        .with_state(state);
+        .with_state(mod_state);
 
     public
-        .merge(authed)
+        .merge(viewer)
+        .merge(mod_only)
         .layer(CookieManagerLayer::new())
         .layer(TraceLayer::new_for_http())
 }

--- a/crates/web/src/nav.rs
+++ b/crates/web/src/nav.rs
@@ -8,6 +8,7 @@
 //! together at the top of `sidebar.html` and any drift is visible in
 //! a single file.
 
+pub const LEADERBOARD: &str = "leaderboard";
 pub const PINGS: &str = "pings";
 pub const MEMORY_TREE: &str = "memory";
 pub const MEMORY_SOUL: &str = "memory_soul";

--- a/crates/web/src/routes/flights.rs
+++ b/crates/web/src/routes/flights.rs
@@ -1,0 +1,68 @@
+//! `/flights` — read-only live snapshot of currently tracked aircraft.
+
+use std::time::Duration;
+
+use askama::Template;
+use axum::Router;
+use axum::extract::{Extension, State};
+use axum::response::Response;
+use axum::routing::get;
+use tokio::sync::oneshot;
+use twitch_1337_core::aviation::tracker::{TrackedFlightView, TrackerCommand};
+
+use crate::auth::csrf;
+use crate::auth::session::Session;
+use crate::error::WebError;
+use crate::nav;
+use crate::routes::render;
+use crate::state::WebState;
+
+#[derive(Template)]
+#[template(path = "flights/list.html")]
+struct ListTpl {
+    flights: Vec<TrackedFlightView>,
+    aviation_disabled: bool,
+    user_login: String,
+    csrf: String,
+    current_page: &'static str,
+}
+
+pub fn router() -> Router<WebState> {
+    Router::new().route("/flights", get(list))
+}
+
+const SNAPSHOT_TIMEOUT: Duration = Duration::from_millis(500);
+
+async fn list(
+    State(state): State<WebState>,
+    Extension(session): Extension<Session>,
+) -> Result<Response, WebError> {
+    let (flights, aviation_disabled) = match state.tracker_tx.as_ref() {
+        Some(tx) => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let send_ok = tx
+                .send(TrackerCommand::Snapshot { reply: reply_tx })
+                .await
+                .is_ok();
+            let flights = if send_ok {
+                tokio::time::timeout(SNAPSHOT_TIMEOUT, reply_rx)
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            (flights, false)
+        }
+        None => (Vec::new(), true),
+    };
+    let csrf = csrf::encode(&session.csrf_value);
+    render(&ListTpl {
+        flights,
+        aviation_disabled,
+        user_login: session.user_login,
+        csrf,
+        current_page: nav::FLIGHTS,
+    })
+}

--- a/crates/web/src/routes/flights.rs
+++ b/crates/web/src/routes/flights.rs
@@ -59,7 +59,7 @@ async fn list(
         None => (Vec::new(), true),
     };
     let csrf = csrf::encode(&session.csrf_value);
-    let is_mod = session.role == crate::auth::role::Role::Mod;
+    let is_mod = session.is_mod();
     render(&ListTpl {
         flights,
         aviation_disabled,

--- a/crates/web/src/routes/flights.rs
+++ b/crates/web/src/routes/flights.rs
@@ -25,6 +25,7 @@ struct ListTpl {
     user_login: String,
     csrf: String,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 pub fn router() -> Router<WebState> {
@@ -58,11 +59,13 @@ async fn list(
         None => (Vec::new(), true),
     };
     let csrf = csrf::encode(&session.csrf_value);
+    let is_mod = session.role == crate::auth::role::Role::Mod;
     render(&ListTpl {
         flights,
         aviation_disabled,
         user_login: session.user_login,
         csrf,
         current_page: nav::FLIGHTS,
+        is_mod,
     })
 }

--- a/crates/web/src/routes/leaderboard.rs
+++ b/crates/web/src/routes/leaderboard.rs
@@ -19,6 +19,7 @@ struct ListTpl {
     user_login: String,
     csrf: String,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 struct RowView {
@@ -58,10 +59,12 @@ async fn list(
         .collect();
 
     let csrf = csrf::encode(&session.csrf_value);
+    let is_mod = session.role == crate::auth::role::Role::Mod;
     render(&ListTpl {
         rows,
         user_login: session.user_login,
         csrf,
         current_page: crate::nav::LEADERBOARD,
+        is_mod,
     })
 }

--- a/crates/web/src/routes/leaderboard.rs
+++ b/crates/web/src/routes/leaderboard.rs
@@ -1,0 +1,67 @@
+//! `/leaderboard` — read-only 1337 PB ranking.
+
+use askama::Template;
+use axum::Router;
+use axum::extract::{Extension, State};
+use axum::response::Response;
+use axum::routing::get;
+
+use crate::auth::csrf;
+use crate::auth::session::Session;
+use crate::error::WebError;
+use crate::routes::render;
+use crate::state::WebState;
+
+#[derive(Template)]
+#[template(path = "leaderboard/list.html")]
+struct ListTpl {
+    rows: Vec<RowView>,
+    user_login: String,
+    csrf: String,
+    current_page: &'static str,
+}
+
+struct RowView {
+    rank: usize,
+    login: String,
+    ms: u64,
+    date: chrono::NaiveDate,
+}
+
+pub fn router() -> Router<WebState> {
+    Router::new().route("/leaderboard", get(list))
+}
+
+async fn list(
+    State(state): State<WebState>,
+    Extension(session): Extension<Session>,
+) -> Result<Response, WebError> {
+    let lb = state.leaderboard.read().await;
+    let mut entries: Vec<(String, u64, chrono::NaiveDate)> = lb
+        .iter()
+        .map(|(login, pb)| (login.clone(), pb.ms, pb.date))
+        .collect();
+    drop(lb);
+
+    // Sort by best time ascending; break ties alphabetically by login.
+    entries.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+
+    let rows = entries
+        .into_iter()
+        .enumerate()
+        .map(|(i, (login, ms, date))| RowView {
+            rank: i + 1,
+            login,
+            ms,
+            date,
+        })
+        .collect();
+
+    let csrf = csrf::encode(&session.csrf_value);
+    render(&ListTpl {
+        rows,
+        user_login: session.user_login,
+        csrf,
+        current_page: crate::nav::LEADERBOARD,
+    })
+}

--- a/crates/web/src/routes/leaderboard.rs
+++ b/crates/web/src/routes/leaderboard.rs
@@ -59,7 +59,7 @@ async fn list(
         .collect();
 
     let csrf = csrf::encode(&session.csrf_value);
-    let is_mod = session.role == crate::auth::role::Role::Mod;
+    let is_mod = session.is_mod();
     render(&ListTpl {
         rows,
         user_login: session.user_login,

--- a/crates/web/src/routes/memory.rs
+++ b/crates/web/src/routes/memory.rs
@@ -57,6 +57,7 @@ struct TreeTpl {
     csrf: String,
     user_login: String,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 #[derive(Template)]
@@ -80,6 +81,7 @@ struct EditorTpl<'a> {
     error: Option<String>,
     user_login: &'a str,
     current_page: &'static str,
+    is_mod: bool,
     /// Render the user-only frontmatter inputs (`username`, `display_name`).
     show_user_fm: bool,
     /// Render the state-only frontmatter input (`created_by`).
@@ -108,6 +110,7 @@ struct StateListTpl {
     csrf: String,
     user_login: String,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 struct UserRow {
@@ -129,6 +132,7 @@ struct UsersListTpl {
     csrf: String,
     user_login: String,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 fn fmt_ts(t: DateTime<Utc>) -> String {
@@ -238,6 +242,7 @@ async fn tree(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::MEMORY_TREE,
+        is_mod: session.role == crate::auth::role::Role::Mod,
     })
 }
 
@@ -283,6 +288,7 @@ async fn view_kind(
         error: None,
         user_login: &session.user_login,
         current_page,
+        is_mod: session.role == crate::auth::role::Role::Mod,
         show_user_fm: matches!(kind, FileKind::User { .. }),
         show_state_fm: matches!(kind, FileKind::State { .. }),
         fm_username: mf.frontmatter.username.as_deref().unwrap_or(""),
@@ -360,6 +366,7 @@ async fn list_users(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::MEMORY_USERS,
+        is_mod: session.role == crate::auth::role::Role::Mod,
     })
 }
 
@@ -457,6 +464,7 @@ async fn list_state(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::MEMORY_STATE,
+        is_mod: session.role == crate::auth::role::Role::Mod,
     })
 }
 
@@ -473,6 +481,7 @@ async fn new_state_form(
         cap,
         &csrf_hex,
         &session.user_login,
+        session.role == crate::auth::role::Role::Mod,
     )
 }
 
@@ -591,6 +600,7 @@ async fn save_kind(
                 draft: form.body,
                 csrf: csrf_hex,
                 user_login: session.user_login.clone(),
+                is_mod: session.role == crate::auth::role::Role::Mod,
                 current_page,
                 cancel_url,
             })))
@@ -631,6 +641,7 @@ async fn save_kind(
                     error: Some(msg),
                     user_login: &session.user_login,
                     current_page,
+                    is_mod: session.role == crate::auth::role::Role::Mod,
                     show_user_fm: matches!(&kind, FileKind::User { .. }),
                     show_state_fm: matches!(&kind, FileKind::State { .. }),
                     fm_username: &form.fm_username,
@@ -771,6 +782,7 @@ async fn create_state(
             cap,
             &csrf_hex,
             &session.user_login,
+            session.role == crate::auth::role::Role::Mod,
         );
     }
     let slug = form.slug.clone();
@@ -818,6 +830,7 @@ async fn create_state(
                 cap,
                 &csrf_hex,
                 &session.user_login,
+                session.role == crate::auth::role::Role::Mod,
             )
         }
     }
@@ -830,6 +843,7 @@ fn render_state_create(
     cap: usize,
     csrf_hex: &str,
     user_login: &str,
+    is_mod: bool,
 ) -> Result<Response, WebError> {
     render_with(
         status,
@@ -849,6 +863,7 @@ fn render_state_create(
             error,
             user_login,
             current_page: crate::nav::MEMORY_STATE,
+            is_mod,
             show_user_fm: false,
             show_state_fm: false,
             fm_username: "",

--- a/crates/web/src/routes/memory.rs
+++ b/crates/web/src/routes/memory.rs
@@ -242,7 +242,7 @@ async fn tree(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::MEMORY_TREE,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
     })
 }
 
@@ -288,7 +288,7 @@ async fn view_kind(
         error: None,
         user_login: &session.user_login,
         current_page,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
         show_user_fm: matches!(kind, FileKind::User { .. }),
         show_state_fm: matches!(kind, FileKind::State { .. }),
         fm_username: mf.frontmatter.username.as_deref().unwrap_or(""),
@@ -366,7 +366,7 @@ async fn list_users(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::MEMORY_USERS,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
     })
 }
 
@@ -464,7 +464,7 @@ async fn list_state(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::MEMORY_STATE,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
     })
 }
 
@@ -481,7 +481,7 @@ async fn new_state_form(
         cap,
         &csrf_hex,
         &session.user_login,
-        session.role == crate::auth::role::Role::Mod,
+        session.is_mod(),
     )
 }
 
@@ -600,7 +600,7 @@ async fn save_kind(
                 draft: form.body,
                 csrf: csrf_hex,
                 user_login: session.user_login.clone(),
-                is_mod: session.role == crate::auth::role::Role::Mod,
+                is_mod: session.is_mod(),
                 current_page,
                 cancel_url,
             })))
@@ -641,7 +641,7 @@ async fn save_kind(
                     error: Some(msg),
                     user_login: &session.user_login,
                     current_page,
-                    is_mod: session.role == crate::auth::role::Role::Mod,
+                    is_mod: session.is_mod(),
                     show_user_fm: matches!(&kind, FileKind::User { .. }),
                     show_state_fm: matches!(&kind, FileKind::State { .. }),
                     fm_username: &form.fm_username,
@@ -782,7 +782,7 @@ async fn create_state(
             cap,
             &csrf_hex,
             &session.user_login,
-            session.role == crate::auth::role::Role::Mod,
+            session.is_mod(),
         );
     }
     let slug = form.slug.clone();
@@ -830,7 +830,7 @@ async fn create_state(
                 cap,
                 &csrf_hex,
                 &session.user_login,
-                session.role == crate::auth::role::Role::Mod,
+                session.is_mod(),
             )
         }
     }

--- a/crates/web/src/routes/mod.rs
+++ b/crates/web/src/routes/mod.rs
@@ -5,6 +5,7 @@ use axum::response::{Html, IntoResponse, Response};
 use crate::error::WebError;
 
 pub mod assets;
+pub mod flights;
 pub mod health;
 pub mod leaderboard;
 pub mod memory;

--- a/crates/web/src/routes/mod.rs
+++ b/crates/web/src/routes/mod.rs
@@ -6,6 +6,7 @@ use crate::error::WebError;
 
 pub mod assets;
 pub mod health;
+pub mod leaderboard;
 pub mod memory;
 pub mod pings;
 pub mod stubs;

--- a/crates/web/src/routes/pings.rs
+++ b/crates/web/src/routes/pings.rs
@@ -1,6 +1,9 @@
 //! `/pings` CRUD handlers.
 //!
-//! Mounted under the authed sub-router so every entry point is mod-gated.
+//! Surfaces split by auth tier:
+//! - [`viewer_router`]: `GET /pings` list — read-only, viewer-tier.
+//! - [`mod_router`]: everything else (create, edit, delete, member ops) — mod-tier.
+//!
 //! Form POSTs validate the `_csrf` field against the session csrf value;
 //! the HTMX delete uses an `X-Csrf-Token` header (no body to round-trip).
 //! Persistence + validation reuse `PingManager`'s existing checks
@@ -26,9 +29,17 @@ use crate::flash;
 use crate::routes::{initial_of, render, render_with};
 use crate::state::WebState;
 
-pub fn router() -> Router<WebState> {
+/// Viewer-tier surface: GET /pings list. Detail (`/pings/{name}` GET) and
+/// form (`/pings/new` GET) stay on the mod router because they target
+/// mutation flows the viewer can't initiate.
+pub fn viewer_router() -> Router<WebState> {
+    Router::new().route("/pings", get(list))
+}
+
+/// Mod-tier surface: everything that isn't the read-only list.
+pub fn mod_router() -> Router<WebState> {
     Router::new()
-        .route("/pings", get(list).post(create))
+        .route("/pings", post(create))
         .route("/pings/new", get(new_form))
         .route("/pings/{name}", get(edit_form).post(update))
         .route("/pings/{name}/delete", post(delete))

--- a/crates/web/src/routes/pings.rs
+++ b/crates/web/src/routes/pings.rs
@@ -135,7 +135,7 @@ async fn list(
 
     rows.sort_by(|a, b| a.name.cmp(&b.name));
     let total_pings = rows.len();
-    let is_mod = session.role == crate::auth::role::Role::Mod;
+    let is_mod = session.is_mod();
     let tpl = ListTpl {
         rows,
         total_pings,
@@ -161,7 +161,7 @@ async fn new_form(Extension(session): Extension<Session>) -> Result<Response, We
         error: None,
         user_login: &session.user_login,
         current_page: crate::nav::PINGS,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
         members: Vec::new(),
         member_error: None,
     })
@@ -207,7 +207,7 @@ async fn create(
                 error: Some(format!("ping `{name}` already exists")),
                 user_login: &session.user_login,
                 current_page: crate::nav::PINGS,
-                is_mod: session.role == crate::auth::role::Role::Mod,
+                is_mod: session.is_mod(),
                 members: Vec::new(),
                 member_error: None,
             },
@@ -237,7 +237,7 @@ async fn create(
                 error: Some(e.to_string()),
                 user_login: &session.user_login,
                 current_page: crate::nav::PINGS,
-                is_mod: session.role == crate::auth::role::Role::Mod,
+                is_mod: session.is_mod(),
                 members: Vec::new(),
                 member_error: None,
             },
@@ -278,7 +278,7 @@ async fn edit_form(
         error: None,
         user_login: &session.user_login,
         current_page: crate::nav::PINGS,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
         members,
         member_error: None,
     })
@@ -327,7 +327,7 @@ async fn update(
                 error: Some(e.to_string()),
                 user_login: &session.user_login,
                 current_page: crate::nav::PINGS,
-                is_mod: session.role == crate::auth::role::Role::Mod,
+                is_mod: session.is_mod(),
                 members,
                 member_error: None,
             },
@@ -423,7 +423,7 @@ async fn add_member(
                     error: None,
                     user_login: &session.user_login,
                     current_page: crate::nav::PINGS,
-                    is_mod: session.role == crate::auth::role::Role::Mod,
+                    is_mod: session.is_mod(),
                     members,
                     member_error: Some(msg),
                 },

--- a/crates/web/src/routes/pings.rs
+++ b/crates/web/src/routes/pings.rs
@@ -60,6 +60,7 @@ struct ListTpl {
     csrf: String,
     user_login: String,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 #[derive(Template)]
@@ -122,6 +123,7 @@ async fn list(
 
     rows.sort_by(|a, b| a.name.cmp(&b.name));
     let total_pings = rows.len();
+    let is_mod = session.role == crate::auth::role::Role::Mod;
     let tpl = ListTpl {
         rows,
         total_pings,
@@ -132,6 +134,7 @@ async fn list(
         csrf: csrf::encode(&session.csrf_value),
         user_login: session.user_login.clone(),
         current_page: crate::nav::PINGS,
+        is_mod,
     };
     render(&tpl)
 }

--- a/crates/web/src/routes/pings.rs
+++ b/crates/web/src/routes/pings.rs
@@ -84,6 +84,7 @@ struct FormTpl<'a> {
     error: Option<String>,
     user_login: &'a str,
     current_page: &'static str,
+    is_mod: bool,
     /// Sorted lowercase logins. Empty on the create form.
     members: Vec<String>,
     /// Inline error from a recent add/remove attempt, rendered above the
@@ -160,6 +161,7 @@ async fn new_form(Extension(session): Extension<Session>) -> Result<Response, We
         error: None,
         user_login: &session.user_login,
         current_page: crate::nav::PINGS,
+        is_mod: session.role == crate::auth::role::Role::Mod,
         members: Vec::new(),
         member_error: None,
     })
@@ -205,6 +207,7 @@ async fn create(
                 error: Some(format!("ping `{name}` already exists")),
                 user_login: &session.user_login,
                 current_page: crate::nav::PINGS,
+                is_mod: session.role == crate::auth::role::Role::Mod,
                 members: Vec::new(),
                 member_error: None,
             },
@@ -234,6 +237,7 @@ async fn create(
                 error: Some(e.to_string()),
                 user_login: &session.user_login,
                 current_page: crate::nav::PINGS,
+                is_mod: session.role == crate::auth::role::Role::Mod,
                 members: Vec::new(),
                 member_error: None,
             },
@@ -274,6 +278,7 @@ async fn edit_form(
         error: None,
         user_login: &session.user_login,
         current_page: crate::nav::PINGS,
+        is_mod: session.role == crate::auth::role::Role::Mod,
         members,
         member_error: None,
     })
@@ -322,6 +327,7 @@ async fn update(
                 error: Some(e.to_string()),
                 user_login: &session.user_login,
                 current_page: crate::nav::PINGS,
+                is_mod: session.role == crate::auth::role::Role::Mod,
                 members,
                 member_error: None,
             },
@@ -417,6 +423,7 @@ async fn add_member(
                     error: None,
                     user_login: &session.user_login,
                     current_page: crate::nav::PINGS,
+                    is_mod: session.role == crate::auth::role::Role::Mod,
                     members,
                     member_error: Some(msg),
                 },

--- a/crates/web/src/routes/stubs.rs
+++ b/crates/web/src/routes/stubs.rs
@@ -63,6 +63,7 @@ struct StubTpl<'a> {
     csrf: String,
     user_login: &'a str,
     current_page: &'static str,
+    is_mod: bool,
 }
 
 async fn render_stub(
@@ -77,5 +78,6 @@ async fn render_stub(
         csrf: csrf::encode(&session.csrf_value),
         user_login: &session.user_login,
         current_page: meta.nav,
+        is_mod: session.role == crate::auth::role::Role::Mod,
     })
 }

--- a/crates/web/src/routes/stubs.rs
+++ b/crates/web/src/routes/stubs.rs
@@ -30,14 +30,6 @@ const SCHEDULES: StubMeta = StubMeta {
     nav: crate::nav::SCHEDULES,
 };
 
-const FLIGHTS: StubMeta = StubMeta {
-    title: "Flights",
-    subtitle: "Active flight tracker subscriptions and last-seen ADS-B telemetry.",
-    slug: "flights",
-    note: "Tracker state is persisted in flights.ron and managed via !track / !untrack in chat.",
-    nav: crate::nav::FLIGHTS,
-};
-
 const LOGS: StubMeta = StubMeta {
     title: "Logs",
     subtitle: "Live event tail across handlers — 1337 pings, AI turns, dreamer rituals.",
@@ -57,7 +49,6 @@ const CONFIG: StubMeta = StubMeta {
 pub fn router() -> Router<WebState> {
     Router::new()
         .route("/schedules", get(|s| render_stub(SCHEDULES, s)))
-        .route("/flights", get(|s| render_stub(FLIGHTS, s)))
         .route("/logs", get(|s| render_stub(LOGS, s)))
         .route("/config", get(|s| render_stub(CONFIG, s)))
 }

--- a/crates/web/src/routes/stubs.rs
+++ b/crates/web/src/routes/stubs.rs
@@ -78,6 +78,6 @@ async fn render_stub(
         csrf: csrf::encode(&session.csrf_value),
         user_login: &session.user_login,
         current_page: meta.nav,
-        is_mod: session.role == crate::auth::role::Role::Mod,
+        is_mod: session.is_mod(),
     })
 }

--- a/crates/web/src/state.rs
+++ b/crates/web/src/state.rs
@@ -59,8 +59,8 @@ pub struct WebState {
     /// from web handlers; mutations happen only inside the IRC tracker.
     pub leaderboard: Arc<RwLock<HashMap<String, PersonalBest>>>,
     /// Sender half of the flight-tracker command channel. `None` when
-    /// aviation is disabled at startup. Web handlers use this to request a
-    /// live snapshot (Task 12).
+    /// aviation is disabled at startup; the `/flights` handler then renders
+    /// the disabled placeholder instead of awaiting a snapshot.
     pub tracker_tx: Option<Arc<tokio::sync::mpsc::Sender<TrackerCommand>>>,
 }
 

--- a/crates/web/src/state.rs
+++ b/crates/web/src/state.rs
@@ -4,6 +4,7 @@
 //! [`crate::build_router`]. Every handler clones individual `Arc`s out of
 //! this struct.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -13,6 +14,8 @@ use secrecy::SecretString;
 use tokio::sync::RwLock;
 use tower_cookies::Key;
 use twitch_1337_core::ai::memory::store::MemoryStore;
+use twitch_1337_core::aviation::TrackerCommand;
+use twitch_1337_core::commands::leaderboard::PersonalBest;
 use twitch_1337_core::ping::PingManager;
 
 use crate::auth::OAuthCtx;
@@ -51,6 +54,14 @@ pub struct WebState {
     /// `[web].session_secret` in the bin so tampering with sid is detected
     /// on the next request rather than handled by HashMap miss alone.
     pub signed_key: Key,
+    /// Shared 1337 leaderboard (same `Arc` the tracker handler writes
+    /// through). `None`-valued entries mean the user was removed. Read-only
+    /// from web handlers; mutations happen only inside the IRC tracker.
+    pub leaderboard: Arc<RwLock<HashMap<String, PersonalBest>>>,
+    /// Sender half of the flight-tracker command channel. `None` when
+    /// aviation is disabled at startup. Web handlers use this to request a
+    /// live snapshot (Task 12).
+    pub tracker_tx: Option<Arc<tokio::sync::mpsc::Sender<TrackerCommand>>>,
 }
 
 /// Derive the signed-cookie [`Key`] from `[web].session_secret`.

--- a/crates/web/templates/flights/list.html
+++ b/crates/web/templates/flights/list.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}Flights — twitch-1337{% endblock %}
+{% block content %}
+<div class="page-head">
+  <div>
+    <h1>Flights <span class="count">({{ flights.len() }})</span></h1>
+    <p class="page-sub">Currently tracked aircraft.</p>
+  </div>
+</div>
+
+<div class="table flights">
+  <div class="thead">
+    <div class="th col-id">ID</div>
+    <div class="th col-cs">Callsign</div>
+    <div class="th col-by">Owner</div>
+    <div class="th col-phase">Phase</div>
+    <div class="th col-alt">Altitude</div>
+    <div class="th col-gs">Speed</div>
+    <div class="th col-age">Seen</div>
+  </div>
+  {% if aviation_disabled %}
+    <div class="empty">Aviation tracking is disabled.</div>
+  {% else if flights.is_empty() %}
+    <div class="empty">No flights tracked right now.</div>
+  {% else %}
+    <div class="tbody">
+    {% for f in flights %}
+      <div class="tr">
+        <div class="td col-id mono">{{ f.identifier }}</div>
+        <div class="td col-cs mono">{% match f.callsign %}{% when Some(v) %}{{ v }}{% when None %}—{% endmatch %}</div>
+        <div class="td col-by mono">{{ f.owner_login }}</div>
+        <div class="td col-phase mono">{{ f.phase }}</div>
+        <div class="td col-alt mono num">{% match f.altitude_ft %}{% when Some(v) %}{{ v }} ft{% when None %}—{% endmatch %}</div>
+        <div class="td col-gs mono num">{% match f.ground_speed_kts %}{% when Some(v) %}{{ v }} kt{% when None %}—{% endmatch %}</div>
+        <div class="td col-age mono num">{% match f.last_seen_secs_ago %}{% when Some(v) %}{{ v }}s{% when None %}—{% endmatch %}</div>
+      </div>
+    {% endfor %}
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/crates/web/templates/leaderboard/list.html
+++ b/crates/web/templates/leaderboard/list.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Leaderboard — twitch-1337{% endblock %}
+{% block content %}
+<div class="page-head">
+  <div>
+    <h1>Leaderboard <span class="count">({{ rows.len() }})</span></h1>
+    <p class="page-sub">Sub-second 1337 personal bests. Fastest wins.</p>
+  </div>
+</div>
+
+<div class="table leaderboard">
+  <div class="thead">
+    <div class="th col-rank">#</div>
+    <div class="th col-user">User</div>
+    <div class="th col-best">Best</div>
+    <div class="th col-date">Date</div>
+  </div>
+  {% if rows.is_empty() %}
+    <div class="empty">No personal bests yet.</div>
+  {% else %}
+    <div class="tbody">
+    {% for row in rows %}
+      <div class="tr">
+        <div class="td col-rank mono">{{ row.rank }}</div>
+        <div class="td col-user mono">{{ row.login }}</div>
+        <div class="td col-best mono num">{{ row.ms }} ms</div>
+        <div class="td col-date mono">{{ row.date }}</div>
+      </div>
+    {% endfor %}
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/crates/web/templates/pings/list.html
+++ b/crates/web/templates/pings/list.html
@@ -7,7 +7,9 @@
     <p class="page-sub">Template-based community shouts. Members can <code>!&lt;name&gt;</code> to fire.</p>
   </div>
   <div class="page-actions">
+    {% if is_mod %}
     <a class="btn primary" href="/pings/new">+ New ping</a>
+    {% endif %}
   </div>
 </div>
 
@@ -38,7 +40,9 @@
   <button type="button" class="chip">Public</button>
   <button type="button" class="chip">Recently fired</button>
   <div class="filters-spacer"></div>
+  {% if is_mod %}
   <button type="button" class="chip ghost">Sort: A → Z ↓</button>
+  {% endif %}
 </div>
 
 <div class="table pings">
@@ -81,6 +85,7 @@
         </div>
         <div class="td col-fired"><span class="muted">—</span></div>
         <div class="td col-act">
+          {% if is_mod %}
           <a class="row-act" href="/pings/{{ row.name }}" title="Edit">✎</a>
           <button type="button" class="row-act danger" title="Delete"
                   hx-post="/pings/{{ row.name }}/delete"
@@ -88,6 +93,7 @@
                   hx-target="closest .tr"
                   hx-swap="outerHTML"
                   hx-headers='{"X-Csrf-Token": "{{ csrf }}"}'>✕</button>
+          {% endif %}
         </div>
       </div>
     {% endfor %}

--- a/crates/web/templates/sidebar.html
+++ b/crates/web/templates/sidebar.html
@@ -20,11 +20,15 @@
       <div class="nav-group-label">Operate</div>
       <ul class="nav-list">
         {% call nav_item("pings", "/pings", "Pings") %}{% endcall %}
-        {% call nav_item("schedules", "/schedules", "Schedules") %}{% endcall %}
+        {% call nav_item("leaderboard", "/leaderboard", "Leaderboard") %}{% endcall %}
         {% call nav_item("flights", "/flights", "Flights") %}{% endcall %}
+        {% if is_mod %}
+        {% call nav_item("schedules", "/schedules", "Schedules") %}{% endcall %}
+        {% endif %}
       </ul>
     </div>
 
+    {% if is_mod %}
     <div class="nav-group">
       <a class="nav-group-label nav-group-link{% if current_page == "memory" %} active{% endif %}" href="/memory">Memory</a>
       <ul class="nav-list">
@@ -42,6 +46,7 @@
         {% call nav_item("config", "/config", "Config") %}{% endcall %}
       </ul>
     </div>
+    {% endif %}
   </nav>
 
   <div class="side-footer">
@@ -49,7 +54,7 @@
       <span class="avatar" style="width:28px;height:28px;font-size:11px;background:oklch(0.6 0.12 280);">{{ user_login.chars().next().unwrap_or('?') }}</span>
       <div class="me-meta">
         <span class="me-name">{{ user_login }}</span>
-        <span class="me-role">broadcaster · mod</span>
+        <span class="me-role">{% if is_mod %}broadcaster · mod{% else %}follower · viewer{% endif %}</span>
       </div>
     </div>
     <form class="logout-form" method="post" action="/logout">

--- a/crates/web/tests/assets_smoke.rs
+++ b/crates/web/tests/assets_smoke.rs
@@ -17,7 +17,7 @@ use helpers::{FakeHelix, build_state, install_crypto};
 fn fake_helix() -> Arc<dyn HelixClient> {
     Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: HashMap::new(),
     })
 }

--- a/crates/web/tests/assets_smoke.rs
+++ b/crates/web/tests/assets_smoke.rs
@@ -17,6 +17,7 @@ use helpers::{FakeHelix, build_state, install_crypto};
 fn fake_helix() -> Arc<dyn HelixClient> {
     Arc::new(FakeHelix {
         moderators: vec![],
+        followers: vec![],
         users: HashMap::new(),
     })
 }

--- a/crates/web/tests/auth_follower_check.rs
+++ b/crates/web/tests/auth_follower_check.rs
@@ -14,7 +14,9 @@ async fn run_check(total: u64) -> GateOutcome {
         .and(path("/helix/channels/followed"))
         .and(query_param("user_id", "42"))
         .and(query_param("broadcaster_id", "100"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "total": total, "data": [] })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "total": total, "data": [] })),
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -61,8 +63,8 @@ async fn follower_total_zero_denies() {
 #[tokio::test]
 async fn check_is_follower_with_token_is_callable() {
     install_crypto();
-    use std::sync::Arc;
     use helpers::FakeHelix;
+    use std::sync::Arc;
 
     let helix: Arc<dyn twitch_1337_web::helix::HelixClient> = Arc::new(FakeHelix {
         moderators: vec![],
@@ -71,7 +73,6 @@ async fn check_is_follower_with_token_is_callable() {
     });
     let state = build_state(helix).await;
     // Will fail to connect (test-invalid host); we assert it's an Err, not a panic.
-    let result =
-        check_is_follower_with_token(&state, "42", "user-token", "100").await;
+    let result = check_is_follower_with_token(&state, "42", "user-token", "100").await;
     assert!(result.is_err(), "expected network error, got {:?}", result);
 }

--- a/crates/web/tests/auth_follower_check.rs
+++ b/crates/web/tests/auth_follower_check.rs
@@ -68,7 +68,7 @@ async fn check_is_follower_with_token_is_callable() {
 
     let helix: Arc<dyn twitch_1337_web::helix::HelixClient> = Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: Default::default(),
     });
     let state = build_state(helix).await;

--- a/crates/web/tests/auth_follower_check.rs
+++ b/crates/web/tests/auth_follower_check.rs
@@ -1,0 +1,77 @@
+use serde_json::json;
+use twitch_1337_web::auth::role_check::{GateOutcome, check_is_follower_with_token};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod helpers;
+use helpers::{build_state, install_crypto};
+
+async fn run_check(total: u64) -> GateOutcome {
+    install_crypto();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/helix/channels/followed"))
+        .and(query_param("user_id", "42"))
+        .and(query_param("broadcaster_id", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "total": total, "data": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Build a state whose oauth.http points at the wiremock server.
+    // `check_is_follower_with_token` hard-codes "https://api.twitch.tv" as the
+    // base, so we test `user_follows_channel` directly which accepts an
+    // arbitrary base URL.
+    twitch_1337_web::helix::user_follows_channel(
+        &reqwest::Client::new(),
+        &server.uri(),
+        "client-id",
+        "user-token",
+        "42",
+        "100",
+        "test ctx",
+    )
+    .await
+    .map(|follows| {
+        if follows {
+            GateOutcome::Allow
+        } else {
+            GateOutcome::Deny
+        }
+    })
+    .unwrap()
+}
+
+#[tokio::test]
+async fn follower_total_gt_zero_allows() {
+    assert_eq!(run_check(1).await, GateOutcome::Allow);
+}
+
+#[tokio::test]
+async fn follower_total_zero_denies() {
+    assert_eq!(run_check(0).await, GateOutcome::Deny);
+}
+
+/// Smoke-test: `build_state` wires up `WebState`; we check that
+/// `check_is_follower_with_token` returns `Deny` when `user_follows_channel`
+/// would get a non-follower response. We can't inject a custom base URL
+/// through the public API here, so we just verify the function is callable
+/// and returns an error (unreachable host) rather than panicking.
+#[tokio::test]
+async fn check_is_follower_with_token_is_callable() {
+    install_crypto();
+    use std::sync::Arc;
+    use helpers::FakeHelix;
+
+    let helix: Arc<dyn twitch_1337_web::helix::HelixClient> = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec![],
+        users: Default::default(),
+    });
+    let state = build_state(helix).await;
+    // Will fail to connect (test-invalid host); we assert it's an Err, not a panic.
+    let result =
+        check_is_follower_with_token(&state, "42", "user-token", "100").await;
+    assert!(result.is_err(), "expected network error, got {:?}", result);
+}

--- a/crates/web/tests/auth_mod_check.rs
+++ b/crates/web/tests/auth_mod_check.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use twitch_1337_web::auth::mod_check::{ModCheckOutcome, check_is_mod};
+use twitch_1337_web::auth::role_check::{GateOutcome, check_is_mod};
 use twitch_1337_web::helix::{HelixClient, HelixUser};
 
 struct FakeHelix {
@@ -31,7 +31,7 @@ async fn hidden_admin_short_circuits() {
     let outcome = check_is_mod(&helix, "12345", "200", &["12345".into()])
         .await
         .unwrap();
-    assert_eq!(outcome, ModCheckOutcome::Allow);
+    assert_eq!(outcome, GateOutcome::Allow);
 }
 
 #[tokio::test]
@@ -41,7 +41,7 @@ async fn broadcaster_short_circuits() {
         users: HashMap::new(),
     };
     let outcome = check_is_mod(&helix, "200", "200", &[]).await.unwrap();
-    assert_eq!(outcome, ModCheckOutcome::Allow);
+    assert_eq!(outcome, GateOutcome::Allow);
 }
 
 #[tokio::test]
@@ -51,7 +51,7 @@ async fn moderator_path_admits() {
         users: HashMap::new(),
     };
     let outcome = check_is_mod(&helix, "999", "200", &[]).await.unwrap();
-    assert_eq!(outcome, ModCheckOutcome::Allow);
+    assert_eq!(outcome, GateOutcome::Allow);
 }
 
 #[tokio::test]
@@ -61,5 +61,5 @@ async fn non_mod_denied() {
         users: HashMap::new(),
     };
     let outcome = check_is_mod(&helix, "555", "200", &[]).await.unwrap();
-    assert_eq!(outcome, ModCheckOutcome::Deny);
+    assert_eq!(outcome, GateOutcome::Deny);
 }

--- a/crates/web/tests/auth_mod_check.rs
+++ b/crates/web/tests/auth_mod_check.rs
@@ -20,6 +20,9 @@ impl HelixClient for FakeHelix {
     async fn is_moderator(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
         Ok(self.moderators.iter().any(|m| m == user_id))
     }
+    async fn is_follower(&self, _broadcaster: &str, _user_id: &str) -> eyre::Result<bool> {
+        Ok(false)
+    }
 }
 
 #[tokio::test]

--- a/crates/web/tests/auth_next.rs
+++ b/crates/web/tests/auth_next.rs
@@ -29,6 +29,7 @@ use helpers::{FakeHelix, build_state, install_crypto};
 fn fake_helix() -> Arc<dyn HelixClient> {
     Arc::new(FakeHelix {
         moderators: vec![],
+        followers: vec![],
         users: HashMap::new(),
     })
 }

--- a/crates/web/tests/auth_next.rs
+++ b/crates/web/tests/auth_next.rs
@@ -29,7 +29,7 @@ use helpers::{FakeHelix, build_state, install_crypto};
 fn fake_helix() -> Arc<dyn HelixClient> {
     Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: HashMap::new(),
     })
 }

--- a/crates/web/tests/auth_routes.rs
+++ b/crates/web/tests/auth_routes.rs
@@ -17,7 +17,7 @@ use helpers::{FakeHelix, build_state, install_crypto};
 fn fake_helix() -> Arc<dyn HelixClient> {
     Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: HashMap::new(),
     })
 }

--- a/crates/web/tests/auth_routes.rs
+++ b/crates/web/tests/auth_routes.rs
@@ -17,6 +17,7 @@ use helpers::{FakeHelix, build_state, install_crypto};
 fn fake_helix() -> Arc<dyn HelixClient> {
     Arc::new(FakeHelix {
         moderators: vec![],
+        followers: vec![],
         users: HashMap::new(),
     })
 }

--- a/crates/web/tests/auth_session.rs
+++ b/crates/web/tests/auth_session.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, TimeZone, Utc};
+use twitch_1337_web::auth::Role;
 use twitch_1337_web::auth::session::SessionTable;
 use twitch_1337_web::clock::Clock;
 
@@ -30,7 +31,7 @@ fn session_round_trips() {
     ));
     let table = SessionTable::new(Duration::from_secs(7 * 24 * 3600), clock.clone());
     let (id, _csrf) = table
-        .insert("12345".into(), "alice".into())
+        .insert("12345".into(), "alice".into(), Role::Mod)
         .expect("insert");
     let got = table.get_and_touch(&id).expect("present");
     assert_eq!(got.user_login, "alice");
@@ -43,7 +44,7 @@ fn session_expires_after_ttl() {
         Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
     ));
     let table = SessionTable::new(Duration::from_secs(60), clock.clone());
-    let (id, _csrf) = table.insert("12345".into(), "alice".into()).unwrap();
+    let (id, _csrf) = table.insert("12345".into(), "alice".into(), Role::Mod).unwrap();
     clock.advance(61);
     assert!(
         table.get_and_touch(&id).is_none(),
@@ -57,7 +58,7 @@ fn session_sliding_refresh_keeps_alive() {
         Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
     ));
     let table = SessionTable::new(Duration::from_secs(120), clock.clone());
-    let (id, _csrf) = table.insert("12345".into(), "alice".into()).unwrap();
+    let (id, _csrf) = table.insert("12345".into(), "alice".into(), Role::Mod).unwrap();
     clock.advance(60);
     assert!(table.get_and_touch(&id).is_some()); // bumps last_seen
     clock.advance(90);

--- a/crates/web/tests/auth_session.rs
+++ b/crates/web/tests/auth_session.rs
@@ -44,7 +44,9 @@ fn session_expires_after_ttl() {
         Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
     ));
     let table = SessionTable::new(Duration::from_secs(60), clock.clone());
-    let (id, _csrf) = table.insert("12345".into(), "alice".into(), Role::Mod).unwrap();
+    let (id, _csrf) = table
+        .insert("12345".into(), "alice".into(), Role::Mod)
+        .unwrap();
     clock.advance(61);
     assert!(
         table.get_and_touch(&id).is_none(),
@@ -58,7 +60,9 @@ fn session_sliding_refresh_keeps_alive() {
         Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
     ));
     let table = SessionTable::new(Duration::from_secs(120), clock.clone());
-    let (id, _csrf) = table.insert("12345".into(), "alice".into(), Role::Mod).unwrap();
+    let (id, _csrf) = table
+        .insert("12345".into(), "alice".into(), Role::Mod)
+        .unwrap();
     clock.advance(60);
     assert!(table.get_and_touch(&id).is_some()); // bumps last_seen
     clock.advance(90);

--- a/crates/web/tests/auth_signed_cookies.rs
+++ b/crates/web/tests/auth_signed_cookies.rs
@@ -13,6 +13,7 @@ async fn tampered_sid_redirects_to_login() {
     install_crypto();
     let state = build_state(std::sync::Arc::new(FakeHelix {
         moderators: vec!["12345".into()],
+        followers: vec![],
         users: std::collections::HashMap::new(),
     }))
     .await;
@@ -56,6 +57,7 @@ async fn untampered_sid_passes_through() {
     install_crypto();
     let state = build_state(std::sync::Arc::new(FakeHelix {
         moderators: vec!["12345".into()],
+        followers: vec![],
         users: std::collections::HashMap::new(),
     }))
     .await;

--- a/crates/web/tests/auth_signed_cookies.rs
+++ b/crates/web/tests/auth_signed_cookies.rs
@@ -13,7 +13,7 @@ async fn tampered_sid_redirects_to_login() {
     install_crypto();
     let state = build_state(std::sync::Arc::new(FakeHelix {
         moderators: vec!["12345".into()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: std::collections::HashMap::new(),
     }))
     .await;
@@ -57,7 +57,7 @@ async fn untampered_sid_passes_through() {
     install_crypto();
     let state = build_state(std::sync::Arc::new(FakeHelix {
         moderators: vec!["12345".into()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: std::collections::HashMap::new(),
     }))
     .await;

--- a/crates/web/tests/auth_viewer_guard.rs
+++ b/crates/web/tests/auth_viewer_guard.rs
@@ -7,10 +7,18 @@ use tower::ServiceExt as _;
 async fn viewer_method_guard_admits_get() {
     let app = Router::new()
         .route("/x", axum::routing::any(|| async { "ok" }))
-        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+        .layer(axum::middleware::from_fn(
+            twitch_1337_web::auth::viewer_method_guard,
+        ));
 
     let resp = app
-        .oneshot(Request::builder().uri("/x").method(Method::GET).body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/x")
+                .method(Method::GET)
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -20,10 +28,18 @@ async fn viewer_method_guard_admits_get() {
 async fn viewer_method_guard_admits_head() {
     let app = Router::new()
         .route("/x", axum::routing::any(|| async { "ok" }))
-        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+        .layer(axum::middleware::from_fn(
+            twitch_1337_web::auth::viewer_method_guard,
+        ));
 
     let resp = app
-        .oneshot(Request::builder().uri("/x").method(Method::HEAD).body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/x")
+                .method(Method::HEAD)
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -33,10 +49,18 @@ async fn viewer_method_guard_admits_head() {
 async fn viewer_method_guard_rejects_post() {
     let app = Router::new()
         .route("/x", axum::routing::any(|| async { "ok" }))
-        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+        .layer(axum::middleware::from_fn(
+            twitch_1337_web::auth::viewer_method_guard,
+        ));
 
     let resp = app
-        .oneshot(Request::builder().uri("/x").method(Method::POST).body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/x")
+                .method(Method::POST)
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
@@ -46,10 +70,18 @@ async fn viewer_method_guard_rejects_post() {
 async fn viewer_method_guard_rejects_delete() {
     let app = Router::new()
         .route("/x", axum::routing::any(|| async { "ok" }))
-        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+        .layer(axum::middleware::from_fn(
+            twitch_1337_web::auth::viewer_method_guard,
+        ));
 
     let resp = app
-        .oneshot(Request::builder().uri("/x").method(Method::DELETE).body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/x")
+                .method(Method::DELETE)
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);

--- a/crates/web/tests/auth_viewer_guard.rs
+++ b/crates/web/tests/auth_viewer_guard.rs
@@ -1,0 +1,56 @@
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use tower::ServiceExt as _;
+
+#[tokio::test]
+async fn viewer_method_guard_admits_get() {
+    let app = Router::new()
+        .route("/x", axum::routing::any(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/x").method(Method::GET).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn viewer_method_guard_admits_head() {
+    let app = Router::new()
+        .route("/x", axum::routing::any(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/x").method(Method::HEAD).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn viewer_method_guard_rejects_post() {
+    let app = Router::new()
+        .route("/x", axum::routing::any(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/x").method(Method::POST).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn viewer_method_guard_rejects_delete() {
+    let app = Router::new()
+        .route("/x", axum::routing::any(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/x").method(Method::DELETE).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}

--- a/crates/web/tests/auth_viewer_tier.rs
+++ b/crates/web/tests/auth_viewer_tier.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use helpers::{
-    FakeHelix, build_state_with_dirs, build_state_with_overrides, cookie_header, install_crypto,
-    insert_session_as,
+    FakeHelix, build_state_with_dirs, build_state_with_overrides, cookie_header, insert_session_as,
+    install_crypto,
 };
 use tower::ServiceExt as _;
 use twitch_1337_web::auth::Role;
@@ -21,7 +21,6 @@ fn viewer_helix(user_id: &str) -> Arc<FakeHelix> {
         users: Default::default(),
     })
 }
-
 
 #[tokio::test]
 async fn viewer_can_read_pings_leaderboard_flights() {
@@ -156,8 +155,7 @@ async fn viewer_loses_follow_after_recheck_window() {
     // Keep a typed handle for mutation; pass a dyn handle to build_state.
     let helix_typed = helix.clone();
     let helix_dyn: Arc<dyn twitch_1337_web::helix::HelixClient> = helix.clone();
-    let (state, _td_p, _td_m) =
-        build_state_with_overrides(helix_dyn, Duration::from_secs(0)).await;
+    let (state, _td_p, _td_m) = build_state_with_overrides(helix_dyn, Duration::from_secs(0)).await;
     let (sid, csrf, _bare) = insert_session_as(&state, "42", "alice", Role::Viewer);
     let cookie = cookie_header(&sid, &csrf);
     let app = twitch_1337_web::build_router(state.clone());

--- a/crates/web/tests/auth_viewer_tier.rs
+++ b/crates/web/tests/auth_viewer_tier.rs
@@ -1,0 +1,200 @@
+//! Viewer-tier (follower) integration scenarios.
+
+mod helpers;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use helpers::{
+    FakeHelix, build_state_with_dirs, build_state_with_overrides, cookie_header, install_crypto,
+    insert_session_as,
+};
+use tower::ServiceExt as _;
+use twitch_1337_web::auth::Role;
+
+fn viewer_helix(user_id: &str) -> Arc<FakeHelix> {
+    Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: tokio::sync::RwLock::new(vec![user_id.into()]),
+        users: Default::default(),
+    })
+}
+
+
+#[tokio::test]
+async fn viewer_can_read_pings_leaderboard_flights() {
+    install_crypto();
+    let (state, _td_p, _td_m) = build_state_with_dirs(viewer_helix("42")).await;
+    let (sid, csrf, _bare) = insert_session_as(&state, "42", "alice", Role::Viewer);
+    let cookie = cookie_header(&sid, &csrf);
+    let app = twitch_1337_web::build_router(state.clone());
+
+    for path in ["/pings", "/leaderboard", "/flights"] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .method(Method::GET)
+                    .header("cookie", cookie.clone())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "viewer GET {path}");
+    }
+}
+
+#[tokio::test]
+async fn viewer_blocked_from_memory_and_mutations() {
+    install_crypto();
+    let (state, _td_p, _td_m) = build_state_with_dirs(viewer_helix("42")).await;
+    let (sid, csrf, _bare) = insert_session_as(&state, "42", "alice", Role::Viewer);
+    let cookie = cookie_header(&sid, &csrf);
+    let app = twitch_1337_web::build_router(state.clone());
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/memory/soul")
+                .method(Method::GET)
+                .header("cookie", cookie.clone())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "viewer cannot read memory"
+    );
+
+    // POST to a mod-only route; require_role(Mod) should reject with 403.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/pings/anything/delete")
+                .method(Method::POST)
+                .header("cookie", cookie)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "viewer cannot mutate pings"
+    );
+}
+
+#[tokio::test]
+async fn root_redirects_by_role() {
+    install_crypto();
+    let helix = Arc::new(FakeHelix {
+        moderators: vec!["9".into()],
+        followers: tokio::sync::RwLock::new(vec!["42".into()]),
+        users: Default::default(),
+    });
+    let (state, _td_p, _td_m) = build_state_with_dirs(helix).await;
+    let (viewer_sid, viewer_csrf, _) = insert_session_as(&state, "42", "alice", Role::Viewer);
+    let (mod_sid, mod_csrf, _) = insert_session_as(&state, "9", "boss", Role::Mod);
+    let app = twitch_1337_web::build_router(state.clone());
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .method(Method::GET)
+                .header("cookie", cookie_header(&viewer_sid, &viewer_csrf))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_redirection(), "viewer / should redirect");
+    assert_eq!(
+        resp.headers().get("location").unwrap(),
+        "/leaderboard",
+        "viewer / should redirect to /leaderboard"
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .method(Method::GET)
+                .header("cookie", cookie_header(&mod_sid, &mod_csrf))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(resp.status().is_redirection(), "mod / should redirect");
+    assert_eq!(
+        resp.headers().get("location").unwrap(),
+        "/pings",
+        "mod / should redirect to /pings"
+    );
+}
+
+#[tokio::test]
+async fn viewer_loses_follow_after_recheck_window() {
+    install_crypto();
+    let helix = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: tokio::sync::RwLock::new(vec!["42".into()]),
+        users: Default::default(),
+    });
+    // Keep a typed handle for mutation; pass a dyn handle to build_state.
+    let helix_typed = helix.clone();
+    let helix_dyn: Arc<dyn twitch_1337_web::helix::HelixClient> = helix.clone();
+    let (state, _td_p, _td_m) =
+        build_state_with_overrides(helix_dyn, Duration::from_secs(0)).await;
+    let (sid, csrf, _bare) = insert_session_as(&state, "42", "alice", Role::Viewer);
+    let cookie = cookie_header(&sid, &csrf);
+    let app = twitch_1337_web::build_router(state.clone());
+
+    // First request: still a follower — should pass.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/leaderboard")
+                .method(Method::GET)
+                .header("cookie", cookie.clone())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "first request should be 200");
+
+    // Drop the follow so the next recheck denies.
+    helix_typed.followers.write().await.clear();
+
+    // Second request: recheck fires (refresh=0, elapsed > 0) → Deny → 403.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/leaderboard")
+                .method(Method::GET)
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "second request after follow dropped should be 403"
+    );
+}

--- a/crates/web/tests/flights_route.rs
+++ b/crates/web/tests/flights_route.rs
@@ -1,0 +1,128 @@
+//! Integration tests for `/flights` read-only route.
+//!
+//! The route is not yet mounted in `build_router` (Task 14 handles that),
+//! so we assemble a minimal `Router<WebState>` locally that merges
+//! `routes::flights::router()` behind a `require_mod` layer. This keeps
+//! the test self-contained and independent of Task 14.
+
+mod helpers;
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode, header};
+use helpers::{FakeHelix, build_state_with_dirs, cookie_header, install_crypto, insert_session};
+use tokio::sync::mpsc;
+use tower::ServiceExt as _;
+use twitch_1337_core::aviation::tracker::{TrackedFlightView, TrackerCommand};
+use twitch_1337_web::auth::require_mod;
+use twitch_1337_web::routes::flights;
+
+fn mod_helix() -> Arc<FakeHelix> {
+    Arc::new(FakeHelix {
+        moderators: vec!["42".into()],
+        followers: vec![],
+        users: Default::default(),
+    })
+}
+
+fn app(state: twitch_1337_web::WebState) -> Router {
+    Router::new()
+        .merge(flights::router())
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_mod,
+        ))
+        .with_state(state)
+        .layer(tower_cookies::CookieManagerLayer::new())
+}
+
+async fn body_string(res: axum::http::Response<Body>) -> String {
+    let bytes = to_bytes(res.into_body(), 128 * 1024).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn flights_empty_state_when_no_tracker() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(mod_helix()).await;
+    // tracker_tx is None by default in test helpers
+    let (sid, csrf, _bare) = insert_session(&state, "42", "admin");
+    let req = Request::builder()
+        .uri("/flights")
+        .method(Method::GET)
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+    let res = app(state).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+    assert!(
+        html.contains("disabled"),
+        "should show aviation-disabled placeholder; got {html}"
+    );
+}
+
+#[tokio::test]
+async fn flights_renders_snapshot_from_tracker() {
+    install_crypto();
+    let (mut state, _td_pings, _td_mem) = build_state_with_dirs(mod_helix()).await;
+    let (tx, mut rx) = mpsc::channel::<TrackerCommand>(8);
+    state.tracker_tx = Some(Arc::new(tx));
+
+    // Spawn a tiny task that answers the next Snapshot command.
+    tokio::spawn(async move {
+        while let Some(cmd) = rx.recv().await {
+            if let TrackerCommand::Snapshot { reply } = cmd {
+                let _ = reply.send(vec![TrackedFlightView {
+                    identifier: "DLH123".into(),
+                    callsign: Some("DLH123".into()),
+                    owner_login: "alice".into(),
+                    phase: "Cruise".into(),
+                    altitude_ft: Some(34000),
+                    ground_speed_kts: Some(450.0),
+                    last_seen_secs_ago: Some(12),
+                }]);
+                break;
+            }
+        }
+    });
+
+    let (sid, csrf, _bare) = insert_session(&state, "42", "admin");
+    let req = Request::builder()
+        .uri("/flights")
+        .method(Method::GET)
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+    let res = app(state).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+    assert!(
+        html.contains("DLH123"),
+        "should render callsign; got {html}"
+    );
+    assert!(
+        html.contains("alice"),
+        "should render owner login; got {html}"
+    );
+}
+
+#[tokio::test]
+async fn flights_unauthenticated_redirects() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(mod_helix()).await;
+
+    let req = Request::builder()
+        .uri("/flights")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app(state).oneshot(req).await.unwrap();
+    assert!(
+        res.status() == StatusCode::SEE_OTHER || res.status() == StatusCode::UNAUTHORIZED,
+        "unauthenticated request must not get 200; got {}",
+        res.status()
+    );
+}

--- a/crates/web/tests/flights_route.rs
+++ b/crates/web/tests/flights_route.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::http::{Method, Request, StatusCode, header};
-use helpers::{FakeHelix, build_state_with_dirs, cookie_header, install_crypto, insert_session};
+use helpers::{FakeHelix, build_state_with_dirs, cookie_header, insert_session, install_crypto};
 use tokio::sync::mpsc;
 use tower::ServiceExt as _;
 use twitch_1337_core::aviation::tracker::{TrackedFlightView, TrackerCommand};

--- a/crates/web/tests/flights_route.rs
+++ b/crates/web/tests/flights_route.rs
@@ -22,7 +22,7 @@ use twitch_1337_web::routes::flights;
 fn mod_helix() -> Arc<FakeHelix> {
     Arc::new(FakeHelix {
         moderators: vec!["42".into()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: Default::default(),
     })
 }

--- a/crates/web/tests/helix_follower_check.rs
+++ b/crates/web/tests/helix_follower_check.rs
@@ -1,0 +1,17 @@
+mod helpers;
+
+use std::sync::Arc;
+
+use helpers::FakeHelix;
+use twitch_1337_web::helix::HelixClient;
+
+#[tokio::test]
+async fn is_follower_reports_membership() {
+    let helix: Arc<dyn HelixClient> = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec!["42".into()],
+        users: Default::default(),
+    });
+    assert!(helix.is_follower("b123", "42").await.unwrap());
+    assert!(!helix.is_follower("b123", "99").await.unwrap());
+}

--- a/crates/web/tests/helix_follower_check.rs
+++ b/crates/web/tests/helix_follower_check.rs
@@ -9,7 +9,7 @@ use twitch_1337_web::helix::HelixClient;
 async fn is_follower_reports_membership() {
     let helix: Arc<dyn HelixClient> = Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec!["42".into()],
+        followers: tokio::sync::RwLock::new(vec!["42".into()]),
         users: Default::default(),
     });
     assert!(helix.is_follower("b123", "42").await.unwrap());

--- a/crates/web/tests/helpers/mod.rs
+++ b/crates/web/tests/helpers/mod.rs
@@ -144,13 +144,19 @@ pub fn insert_session(
     user_id: &str,
     user_login: &str,
 ) -> (String, String, String) {
+    insert_session_as(state, user_id, user_login, twitch_1337_web::auth::Role::Mod)
+}
+
+/// Like [`insert_session`] but lets the caller specify the role.
+pub fn insert_session_as(
+    state: &WebState,
+    user_id: &str,
+    user_login: &str,
+    role: twitch_1337_web::auth::Role,
+) -> (String, String, String) {
     let (sid, csrf) = state
         .sessions
-        .insert(
-            user_id.to_owned(),
-            user_login.to_owned(),
-            twitch_1337_web::auth::Role::Mod,
-        )
+        .insert(user_id.to_owned(), user_login.to_owned(), role)
         .expect("insert session");
     let bare_csrf = hex::encode(csrf);
     let signed_sid = sign_for_tests(state, "tw1337_sid", &sid);

--- a/crates/web/tests/helpers/mod.rs
+++ b/crates/web/tests/helpers/mod.rs
@@ -125,6 +125,8 @@ pub async fn build_state_with_dirs(helix: Arc<dyn HelixClient>) -> (WebState, Te
         ping_manager,
         memory_store,
         signed_key,
+        leaderboard: Arc::new(RwLock::new(HashMap::new())),
+        tracker_tx: None,
     };
     (state, pings_dir, memory_dir)
 }

--- a/crates/web/tests/helpers/mod.rs
+++ b/crates/web/tests/helpers/mod.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -35,9 +35,34 @@ impl Clock for FixedClock {
     }
 }
 
+/// A clock that advances by one second on every call to `now()`.
+/// The first call returns `T0`, the second `T0 + 1s`, etc.
+/// Used to ensure that `elapsed > role_check_refresh` evaluates to `true`
+/// even when `role_check_refresh` is `Duration::ZERO`.
+pub struct StepClock {
+    base: DateTime<Utc>,
+    counter: AtomicI64,
+}
+
+impl StepClock {
+    pub fn new(base: DateTime<Utc>) -> Self {
+        Self {
+            base,
+            counter: AtomicI64::new(0),
+        }
+    }
+}
+
+impl Clock for StepClock {
+    fn now(&self) -> DateTime<Utc> {
+        let n = self.counter.fetch_add(1, Ordering::Relaxed);
+        self.base + chrono::Duration::seconds(n)
+    }
+}
+
 pub struct FakeHelix {
     pub moderators: Vec<String>,
-    pub followers: Vec<String>,
+    pub followers: RwLock<Vec<String>>,
     pub users: HashMap<String, HelixUser>,
 }
 
@@ -53,7 +78,8 @@ impl HelixClient for FakeHelix {
         Ok(self.moderators.iter().any(|m| m == user_id))
     }
     async fn is_follower(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
-        Ok(self.followers.iter().any(|f| f == user_id))
+        let g = self.followers.read().await;
+        Ok(g.iter().any(|f| f == user_id))
     }
 }
 
@@ -82,6 +108,34 @@ pub async fn build_state_with_ping_dir(helix: Arc<dyn HelixClient>) -> (WebState
 /// Variant that returns both the ping and memory tempdirs so callers can
 /// keep them alive while exercising persistent CRUD paths.
 pub async fn build_state_with_dirs(helix: Arc<dyn HelixClient>) -> (WebState, TempDir, TempDir) {
+    let clock: Arc<dyn Clock> = Arc::new(FixedClock(
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 1, 1, 0, 0, 0).unwrap(),
+    ));
+    build_state_inner(helix, Duration::from_secs(300), clock).await
+}
+
+/// Like [`build_state_with_dirs`] but lets the caller override the
+/// `role_check_refresh` window.
+///
+/// Uses a [`StepClock`] that increments by one second on each `now()` call so
+/// that `elapsed > role_check_refresh` evaluates to `true` even when
+/// `role_check_refresh` is `Duration::ZERO` — the session is inserted at `T0`
+/// and the first middleware check sees `T0 + Ns` where `N ≥ 1`.
+pub async fn build_state_with_overrides(
+    helix: Arc<dyn HelixClient>,
+    role_check_refresh: Duration,
+) -> (WebState, TempDir, TempDir) {
+    let clock: Arc<dyn Clock> = Arc::new(StepClock::new(
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 1, 1, 0, 0, 0).unwrap(),
+    ));
+    build_state_inner(helix, role_check_refresh, clock).await
+}
+
+async fn build_state_inner(
+    helix: Arc<dyn HelixClient>,
+    role_check_refresh: Duration,
+    clock: Arc<dyn Clock>,
+) -> (WebState, TempDir, TempDir) {
     let pings_dir = TempDir::new().expect("pings tempdir");
     let memory_dir = TempDir::new().expect("memory tempdir");
     let pings = PingManager::load(pings_dir.path()).expect("load empty ping manager");
@@ -89,9 +143,6 @@ pub async fn build_state_with_dirs(helix: Arc<dyn HelixClient>) -> (WebState, Te
     let memory_store = MemoryStore::open(memory_dir.path(), Caps::default())
         .await
         .expect("open memory store");
-    let clock = Arc::new(FixedClock(
-        chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 1, 1, 0, 0, 0).unwrap(),
-    ));
     let sessions = Arc::new(SessionTable::new(Duration::from_secs(7200), clock.clone()));
     let oauth = Arc::new(
         OAuthCtx::new(
@@ -106,7 +157,7 @@ pub async fn build_state_with_dirs(helix: Arc<dyn HelixClient>) -> (WebState, Te
         public_url: "https://test.invalid".into(),
         session_secret: SecretString::new("0".repeat(64).into()),
         session_ttl: Duration::from_secs(7200),
-        role_check_refresh: Duration::from_secs(300),
+        role_check_refresh,
     });
     // Tests don't need a real production secret; a fixed 32-byte key keeps
     // signed-cookie round-trips deterministic across reruns.

--- a/crates/web/tests/helpers/mod.rs
+++ b/crates/web/tests/helpers/mod.rs
@@ -37,6 +37,7 @@ impl Clock for FixedClock {
 
 pub struct FakeHelix {
     pub moderators: Vec<String>,
+    pub followers: Vec<String>,
     pub users: HashMap<String, HelixUser>,
 }
 
@@ -50,6 +51,9 @@ impl HelixClient for FakeHelix {
     }
     async fn is_moderator(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
         Ok(self.moderators.iter().any(|m| m == user_id))
+    }
+    async fn is_follower(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
+        Ok(self.followers.iter().any(|f| f == user_id))
     }
 }
 

--- a/crates/web/tests/helpers/mod.rs
+++ b/crates/web/tests/helpers/mod.rs
@@ -102,7 +102,7 @@ pub async fn build_state_with_dirs(helix: Arc<dyn HelixClient>) -> (WebState, Te
         public_url: "https://test.invalid".into(),
         session_secret: SecretString::new("0".repeat(64).into()),
         session_ttl: Duration::from_secs(7200),
-        mod_check_refresh: Duration::from_secs(300),
+        role_check_refresh: Duration::from_secs(300),
     });
     // Tests don't need a real production secret; a fixed 32-byte key keeps
     // signed-cookie round-trips deterministic across reruns.
@@ -140,7 +140,11 @@ pub fn insert_session(
 ) -> (String, String, String) {
     let (sid, csrf) = state
         .sessions
-        .insert(user_id.to_owned(), user_login.to_owned())
+        .insert(
+            user_id.to_owned(),
+            user_login.to_owned(),
+            twitch_1337_web::auth::Role::Mod,
+        )
         .expect("insert session");
     let bare_csrf = hex::encode(csrf);
     let signed_sid = sign_for_tests(state, "tw1337_sid", &sid);

--- a/crates/web/tests/leaderboard_route.rs
+++ b/crates/web/tests/leaderboard_route.rs
@@ -19,7 +19,7 @@ use twitch_1337_web::auth::require_mod;
 use twitch_1337_web::routes::leaderboard;
 
 mod helpers;
-use helpers::{FakeHelix, build_state_with_dirs, cookie_header, install_crypto, insert_session};
+use helpers::{FakeHelix, build_state_with_dirs, cookie_header, insert_session, install_crypto};
 
 fn helix() -> Arc<FakeHelix> {
     let mut users = HashMap::new();

--- a/crates/web/tests/leaderboard_route.rs
+++ b/crates/web/tests/leaderboard_route.rs
@@ -33,7 +33,7 @@ fn helix() -> Arc<FakeHelix> {
     );
     Arc::new(FakeHelix {
         moderators: vec!["42".into()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users,
     })
 }

--- a/crates/web/tests/leaderboard_route.rs
+++ b/crates/web/tests/leaderboard_route.rs
@@ -1,0 +1,169 @@
+//! Integration tests for `/leaderboard` read-only route.
+//!
+//! The route is not yet mounted in `build_router` (Task 14 handles that),
+//! so we assemble a minimal `Router<WebState>` locally that merges
+//! `routes::leaderboard::router()` behind a `require_mod` layer. This keeps
+//! the test self-contained and independent of Task 14.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode, header};
+use chrono::NaiveDate;
+use tower::ServiceExt as _;
+use twitch_1337_core::commands::leaderboard::PersonalBest;
+use twitch_1337_web::WebState;
+use twitch_1337_web::auth::require_mod;
+use twitch_1337_web::routes::leaderboard;
+
+mod helpers;
+use helpers::{FakeHelix, build_state_with_dirs, cookie_header, install_crypto, insert_session};
+
+fn helix() -> Arc<FakeHelix> {
+    let mut users = HashMap::new();
+    users.insert(
+        "42".to_owned(),
+        twitch_1337_web::helix::HelixUser {
+            id: "42".into(),
+            login: "admin".into(),
+            display_name: "admin".into(),
+        },
+    );
+    Arc::new(FakeHelix {
+        moderators: vec!["42".into()],
+        followers: vec![],
+        users,
+    })
+}
+
+fn app(state: WebState) -> Router {
+    Router::new()
+        .merge(leaderboard::router())
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_mod,
+        ))
+        .with_state(state)
+        .layer(tower_cookies::CookieManagerLayer::new())
+}
+
+async fn body_string(res: axum::http::Response<Body>) -> String {
+    let bytes = to_bytes(res.into_body(), 1024 * 1024).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn leaderboard_renders_seeded_pb() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(helix()).await;
+
+    // Seed one entry into the shared leaderboard.
+    {
+        let mut lb = state.leaderboard.write().await;
+        lb.insert(
+            "alice".into(),
+            PersonalBest {
+                ms: 123,
+                date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            },
+        );
+    }
+
+    let (sid, csrf, _bare) = insert_session(&state, "42", "admin");
+    let req = Request::builder()
+        .uri("/leaderboard")
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app(state).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+    assert!(html.contains("alice"), "row must contain login; got {html}");
+    assert!(html.contains("123"), "row must contain ms; got {html}");
+}
+
+#[tokio::test]
+async fn leaderboard_empty_state_renders_without_rows() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(helix()).await;
+
+    let (sid, csrf, _bare) = insert_session(&state, "42", "admin");
+    let req = Request::builder()
+        .uri("/leaderboard")
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app(state).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+    assert!(
+        html.contains("No personal bests yet"),
+        "empty state must render; got {html}"
+    );
+}
+
+#[tokio::test]
+async fn leaderboard_unauthenticated_redirects() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(helix()).await;
+
+    let req = Request::builder()
+        .uri("/leaderboard")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app(state).oneshot(req).await.unwrap();
+    // require_mod returns WebError::Unauthenticated → 401/redirect
+    assert!(
+        res.status() == StatusCode::SEE_OTHER || res.status() == StatusCode::UNAUTHORIZED,
+        "unauthenticated request must not get 200; got {}",
+        res.status()
+    );
+}
+
+#[tokio::test]
+async fn leaderboard_rows_sorted_by_ms_asc() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(helix()).await;
+
+    {
+        let mut lb = state.leaderboard.write().await;
+        lb.insert(
+            "bob".into(),
+            PersonalBest {
+                ms: 500,
+                date: NaiveDate::from_ymd_opt(2026, 2, 1).unwrap(),
+            },
+        );
+        lb.insert(
+            "alice".into(),
+            PersonalBest {
+                ms: 100,
+                date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            },
+        );
+    }
+
+    let (sid, csrf, _bare) = insert_session(&state, "42", "admin");
+    let req = Request::builder()
+        .uri("/leaderboard")
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app(state).oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+
+    // alice (100 ms) must appear before bob (500 ms).
+    let alice_pos = html.find("alice").expect("alice must appear");
+    let bob_pos = html.find("bob").expect("bob must appear");
+    assert!(
+        alice_pos < bob_pos,
+        "alice (100 ms) must rank above bob (500 ms); got {html}"
+    );
+}

--- a/crates/web/tests/memory_read.rs
+++ b/crates/web/tests/memory_read.rs
@@ -33,7 +33,7 @@ fn admin_helix(user_id: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users,
     })
 }

--- a/crates/web/tests/memory_read.rs
+++ b/crates/web/tests/memory_read.rs
@@ -33,6 +33,7 @@ fn admin_helix(user_id: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
+        followers: vec![],
         users,
     })
 }

--- a/crates/web/tests/memory_write.rs
+++ b/crates/web/tests/memory_write.rs
@@ -31,6 +31,7 @@ fn admin_helix(user_id: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
+        followers: vec![],
         users,
     })
 }

--- a/crates/web/tests/memory_write.rs
+++ b/crates/web/tests/memory_write.rs
@@ -31,7 +31,7 @@ fn admin_helix(user_id: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users,
     })
 }

--- a/crates/web/tests/pings_routes.rs
+++ b/crates/web/tests/pings_routes.rs
@@ -17,7 +17,8 @@ use twitch_1337_web::helix::{HelixClient, HelixUser};
 
 mod helpers;
 use helpers::{
-    FakeHelix, build_state_with_ping_dir, cookie_header, insert_session, install_crypto,
+    FakeHelix, build_state_with_ping_dir, cookie_header, insert_session, insert_session_as,
+    install_crypto,
 };
 
 /// FakeHelix flavored to admit the test admin during periodic mod rechecks.
@@ -467,5 +468,117 @@ async fn create_rejects_bad_form_csrf() {
     assert!(
         mgr.get("tampered").is_none(),
         "ping must not persist with mismatched _csrf",
+    );
+}
+
+/// Build a minimal router that mounts the pings routes under
+/// `require_role(Viewer)` so tests can exercise viewer-rendered HTML without
+/// waiting for Task 14 to wire up the real viewer sub-router.
+fn viewer_pings_app(
+    state: twitch_1337_web::WebState,
+) -> axum::Router {
+    use axum::Router;
+    use axum::middleware::from_fn_with_state;
+    use tower_cookies::CookieManagerLayer;
+    use twitch_1337_web::auth::{require_role, Role};
+    use twitch_1337_web::routes::pings::router as pings_router;
+
+    Router::new()
+        .merge(pings_router())
+        .route_layer(from_fn_with_state(state.clone(), move |s, c, r, n| {
+            require_role(Role::Viewer, s, c, r, n)
+        }))
+        .with_state(state)
+        .layer(CookieManagerLayer::new())
+}
+
+#[tokio::test]
+async fn viewer_pings_list_has_no_mutation_controls() {
+    install_crypto();
+    let helix = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec!["42".into()],
+        users: Default::default(),
+    });
+    let (state, _td) = build_state_with_ping_dir(helix).await;
+
+    // Seed a ping so the table renders rows, not the empty state.
+    {
+        let mut mgr = state.ping_manager.write().await;
+        mgr.create_ping("alpha".into(), "{mentions}".into(), "creator".into(), None)
+            .unwrap();
+    }
+
+    let (sid, csrf, _bare_csrf) =
+        insert_session_as(&state, "42", "alice", twitch_1337_web::auth::Role::Viewer);
+
+    let app = viewer_pings_app(state);
+    let req = Request::builder()
+        .uri("/pings")
+        .method("GET")
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+
+    assert!(html.contains("alpha"), "ping name should render for viewer");
+    assert!(
+        !html.contains(r#"href="/pings/new""#),
+        "viewer must not see +New button; got {html}"
+    );
+    assert!(
+        !html.contains("hx-post=\"/pings/"),
+        "viewer must not see delete buttons; got {html}"
+    );
+    assert!(
+        !html.contains("Sort: A"),
+        "viewer must not see sort chip; got {html}"
+    );
+}
+
+#[tokio::test]
+async fn mod_pings_list_shows_mutation_controls() {
+    install_crypto();
+    let user_id = "9002";
+    let helix = Arc::new(FakeHelix {
+        moderators: vec![user_id.into()],
+        followers: vec![],
+        users: Default::default(),
+    });
+    let (state, _td) = build_state_with_ping_dir(helix).await;
+
+    {
+        let mut mgr = state.ping_manager.write().await;
+        mgr.create_ping("beta".into(), "{mentions}".into(), "creator".into(), None)
+            .unwrap();
+    }
+
+    let (sid, csrf, _bare_csrf) =
+        insert_session_as(&state, user_id, "moduser", twitch_1337_web::auth::Role::Mod);
+
+    let app = build_router(state);
+    let req = Request::builder()
+        .uri("/pings")
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let html = body_string(res).await;
+
+    assert!(html.contains("beta"), "ping name should render for mod");
+    assert!(
+        html.contains(r#"href="/pings/new""#),
+        "mod must see +New button; got {html}"
+    );
+    assert!(
+        html.contains("hx-post=\"/pings/"),
+        "mod must see delete buttons; got {html}"
+    );
+    assert!(
+        html.contains("Sort: A"),
+        "mod must see sort chip; got {html}"
     );
 }

--- a/crates/web/tests/pings_routes.rs
+++ b/crates/web/tests/pings_routes.rs
@@ -474,13 +474,11 @@ async fn create_rejects_bad_form_csrf() {
 /// Build a minimal router that mounts the pings viewer routes under
 /// `require_role(Viewer)` so tests can exercise viewer-rendered HTML via the
 /// real viewer sub-router surface.
-fn viewer_pings_app(
-    state: twitch_1337_web::WebState,
-) -> axum::Router {
+fn viewer_pings_app(state: twitch_1337_web::WebState) -> axum::Router {
     use axum::Router;
     use axum::middleware::from_fn_with_state;
     use tower_cookies::CookieManagerLayer;
-    use twitch_1337_web::auth::{require_role, Role};
+    use twitch_1337_web::auth::{Role, require_role};
     use twitch_1337_web::routes::pings::viewer_router;
 
     Router::new()

--- a/crates/web/tests/pings_routes.rs
+++ b/crates/web/tests/pings_routes.rs
@@ -34,7 +34,7 @@ fn admin_helix(user_id: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users,
     })
 }
@@ -497,7 +497,7 @@ async fn viewer_pings_list_has_no_mutation_controls() {
     install_crypto();
     let helix = Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec!["42".into()],
+        followers: tokio::sync::RwLock::new(vec!["42".into()]),
         users: Default::default(),
     });
     let (state, _td) = build_state_with_ping_dir(helix).await;
@@ -544,7 +544,7 @@ async fn mod_pings_list_shows_mutation_controls() {
     let user_id = "9002";
     let helix = Arc::new(FakeHelix {
         moderators: vec![user_id.into()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users: Default::default(),
     });
     let (state, _td) = build_state_with_ping_dir(helix).await;

--- a/crates/web/tests/pings_routes.rs
+++ b/crates/web/tests/pings_routes.rs
@@ -33,6 +33,7 @@ fn admin_helix(user_id: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
+        followers: vec![],
         users,
     })
 }

--- a/crates/web/tests/pings_routes.rs
+++ b/crates/web/tests/pings_routes.rs
@@ -471,9 +471,9 @@ async fn create_rejects_bad_form_csrf() {
     );
 }
 
-/// Build a minimal router that mounts the pings routes under
-/// `require_role(Viewer)` so tests can exercise viewer-rendered HTML without
-/// waiting for Task 14 to wire up the real viewer sub-router.
+/// Build a minimal router that mounts the pings viewer routes under
+/// `require_role(Viewer)` so tests can exercise viewer-rendered HTML via the
+/// real viewer sub-router surface.
 fn viewer_pings_app(
     state: twitch_1337_web::WebState,
 ) -> axum::Router {
@@ -481,10 +481,10 @@ fn viewer_pings_app(
     use axum::middleware::from_fn_with_state;
     use tower_cookies::CookieManagerLayer;
     use twitch_1337_web::auth::{require_role, Role};
-    use twitch_1337_web::routes::pings::router as pings_router;
+    use twitch_1337_web::routes::pings::viewer_router;
 
     Router::new()
-        .merge(pings_router())
+        .merge(viewer_router())
         .route_layer(from_fn_with_state(state.clone(), move |s, c, r, n| {
             require_role(Role::Viewer, s, c, r, n)
         }))

--- a/crates/web/tests/sidebar_smoke.rs
+++ b/crates/web/tests/sidebar_smoke.rs
@@ -10,7 +10,10 @@ use twitch_1337_web::build_router;
 use twitch_1337_web::helix::{HelixClient, HelixUser};
 
 mod helpers;
-use helpers::{FakeHelix, build_state_with_dirs, cookie_header, insert_session, install_crypto};
+use helpers::{
+    FakeHelix, build_state_with_dirs, cookie_header, insert_session, insert_session_as,
+    install_crypto,
+};
 
 /// FakeHelix flavored to admit the seeded test user during periodic mod
 /// rechecks, mirroring `admin_helix` in the other route tests.
@@ -76,4 +79,36 @@ async fn memory_state_page_highlights_state() {
         .nth(1)
         .expect("active class present");
     assert!(snippet.contains("/memory/state"));
+}
+
+#[tokio::test]
+async fn sidebar_hides_memory_and_system_for_viewer() {
+    install_crypto();
+    let helix = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec!["42".into()],
+        users: HashMap::new(),
+    });
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(helix).await;
+    let (sid, csrf, _bare) =
+        insert_session_as(&state, "42", "alice", twitch_1337_web::auth::Role::Viewer);
+    let app = build_router(state);
+    let req = Request::builder()
+        .uri("/leaderboard")
+        .header(header::COOKIE, cookie_header(&sid, &csrf))
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK, "/leaderboard: status");
+    let bytes = to_bytes(res.into_body(), 128 * 1024).await.unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.contains("Leaderboard"), "leaderboard nav entry present");
+    assert!(body.contains("Flights"), "flights nav entry present");
+    assert!(!body.contains("/memory/soul"), "memory group hidden for viewer");
+    assert!(!body.contains("/logs"), "logs hidden for viewer");
+    assert!(!body.contains("/schedules"), "schedules hidden for viewer");
+    assert!(
+        body.contains("follower · viewer"),
+        "footer shows viewer role"
+    );
 }

--- a/crates/web/tests/sidebar_smoke.rs
+++ b/crates/web/tests/sidebar_smoke.rs
@@ -26,6 +26,7 @@ fn fake_helix_with_mod(user_id: &str, login: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
+        followers: vec![],
         users,
     })
 }

--- a/crates/web/tests/sidebar_smoke.rs
+++ b/crates/web/tests/sidebar_smoke.rs
@@ -29,7 +29,7 @@ fn fake_helix_with_mod(user_id: &str, login: &str) -> Arc<dyn HelixClient> {
     );
     Arc::new(FakeHelix {
         moderators: vec![user_id.to_owned()],
-        followers: vec![],
+        followers: tokio::sync::RwLock::new(vec![]),
         users,
     })
 }
@@ -86,7 +86,7 @@ async fn sidebar_hides_memory_and_system_for_viewer() {
     install_crypto();
     let helix = Arc::new(FakeHelix {
         moderators: vec![],
-        followers: vec!["42".into()],
+        followers: tokio::sync::RwLock::new(vec!["42".into()]),
         users: HashMap::new(),
     });
     let (state, _td_pings, _td_mem) = build_state_with_dirs(helix).await;

--- a/crates/web/tests/sidebar_smoke.rs
+++ b/crates/web/tests/sidebar_smoke.rs
@@ -102,9 +102,15 @@ async fn sidebar_hides_memory_and_system_for_viewer() {
     assert_eq!(res.status(), StatusCode::OK, "/leaderboard: status");
     let bytes = to_bytes(res.into_body(), 128 * 1024).await.unwrap();
     let body = String::from_utf8(bytes.to_vec()).unwrap();
-    assert!(body.contains("Leaderboard"), "leaderboard nav entry present");
+    assert!(
+        body.contains("Leaderboard"),
+        "leaderboard nav entry present"
+    );
     assert!(body.contains("Flights"), "flights nav entry present");
-    assert!(!body.contains("/memory/soul"), "memory group hidden for viewer");
+    assert!(
+        !body.contains("/memory/soul"),
+        "memory group hidden for viewer"
+    );
     assert!(!body.contains("/logs"), "logs hidden for viewer");
     assert!(!body.contains("/schedules"), "schedules hidden for viewer");
     assert!(

--- a/docs/superpowers/plans/2026-05-12-dashboard-viewer-tier.md
+++ b/docs/superpowers/plans/2026-05-12-dashboard-viewer-tier.md
@@ -1,0 +1,1761 @@
+# Dashboard viewer tier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a follower-gated, read-only "viewer" tier to the web dashboard so the broader community can see the leaderboard, currently tracked flights, and the ping catalogue while keeping mutations and AI memory mod-only.
+
+**Architecture:** Introduce an ordered `Role { Viewer, Mod }` enum stored on `Session`, generalise the existing `require_mod` middleware to `require_role(min)`, add follower checks against Twitch helix (`/channels/followers` with the bot token, `/channels/followed` with the user token), split the axum router into viewer / mod sub-routers with a `viewer_method_guard` that rejects non-GET/HEAD, and surface two new pages (`/leaderboard`, `/flights`) sourced from shared `Arc<RwLock<HashMap<…>>>` and a new `TrackerCommand::Snapshot` over the existing mpsc.
+
+**Tech Stack:** Rust 2024, axum 0.8, askama, tower-cookies, twitch helix REST, tokio mpsc/oneshot.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-dashboard-viewer-tier-design.md`. See § 14 for the matching build sequence.
+
+**Conventions reminders (project-specific, do not forget):**
+- Use `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail` instead of `cargo test` ([feedback memory](../../../../home/chrono/.claude/projects/-home-chrono-Projects-twitch-1337/memory/feedback_use_nextest.md)).
+- Pre-commit gate: `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo nextest run …`.
+- Cargo.lock must be staged alongside any `Cargo.toml` dep change in the same commit.
+- Use `gh` with the sandbox disabled (see feedback memory).
+- Branch already exists for this work via worktree.
+
+---
+
+## File map
+
+**New:**
+- `crates/web/src/auth/role.rs` — `Role` enum and ordering.
+- `crates/web/src/routes/leaderboard.rs` — `/leaderboard` handler.
+- `crates/web/src/routes/flights.rs` — `/flights` handler.
+- `crates/web/templates/leaderboard/list.html` — leaderboard template.
+- `crates/web/templates/flights/list.html` — flights template.
+- `crates/web/tests/auth_viewer_tier.rs` — viewer-tier integration scenarios.
+
+**Renamed:**
+- `crates/web/src/auth/mod_check.rs` → `crates/web/src/auth/role_check.rs`.
+
+**Modified:**
+- `crates/web/src/auth/mod.rs` — module renames + re-exports.
+- `crates/web/src/auth/session.rs` — add `role` to `Session`, rename `last_mod_check`/`record_mod_check`.
+- `crates/web/src/auth/routes.rs` — add `require_role`, `viewer_method_guard`, scope, callback dispatch.
+- `crates/web/src/helix.rs` — `HelixClient::is_follower`, helper for `/channels/followed`.
+- `crates/web/src/error.rs` — `MethodNotAllowed` variant.
+- `crates/web/src/config.rs` — rename `mod_check_refresh` → `role_check_refresh`.
+- `crates/web/src/state.rs` — leaderboard handle + optional tracker mpsc.
+- `crates/web/src/lib.rs` — viewer / mod router split + root redirect.
+- `crates/web/src/nav.rs` — role-conditional sidebar.
+- `crates/web/src/routes/pings.rs` — pass `is_mod` into templates.
+- `crates/web/src/routes/mod.rs` — register leaderboard/flights.
+- `crates/web/src/routes/stubs.rs` — drop `/flights` stub.
+- `crates/web/src/bin/web_dev.rs` — wire leaderboard + tracker into `WebState`.
+- `crates/web/templates/sidebar.html` — role-gate groups, add Leaderboard.
+- `crates/web/templates/pings/list.html` — gate mutation controls on `is_mod`.
+- `crates/web/tests/helpers/mod.rs` — `FakeHelix.followers`, leaderboard fixtures.
+- `crates/core/src/aviation/tracker.rs` — `TrackerCommand::Snapshot` + handling.
+- `crates/twitch-1337/src/main.rs` (or equivalent bin wiring) — pass leaderboard `Arc` and tracker sender into `WebState`.
+- `CLAUDE.md` — note new OAuth scopes + bot scope under "Config".
+
+---
+
+## Task 1: Add `Role` enum
+
+**Files:**
+- Create: `crates/web/src/auth/role.rs`
+- Modify: `crates/web/src/auth/mod.rs`
+
+- [ ] **Step 1: Create the role module**
+
+Write `crates/web/src/auth/role.rs`:
+
+```rust
+//! Authenticated dashboard tier.
+//!
+//! Ordered so `session.role >= required` is the gate predicate; inserting
+//! a new tier later means slotting it in at the right ordinal.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Role {
+    Viewer,
+    Mod,
+}
+
+impl Role {
+    pub fn label(self) -> &'static str {
+        match self {
+            Role::Viewer => "viewer",
+            Role::Mod => "mod",
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from `auth/mod.rs`**
+
+In `crates/web/src/auth/mod.rs`, add `pub mod role;` next to the other `pub mod`s and `pub use role::Role;` next to the existing `pub use routes::{…};`.
+
+- [ ] **Step 3: Add ordering test**
+
+Append to `crates/web/src/auth/role.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::Role;
+
+    #[test]
+    fn viewer_is_lower_than_mod() {
+        assert!(Role::Viewer < Role::Mod);
+        assert!(Role::Mod >= Role::Viewer);
+        assert!(Role::Viewer >= Role::Viewer);
+    }
+
+    #[test]
+    fn labels_match_tracing_fields() {
+        assert_eq!(Role::Viewer.label(), "viewer");
+        assert_eq!(Role::Mod.label(), "mod");
+    }
+}
+```
+
+- [ ] **Step 4: Run the test, expect pass**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web auth::role`
+Expected: 2 passed.
+
+- [ ] **Step 5: Pre-commit gate + commit**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+git add crates/web/src/auth/role.rs crates/web/src/auth/mod.rs
+git commit -m "feat(web): introduce Role enum (viewer < mod)"
+```
+
+---
+
+## Task 2: Thread `Role` through `Session`
+
+**Files:**
+- Modify: `crates/web/src/auth/session.rs`
+- Modify: `crates/web/src/auth/routes.rs` (compile-fix at single call-site)
+- Modify: `crates/web/tests/helpers/mod.rs` (if it calls `insert`)
+
+- [ ] **Step 1: Add the field + accept it on insert**
+
+In `crates/web/src/auth/session.rs`, change the `Session` struct and `insert` signature:
+
+```rust
+use crate::auth::role::Role;
+
+#[derive(Clone, Debug)]
+pub struct Session {
+    pub user_id: String,
+    pub user_login: String,
+    pub role: Role,
+    pub issued_at: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub last_role_check: DateTime<Utc>,
+    pub csrf_value: [u8; 32],
+}
+```
+
+```rust
+pub fn insert(
+    &self,
+    user_id: String,
+    user_login: String,
+    role: Role,
+) -> Result<(SessionId, [u8; 32])> {
+    let now = self.clock.now();
+    let mut rng = rand::rng();
+    let mut id_bytes = [0u8; 32];
+    rng.fill_bytes(&mut id_bytes);
+    let mut csrf = [0u8; 32];
+    rng.fill_bytes(&mut csrf);
+    let id = hex::encode(id_bytes);
+    self.inner.write().unwrap().insert(
+        id.clone(),
+        Session {
+            user_id,
+            user_login,
+            role,
+            issued_at: now,
+            last_seen: now,
+            last_role_check: now,
+            csrf_value: csrf,
+        },
+    );
+    Ok((id, csrf))
+}
+```
+
+- [ ] **Step 2: Rename `record_mod_check` → `record_role_check`**
+
+In the same file:
+
+```rust
+pub fn record_role_check(&self, id: &str) {
+    let now = self.clock.now();
+    if let Some(s) = self.inner.write().unwrap().get_mut(id) {
+        s.last_role_check = now;
+    }
+}
+```
+
+Also update the file's top-level doc comment to say "role-gate middleware" instead of "mod-gate middleware".
+
+- [ ] **Step 3: Patch the only `insert` call-site**
+
+In `crates/web/src/auth/routes.rs::callback`, replace:
+
+```rust
+let (sid, csrf_value) = state
+    .sessions
+    .insert(me.id.clone(), me.login.clone())
+```
+
+with (temporarily — refined in Task 7):
+
+```rust
+let (sid, csrf_value) = state
+    .sessions
+    .insert(me.id.clone(), me.login.clone(), crate::auth::role::Role::Mod)
+```
+
+Also update `record_mod_check` → `record_role_check` in `require_mod`, and `last_mod_check` → `last_role_check` in the elapsed-since read.
+
+- [ ] **Step 4: Patch test helpers**
+
+In `crates/web/tests/helpers/mod.rs`, the `insert_session` helper calls `sessions.insert(...)`. Add a `Role::Mod` argument so existing tests still seed a mod session by default:
+
+```rust
+pub fn insert_session(state: &WebState, user_id: &str, user_login: &str) -> (String, [u8; 32]) {
+    state
+        .sessions
+        .insert(user_id.to_owned(), user_login.to_owned(), twitch_1337_web::auth::Role::Mod)
+        .expect("insert test session")
+}
+```
+
+(Adjust the actual return type to match whatever the existing helper returns — keep the signature stable for callers.)
+
+- [ ] **Step 5: Rename `mod_check_refresh` → `role_check_refresh`**
+
+In `crates/web/src/config.rs`:
+
+```rust
+#[derive(Clone)]
+pub struct WebConfig {
+    pub bind_addr: String,
+    pub public_url: String,
+    pub session_secret: SecretString,
+    pub session_ttl: Duration,
+    pub role_check_refresh: Duration,
+}
+```
+
+Grep for any remaining `mod_check_refresh` references and update them (`crates/web/src/auth/routes.rs::require_mod`, `crates/web/src/bin/web_dev.rs`, the bin under `crates/twitch-1337/src/`, and `crates/web/tests/helpers/mod.rs`):
+
+```bash
+rg -l "mod_check_refresh" .
+```
+
+Update every hit. Use the same default value (no behaviour change).
+
+- [ ] **Step 6: Build + test**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web`
+Expected: all existing tests still pass (each session is now created with `Role::Mod`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/web/src/auth/session.rs crates/web/src/auth/routes.rs \
+        crates/web/src/config.rs crates/web/tests/helpers/mod.rs \
+        crates/web/src/bin/web_dev.rs crates/twitch-1337/src
+git commit -m "refactor(web): thread Role through Session, rename mod_check→role_check"
+```
+
+(The path list reflects renames; if `crates/twitch-1337/src/` has no `mod_check_refresh` references, drop it from `git add`.)
+
+---
+
+## Task 3: Rename `auth/mod_check.rs` → `auth/role_check.rs`
+
+**Files:**
+- Rename: `crates/web/src/auth/mod_check.rs` → `crates/web/src/auth/role_check.rs`
+- Modify: `crates/web/src/auth/mod.rs`
+- Modify: `crates/web/src/auth/routes.rs` (import path)
+
+- [ ] **Step 1: Move the file**
+
+```bash
+git mv crates/web/src/auth/mod_check.rs crates/web/src/auth/role_check.rs
+```
+
+- [ ] **Step 2: Update `auth/mod.rs`**
+
+Replace `pub mod mod_check;` with `pub mod role_check;` and update the module-level doc comment in `auth/mod.rs` accordingly.
+
+- [ ] **Step 3: Update imports in `routes.rs`**
+
+In `crates/web/src/auth/routes.rs`:
+
+```rust
+use crate::auth::role_check::{ModCheckOutcome, check_is_mod};
+```
+
+becomes:
+
+```rust
+use crate::auth::role_check::{GateOutcome, check_is_mod};
+```
+
+…and inside `role_check.rs` rename the enum:
+
+```rust
+pub enum GateOutcome { Allow, Deny }
+```
+
+Sweep `rg -l "ModCheckOutcome"` and rewrite every match.
+
+- [ ] **Step 4: Build**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A crates/web/src/auth
+git commit -m "refactor(web): rename mod_check → role_check, ModCheckOutcome → GateOutcome"
+```
+
+---
+
+## Task 4: Add `HelixClient::is_follower`
+
+**Files:**
+- Modify: `crates/web/src/helix.rs`
+- Modify: `crates/web/tests/helpers/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/web/tests/helpers/mod.rs` (extending the existing `FakeHelix`):
+
+```rust
+pub struct FakeHelix {
+    pub moderators: Vec<String>,
+    pub followers: Vec<String>, // user ids that follow the broadcaster
+    pub users: HashMap<String, HelixUser>,
+}
+
+#[async_trait]
+impl HelixClient for FakeHelix {
+    // ... existing methods ...
+    async fn is_follower(&self, _broadcaster: &str, user_id: &str) -> eyre::Result<bool> {
+        Ok(self.followers.iter().any(|f| f == user_id))
+    }
+}
+```
+
+Update every existing `FakeHelix { ... }` construction in `tests/*.rs` to include `followers: vec![]`. Run `rg -l "FakeHelix \{"` and patch each one.
+
+Create `crates/web/tests/helix_follower_check.rs` (mirrors the existing `helix_moderator_check.rs`):
+
+```rust
+mod helpers;
+
+use std::sync::Arc;
+
+use helpers::FakeHelix;
+use twitch_1337_web::helix::HelixClient;
+
+#[tokio::test]
+async fn is_follower_reports_membership() {
+    let helix: Arc<dyn HelixClient> = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec!["42".into()],
+        users: Default::default(),
+    });
+    assert!(helix.is_follower("b123", "42").await.unwrap());
+    assert!(!helix.is_follower("b123", "99").await.unwrap());
+}
+```
+
+- [ ] **Step 2: Run the test, expect compile failure**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web helix_follower_check`
+Expected: compile error — `is_follower` not on the trait.
+
+- [ ] **Step 3: Extend the trait**
+
+In `crates/web/src/helix.rs`, add to the trait:
+
+```rust
+async fn is_follower(&self, broadcaster_id: &str, user_id: &str) -> eyre::Result<bool>;
+```
+
+Implement on the production helix client by calling
+`GET https://api.twitch.tv/helix/channels/followers?broadcaster_id={broadcaster_id}&user_id={user_id}`
+with the bot's helix user token (same auth shape as `is_moderator`):
+
+```rust
+async fn is_follower(&self, broadcaster_id: &str, user_id: &str) -> eyre::Result<bool> {
+    #[derive(serde::Deserialize)]
+    struct Resp { total: u64 }
+    let url = format!(
+        "https://api.twitch.tv/helix/channels/followers?broadcaster_id={}&user_id={}",
+        broadcaster_id, user_id,
+    );
+    let resp = self
+        .http
+        .get(&url)
+        .bearer_auth(self.bearer.expose_secret())
+        .header("Client-Id", self.client_id.expose_secret())
+        .send()
+        .await
+        .wrap_err("helix /channels/followers send")?;
+    let status = resp.status();
+    let resp = resp
+        .error_for_status()
+        .wrap_err_with(|| format!("helix /channels/followers returned {status}"))?;
+    let parsed: Resp = resp.json().await.wrap_err("helix /channels/followers decode")?;
+    Ok(parsed.total > 0)
+}
+```
+
+(Match the field names of the existing helix client in `helix.rs`; if it uses `Self::http`, `Self::token`, etc., keep that.)
+
+- [ ] **Step 4: Run the test, expect pass**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web helix_follower_check`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/helix.rs crates/web/tests/helpers/mod.rs crates/web/tests/helix_follower_check.rs crates/web/tests/*.rs
+git commit -m "feat(web): HelixClient::is_follower (channels/followers)"
+```
+
+---
+
+## Task 5: `check_is_follower_with_token` (login-path helper)
+
+**Files:**
+- Modify: `crates/web/src/auth/role_check.rs`
+
+- [ ] **Step 1: Add a unit test against a recorded fixture or HTTP mock**
+
+`role_check.rs` already has `check_is_mod_with_token` calling helix through `state.oauth.http`. The simplest test path is to assert the URL + headers via `wiremock`. If wiremock isn't a dep yet, fall back to a hand-rolled `axum::Router` listener on a free port (pattern used in `auth_routes.rs`). Pseudocode shape (adapt to existing test infra):
+
+```rust
+#[tokio::test]
+async fn check_is_follower_with_token_allows_when_followed() {
+    // Spin up a tiny axum server that returns
+    // {"data":[{"broadcaster_id":"b","user_id":"u"}],"total":1}
+    // when GET /helix/channels/followed?user_id=u&broadcaster_id=b arrives
+    // with the right bearer + client-id. Build a `WebState` pointing at
+    // its base url, call check_is_follower_with_token, assert Allow.
+}
+```
+
+Mirror the test against an empty `data: []` response → expect `Deny`.
+
+- [ ] **Step 2: Run the test, expect failure**
+
+Function does not exist yet. Compile error.
+
+- [ ] **Step 3: Add the helper**
+
+In `crates/web/src/auth/role_check.rs`:
+
+```rust
+/// Login-path check using the viewer's just-issued user token. Calls
+/// `/helix/channels/followed?user_id=…&broadcaster_id=…` (requires the
+/// `user:read:follows` scope on the user token).
+pub async fn check_is_follower_with_token(
+    state: &WebState,
+    user_id: &str,
+    user_access_token: &str,
+    broadcaster_id: &str,
+) -> eyre::Result<GateOutcome> {
+    #[derive(serde::Deserialize)]
+    struct Resp { total: u64 }
+    let url = format!(
+        "{}/helix/channels/followed?user_id={}&broadcaster_id={}",
+        state.helix_base_url(), user_id, broadcaster_id,
+    );
+    let resp = state
+        .oauth
+        .http
+        .get(&url)
+        .bearer_auth(user_access_token)
+        .header("Client-Id", state.client_id.expose_secret())
+        .send()
+        .await
+        .wrap_err("helix /channels/followed send")?;
+    let status = resp.status();
+    let resp = resp
+        .error_for_status()
+        .wrap_err_with(|| format!("helix /channels/followed returned {status}"))?;
+    let parsed: Resp = resp.json().await.wrap_err("helix /channels/followed decode")?;
+    if parsed.total > 0 { Ok(GateOutcome::Allow) } else { Ok(GateOutcome::Deny) }
+}
+```
+
+If `WebState::helix_base_url()` doesn't already exist, mirror what `check_is_mod_with_token` uses today — it hard-codes `https://api.twitch.tv`. Use the same constant here for consistency.
+
+- [ ] **Step 4: Run the test, expect pass**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web check_is_follower`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/auth/role_check.rs crates/web/tests/auth_follower_check.rs
+git commit -m "feat(web): check_is_follower_with_token (login path)"
+```
+
+---
+
+## Task 6: `viewer_method_guard` + `WebError::MethodNotAllowed`
+
+**Files:**
+- Modify: `crates/web/src/error.rs`
+- Modify: `crates/web/src/auth/routes.rs`
+
+- [ ] **Step 1: Add the error variant + its IntoResponse mapping**
+
+In `crates/web/src/error.rs`:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum WebError {
+    // ... existing ...
+    #[error("method not allowed")]
+    MethodNotAllowed,
+}
+```
+
+Extend the `IntoResponse` impl with:
+
+```rust
+WebError::MethodNotAllowed => (axum::http::StatusCode::METHOD_NOT_ALLOWED, "method not allowed").into_response(),
+```
+
+- [ ] **Step 2: Write the guard middleware**
+
+In `crates/web/src/auth/routes.rs`:
+
+```rust
+pub async fn viewer_method_guard(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<axum::response::Response, WebError> {
+    use axum::http::Method;
+    match *req.method() {
+        Method::GET | Method::HEAD => Ok(next.run(req).await),
+        _ => Err(WebError::MethodNotAllowed),
+    }
+}
+```
+
+- [ ] **Step 3: Write a unit test**
+
+In a new `#[cfg(test)] mod` block at the bottom of `routes.rs` or in a new `crates/web/tests/auth_viewer_guard.rs`:
+
+```rust
+#[tokio::test]
+async fn viewer_method_guard_rejects_post() {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use tower::ServiceExt as _;
+
+    let app = Router::new()
+        .route("/x", axum::routing::any(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(twitch_1337_web::auth::viewer_method_guard));
+
+    let resp = app
+        .clone()
+        .oneshot(Request::builder().uri("/x").method(Method::GET).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/x").method(Method::POST).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+```
+
+Re-export `viewer_method_guard` from `auth/mod.rs` so external test crates can name it.
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web viewer_method_guard`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/error.rs crates/web/src/auth/routes.rs crates/web/src/auth/mod.rs crates/web/tests/auth_viewer_guard.rs
+git commit -m "feat(web): viewer_method_guard rejects non-GET/HEAD with 405"
+```
+
+---
+
+## Task 7: Generalise `require_mod` → `require_role`
+
+**Files:**
+- Modify: `crates/web/src/auth/routes.rs`
+- Modify: `crates/web/src/auth/role_check.rs`
+- Modify: `crates/web/src/auth/mod.rs`
+
+- [ ] **Step 1: Add a generic role-aware helix gate**
+
+In `crates/web/src/auth/role_check.rs`, alongside `check_is_mod`, add:
+
+```rust
+pub async fn check_is_follower(
+    helix: &dyn HelixClient,
+    broadcaster_id: &str,
+    user_id: &str,
+) -> eyre::Result<GateOutcome> {
+    if helix.is_follower(broadcaster_id, user_id).await? {
+        Ok(GateOutcome::Allow)
+    } else {
+        Ok(GateOutcome::Deny)
+    }
+}
+```
+
+- [ ] **Step 2: Generalise the middleware**
+
+Replace `require_mod` in `crates/web/src/auth/routes.rs` with:
+
+```rust
+pub async fn require_role(
+    min: crate::auth::role::Role,
+    State(state): State<WebState>,
+    cookies: Cookies,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, WebError> {
+    let captured_next = req.uri().path_and_query().map(|pq| pq.as_str().to_owned());
+    let unauth = || WebError::Unauthenticated { next: captured_next.clone() };
+
+    let sid_cookie = cookies
+        .signed(&state.signed_key)
+        .get(SID_COOKIE)
+        .ok_or_else(unauth)?;
+    let session = state
+        .sessions
+        .get_and_touch(sid_cookie.value())
+        .ok_or_else(unauth)?;
+
+    if session.role < min {
+        return Err(WebError::Forbidden);
+    }
+
+    let now = state.clock.now();
+    let elapsed = now
+        .signed_duration_since(session.last_role_check)
+        .to_std()
+        .unwrap_or_default();
+    if elapsed > state.config.role_check_refresh {
+        let outcome = match session.role {
+            crate::auth::role::Role::Mod => check_is_mod(
+                state.helix.as_ref(),
+                &session.user_id,
+                &state.broadcaster_id,
+                &state.hidden_admins,
+            ).await,
+            crate::auth::role::Role::Viewer => check_is_follower(
+                state.helix.as_ref(),
+                &state.broadcaster_id,
+                &session.user_id,
+            ).await,
+        };
+        match outcome {
+            Ok(GateOutcome::Allow) => state.sessions.record_role_check(sid_cookie.value()),
+            Ok(GateOutcome::Deny) => {
+                state.sessions.drop_session(sid_cookie.value());
+                tracing::info!(
+                    target: "twitch_1337_web",
+                    user_id = %session.user_id,
+                    role = session.role.label(),
+                    action = "role_recheck",
+                    result = "denied",
+                );
+                return Err(WebError::Forbidden);
+            }
+            Err(e) => {
+                tracing::warn!(target: "twitch_1337_web", error = ?e, "role refresh failed; admitting on stale check");
+            }
+        }
+    }
+
+    req.extensions_mut().insert(session);
+    Ok(next.run(req).await)
+}
+```
+
+(Note: axum `from_fn_with_state` takes a function — to bind the `min` arg, use a tiny adapter per layer like `move |s, c, r, n| require_role(Role::Mod, s, c, r, n)`. Wire the adapter in lib.rs in Task 11. For now also keep:)
+
+```rust
+pub async fn require_mod(
+    state: State<WebState>,
+    cookies: Cookies,
+    req: Request,
+    next: Next,
+) -> Result<Response, WebError> {
+    require_role(crate::auth::role::Role::Mod, state, cookies, req, next).await
+}
+```
+
+- [ ] **Step 3: Update `auth/mod.rs` re-exports**
+
+```rust
+pub use routes::{CSRF_COOKIE, OAuthCtx, SID_COOKIE, auth_router, require_mod, require_role, viewer_method_guard};
+```
+
+- [ ] **Step 4: Build + existing tests**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web`
+Expected: all existing tests pass (they seed `Role::Mod` sessions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/auth
+git commit -m "feat(web): generalise require_mod → require_role(min)"
+```
+
+---
+
+## Task 8: Callback tries mod → follower → deny
+
+**Files:**
+- Modify: `crates/web/src/auth/routes.rs`
+
+- [ ] **Step 1: Add `user:read:follows` to the OAuth scope set**
+
+In `auth_start`:
+
+```rust
+.add_scope(Scope::new("user:read:follows".to_owned()))
+```
+
+(Alongside the existing `user:read:email` and `user:read:moderated_channels`.)
+
+- [ ] **Step 2: Rework the callback decision**
+
+Replace the mod-check block in `callback` with:
+
+```rust
+let role = match crate::auth::role_check::check_is_mod_with_token(
+    &state, &me.id, &user_token, &state.broadcaster_id, &state.hidden_admins,
+).await.map_err(|e| WebError::OAuthExchange(e.wrap_err("mod check")))? {
+    GateOutcome::Allow => crate::auth::role::Role::Mod,
+    GateOutcome::Deny => match crate::auth::role_check::check_is_follower_with_token(
+        &state, &me.id, &user_token, &state.broadcaster_id,
+    ).await.map_err(|e| WebError::OAuthExchange(e.wrap_err("follower check")))? {
+        GateOutcome::Allow => crate::auth::role::Role::Viewer,
+        GateOutcome::Deny => {
+            tracing::info!(
+                target: "twitch_1337_web",
+                user_id = %me.id,
+                user_login = %me.login,
+                action = "login",
+                result = "denied",
+            );
+            return Err(WebError::Forbidden);
+        }
+    },
+};
+
+let (sid, csrf_value) = state
+    .sessions
+    .insert(me.id.clone(), me.login.clone(), role)
+    .map_err(WebError::Internal)?;
+```
+
+And extend the success-log line:
+
+```rust
+tracing::info!(
+    target: "twitch_1337_web",
+    user_id = %me.id,
+    user_login = %me.login,
+    role = role.label(),
+    next_path = %next_path,
+    action = "login",
+    result = "ok",
+);
+```
+
+- [ ] **Step 3: Adjust existing callback tests**
+
+`crates/web/tests/auth_routes.rs` and any other callback-path test should still pass because the seeded test user is a moderator. Run:
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web auth_routes`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/web/src/auth/routes.rs
+git commit -m "feat(web): callback tries mod → follower → deny; emits role audit field"
+```
+
+---
+
+## Task 9: `WebState` gains leaderboard + tracker handles
+
+**Files:**
+- Modify: `crates/web/src/state.rs`
+- Modify: `crates/web/src/bin/web_dev.rs`
+- Modify: `crates/web/tests/helpers/mod.rs`
+- Modify: `crates/twitch-1337/src/` (main bin wiring — confirm path with `rg "WebState \{" crates/twitch-1337/src`)
+
+- [ ] **Step 1: Extend `WebState`**
+
+```rust
+use std::collections::HashMap;
+use twitch_1337_core::commands::leaderboard::PersonalBest; // adjust to actual export
+use twitch_1337_core::aviation::tracker::TrackerCommand;
+
+pub struct WebState {
+    // ... existing fields ...
+    pub leaderboard: Arc<tokio::sync::RwLock<HashMap<String, PersonalBest>>>,
+    pub tracker_tx: Option<Arc<tokio::sync::mpsc::Sender<TrackerCommand>>>,
+}
+```
+
+If `PersonalBest` is not `pub`, make it so in `crates/core/src/commands/leaderboard.rs`. If `TrackerCommand` is not `pub`, ditto.
+
+- [ ] **Step 2: Update the bin wiring**
+
+In `crates/web/src/bin/web_dev.rs`, construct an empty leaderboard `Arc` (dev binary has no live bot) and `tracker_tx: None`. In `crates/twitch-1337/src/<main>.rs`, pass the same `Arc` already held by the 1337 tracker handler and the existing `tracker_tx`. Use `rg "leaderboard: Arc<" crates/twitch-1337/src` to find the spot where the 1337 handler is spawned.
+
+- [ ] **Step 3: Patch test helpers**
+
+In `crates/web/tests/helpers/mod.rs::build_state_with_dirs`, add:
+
+```rust
+let leaderboard = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+```
+
+…and pass it into the `WebState` initialiser. `tracker_tx: None`.
+
+- [ ] **Step 4: Build + run existing tests**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/state.rs crates/web/src/bin/web_dev.rs \
+        crates/web/tests/helpers/mod.rs crates/twitch-1337/src crates/core/src/commands/leaderboard.rs
+git commit -m "feat(web): share leaderboard + tracker mpsc through WebState"
+```
+
+---
+
+## Task 10: `TrackerCommand::Snapshot` over mpsc
+
+**Files:**
+- Modify: `crates/core/src/aviation/tracker.rs`
+
+- [ ] **Step 1: Add the snapshot variant + view type**
+
+```rust
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TrackedFlightView {
+    pub callsign: Option<String>,
+    pub owner_login: String,
+    pub phase: String,
+    pub altitude_ft: Option<i32>,
+    pub ground_speed_kt: Option<i32>,
+    pub last_update_secs_ago: u64,
+}
+
+pub enum TrackerCommand {
+    Track { /* ... */ },
+    Untrack { /* ... */ },
+    Status { /* ... */ },
+    Snapshot { reply: tokio::sync::oneshot::Sender<Vec<TrackedFlightView>> },
+}
+```
+
+- [ ] **Step 2: Handle it in the tracker loop**
+
+Inside the existing `match` arm dispatch where `TrackerCommand` is consumed, add:
+
+```rust
+TrackerCommand::Snapshot { reply } => {
+    let now = std::time::Instant::now();
+    let view: Vec<TrackedFlightView> = tracked_flights
+        .iter()
+        .map(|f| TrackedFlightView {
+            callsign: f.callsign.clone(),
+            owner_login: f.owner_login.clone(),
+            phase: format!("{:?}", f.phase),
+            altitude_ft: f.last_state.as_ref().and_then(|s| s.altitude_ft),
+            ground_speed_kt: f.last_state.as_ref().and_then(|s| s.ground_speed_kt),
+            last_update_secs_ago: now.saturating_duration_since(f.last_seen).as_secs(),
+        })
+        .collect();
+    let _ = reply.send(view);
+}
+```
+
+(Field names mirror whatever the existing `TrackedFlight` struct uses — confirm via `rg "struct TrackedFlight" crates/core/src/aviation/tracker.rs`.)
+
+- [ ] **Step 3: Test**
+
+Add a `#[tokio::test]` in `crates/core/src/aviation/tracker.rs` that:
+1. Builds the tracker, spawns the loop, sends `TrackerCommand::Track` for two fake aircraft.
+2. Sends `TrackerCommand::Snapshot` with a fresh oneshot, awaits the reply with a 1s timeout.
+3. Asserts the reply length and field shape.
+
+(If the tracker has no existing tokio integration test scaffolding, drop the integration test here and rely on the `flights_route` test in Task 12 to cover end-to-end behaviour through the mpsc.)
+
+- [ ] **Step 4: Build + run tests**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-core aviation::tracker`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/aviation/tracker.rs
+git commit -m "feat(core): TrackerCommand::Snapshot returns read-only flight view"
+```
+
+---
+
+## Task 11: Leaderboard route + template
+
+**Files:**
+- Create: `crates/web/src/routes/leaderboard.rs`
+- Create: `crates/web/templates/leaderboard/list.html`
+- Modify: `crates/web/src/routes/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/web/tests/leaderboard_route.rs`:
+
+```rust
+mod helpers;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use helpers::{FakeHelix, build_state, install_crypto, cookie_header, insert_session};
+use std::sync::Arc;
+use tower::ServiceExt as _;
+
+#[tokio::test]
+async fn viewer_can_read_leaderboard() {
+    install_crypto();
+    let helix = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec!["42".into()],
+        users: Default::default(),
+    });
+    let state = build_state(helix).await;
+    // Seed leaderboard
+    {
+        let mut lb = state.leaderboard.write().await;
+        lb.insert(
+            "alice".into(),
+            twitch_1337_core::commands::leaderboard::PersonalBest { ms: 250, count: 3 },
+        );
+    }
+    let (sid, _) = state.sessions.insert(
+        "42".into(), "alice".into(), twitch_1337_web::auth::Role::Viewer,
+    ).unwrap();
+    let app = twitch_1337_web::build_router(state.clone());
+    let resp = app.oneshot(
+        Request::builder()
+            .uri("/leaderboard")
+            .method(Method::GET)
+            .header("cookie", cookie_header(&state.signed_key, &sid))
+            .body(Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body_str.contains("alice"), "leaderboard should render alice");
+    assert!(body_str.contains("250"), "leaderboard should render 250 ms");
+}
+```
+
+(Confirm `PersonalBest` field names — adjust `ms` / `count` to match.)
+
+- [ ] **Step 2: Run, expect failure (route not registered)**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web leaderboard_route`
+Expected: `404` or compile failure (`leaderboard` field unknown until Task 9).
+
+- [ ] **Step 3: Add the template**
+
+Write `crates/web/templates/leaderboard/list.html`:
+
+```html
+{% extends "base.html" %}
+{% block content %}
+<header class="page-head">
+  <h1>Leaderboard</h1>
+  <p class="sub">Sub-second 1337 personal bests. Fastest wins.</p>
+</header>
+<section class="card table-card">
+  {% if entries.is_empty() %}
+    <div class="placeholder">No personal bests yet.</div>
+  {% else %}
+  <div class="table" role="table">
+    <div class="row head" role="row">
+      <div role="columnheader">#</div>
+      <div role="columnheader">User</div>
+      <div role="columnheader">Best</div>
+      <div role="columnheader">Count</div>
+    </div>
+    {% for row in entries %}
+    <div class="row" role="row">
+      <div role="cell" class="mono num">{{ loop.index }}</div>
+      <div role="cell" class="mono">{{ row.login }}</div>
+      <div role="cell" class="mono num">{{ row.best_ms }} ms</div>
+      <div role="cell" class="mono num">{{ row.count }}</div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</section>
+{% endblock %}
+```
+
+- [ ] **Step 4: Write the handler**
+
+Create `crates/web/src/routes/leaderboard.rs`:
+
+```rust
+use askama::Template;
+use axum::Router;
+use axum::extract::{Extension, State};
+use axum::response::Response;
+use axum::routing::get;
+
+use crate::auth::session::Session;
+use crate::error::WebError;
+use crate::routes::render;
+use crate::state::WebState;
+
+#[derive(Template)]
+#[template(path = "leaderboard/list.html")]
+struct LeaderboardTpl {
+    entries: Vec<Row>,
+}
+
+struct Row {
+    login: String,
+    best_ms: u32,
+    count: u32,
+}
+
+pub fn router() -> Router<WebState> {
+    Router::new().route("/leaderboard", get(list))
+}
+
+async fn list(
+    State(state): State<WebState>,
+    Extension(_session): Extension<Session>,
+) -> Result<Response, WebError> {
+    let lb = state.leaderboard.read().await;
+    let mut entries: Vec<Row> = lb
+        .iter()
+        .map(|(login, pb)| Row {
+            login: login.clone(),
+            best_ms: pb.ms,
+            count: pb.count,
+        })
+        .collect();
+    entries.sort_by(|a, b| a.best_ms.cmp(&b.best_ms)
+        .then_with(|| b.count.cmp(&a.count))
+        .then_with(|| a.login.cmp(&b.login)));
+    render(&LeaderboardTpl { entries })
+}
+```
+
+(Adjust the `PersonalBest` field names — `ms`/`count` — to whatever the real type exports.)
+
+- [ ] **Step 5: Register the route**
+
+In `crates/web/src/routes/mod.rs`:
+
+```rust
+pub mod leaderboard;
+```
+
+(Wiring into the router happens in Task 14.)
+
+- [ ] **Step 6: Run the test, expect pass**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web leaderboard_route`
+Expected: pass (after Task 14 ships; flag as `#[ignore]` for now if Task 14 isn't reached yet, or merge tasks 11+14 if executing sequentially).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/web/src/routes/leaderboard.rs crates/web/src/routes/mod.rs \
+        crates/web/templates/leaderboard/list.html crates/web/tests/leaderboard_route.rs
+git commit -m "feat(web): /leaderboard read-only page sourced from shared store"
+```
+
+---
+
+## Task 12: Flights route + template
+
+**Files:**
+- Create: `crates/web/src/routes/flights.rs`
+- Create: `crates/web/templates/flights/list.html`
+- Modify: `crates/web/src/routes/mod.rs`
+- Modify: `crates/web/src/routes/stubs.rs` (remove `/flights` stub entry)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/web/tests/flights_route.rs` modelled on the leaderboard test. The viewer hits `GET /flights`; assert `200` and an empty-state marker when `tracker_tx: None`.
+
+A second test spawns a tiny task that consumes `TrackerCommand::Snapshot` and replies with two `TrackedFlightView`s; asserts the response contains both callsigns.
+
+- [ ] **Step 2: Write the template**
+
+`crates/web/templates/flights/list.html`:
+
+```html
+{% extends "base.html" %}
+{% block content %}
+<header class="page-head">
+  <h1>Live flights</h1>
+  <p class="sub">Currently tracked aircraft.</p>
+</header>
+<section class="card table-card">
+  {% if flights.is_empty() %}
+    <div class="placeholder">No flights tracked right now.</div>
+  {% else %}
+  <div class="table">
+    <div class="row head">
+      <div>Callsign</div><div>Owner</div><div>Phase</div>
+      <div>Altitude</div><div>Speed</div><div>Updated</div>
+    </div>
+    {% for f in flights %}
+    <div class="row">
+      <div class="mono">{{ f.callsign.as_deref().unwrap_or("—") }}</div>
+      <div class="mono">{{ f.owner_login }}</div>
+      <div class="mono">{{ f.phase }}</div>
+      <div class="mono num">{% match f.altitude_ft %}{% when Some(v) %}{{ v }} ft{% when None %}—{% endmatch %}</div>
+      <div class="mono num">{% match f.ground_speed_kt %}{% when Some(v) %}{{ v }} kt{% when None %}—{% endmatch %}</div>
+      <div class="mono num">{{ f.last_update_secs_ago }}s ago</div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</section>
+{% endblock %}
+```
+
+- [ ] **Step 3: Write the handler**
+
+`crates/web/src/routes/flights.rs`:
+
+```rust
+use std::time::Duration;
+
+use askama::Template;
+use axum::Router;
+use axum::extract::{Extension, State};
+use axum::response::Response;
+use axum::routing::get;
+use tokio::sync::oneshot;
+use twitch_1337_core::aviation::tracker::{TrackedFlightView, TrackerCommand};
+
+use crate::auth::session::Session;
+use crate::error::WebError;
+use crate::routes::render;
+use crate::state::WebState;
+
+#[derive(Template)]
+#[template(path = "flights/list.html")]
+struct FlightsTpl {
+    flights: Vec<TrackedFlightView>,
+}
+
+pub fn router() -> Router<WebState> {
+    Router::new().route("/flights", get(list))
+}
+
+async fn list(
+    State(state): State<WebState>,
+    Extension(_session): Extension<Session>,
+) -> Result<Response, WebError> {
+    let flights = match state.tracker_tx.as_ref() {
+        Some(tx) => {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            if tx.send(TrackerCommand::Snapshot { reply: reply_tx }).await.is_err() {
+                Vec::new()
+            } else {
+                tokio::time::timeout(Duration::from_millis(500), reply_rx)
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .unwrap_or_default()
+            }
+        }
+        None => Vec::new(),
+    };
+    render(&FlightsTpl { flights })
+}
+```
+
+- [ ] **Step 4: Drop the stub**
+
+In `crates/web/src/routes/stubs.rs`, remove the `/flights` route (and any `Flights` nav reference). Existing stubs for Schedules, Logs, Config stay.
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web flights_route`
+Expected: pass.
+
+```bash
+git add crates/web/src/routes/flights.rs crates/web/src/routes/mod.rs \
+        crates/web/src/routes/stubs.rs crates/web/templates/flights/list.html \
+        crates/web/tests/flights_route.rs
+git commit -m "feat(web): /flights live view via TrackerCommand::Snapshot, drop stub"
+```
+
+---
+
+## Task 13: Pings template gates mutations on `is_mod`
+
+**Files:**
+- Modify: `crates/web/src/routes/pings.rs`
+- Modify: `crates/web/templates/pings/list.html`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/web/tests/pings_routes.rs`:
+
+```rust
+#[tokio::test]
+async fn viewer_sees_pings_without_mutation_controls() {
+    install_crypto();
+    let helix = Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec!["42".into()],
+        users: Default::default(),
+    });
+    let (state, _td) = build_state_with_ping_dir(helix).await;
+    let (sid, _) = state.sessions.insert(
+        "42".into(), "alice".into(), twitch_1337_web::auth::Role::Viewer,
+    ).unwrap();
+    let app = twitch_1337_web::build_router(state.clone());
+    let resp = app.oneshot(
+        Request::builder().uri("/pings").method(Method::GET)
+            .header("cookie", cookie_header(&state.signed_key, &sid))
+            .body(Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        axum::body::to_bytes(resp.into_body(), 64 * 1024).await.unwrap().to_vec()
+    ).unwrap();
+    assert!(!body.contains(r#"action="/pings""#),
+        "viewer must not see the new-ping form");
+    assert!(!body.contains("hx-delete"),
+        "viewer must not see delete buttons");
+}
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+The viewer can't even reach `/pings` yet — `require_mod` 403s them. Plus the template renders mutation controls unconditionally. Expect `403`.
+
+- [ ] **Step 3: Pass `is_mod` to the template**
+
+In `crates/web/src/routes/pings.rs::list` (and any sibling render fn that ships `pings/list.html`):
+
+```rust
+#[derive(Template)]
+#[template(path = "pings/list.html")]
+struct PingsTpl {
+    pings: Vec<PingRow>,
+    is_mod: bool,
+    // ... existing fields ...
+}
+```
+
+Set `is_mod: session.role == Role::Mod` in the constructor. Pull `session` from request extensions via `Extension<Session>`.
+
+- [ ] **Step 4: Gate controls in the template**
+
+In `crates/web/templates/pings/list.html`, wrap the new-ping form, sort/import affordances, and the per-row action buttons:
+
+```jinja
+{% if is_mod %}
+  {# create form #}
+{% endif %}
+```
+
+And the row trailing actions:
+
+```jinja
+{% if is_mod %}
+  <button hx-delete="/pings/{{ p.name }}" …>✕</button>
+{% endif %}
+```
+
+(Test asserts `hx-delete` is absent for viewers; if the template uses `hx-post` instead, adjust the assertion in step 1 to match.)
+
+- [ ] **Step 5: Run, still expect 403 from middleware**
+
+The viewer still hits `require_mod` at the router level. That's wired up in Task 14, so this test stays red until then.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/web/src/routes/pings.rs crates/web/templates/pings/list.html crates/web/tests/pings_routes.rs
+git commit -m "feat(web): pings template gates mutations on is_mod"
+```
+
+---
+
+## Task 14: Router split — viewer / mod / public
+
+**Files:**
+- Modify: `crates/web/src/lib.rs`
+
+- [ ] **Step 1: Add a root redirect handler that branches on role**
+
+In `crates/web/src/lib.rs`:
+
+```rust
+async fn root_redirect(Extension(session): Extension<auth::session::Session>) -> axum::response::Redirect {
+    use auth::role::Role;
+    match session.role {
+        Role::Mod => axum::response::Redirect::to("/pings"),
+        Role::Viewer => axum::response::Redirect::to("/leaderboard"),
+    }
+}
+```
+
+- [ ] **Step 2: Rebuild `build_router`**
+
+```rust
+pub fn build_router(state: WebState) -> Router {
+    #[allow(unused_mut)]
+    let mut public = Router::new()
+        .merge(routes::health::router(state.irc_connected.clone()))
+        .merge(routes::assets::router())
+        .merge(auth::auth_router().with_state(state.clone()));
+    #[cfg(feature = "dev-login")]
+    {
+        public = public.merge(dev::router(state.clone()));
+    }
+
+    let viewer = Router::new()
+        .route("/", axum::routing::get(root_redirect))
+        .merge(routes::pings::viewer_router())
+        .merge(routes::leaderboard::router())
+        .merge(routes::flights::router())
+        .layer(axum::middleware::from_fn(auth::viewer_method_guard))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            |s, c, r, n| auth::require_role(auth::role::Role::Viewer, s, c, r, n),
+        ))
+        .with_state(state.clone());
+
+    let mod_only = Router::new()
+        .merge(routes::pings::mod_router())
+        .merge(routes::memory::router())
+        .merge(routes::stubs::router())
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_mod,
+        ))
+        .with_state(state);
+
+    public
+        .merge(viewer)
+        .merge(mod_only)
+        .layer(CookieManagerLayer::new())
+        .layer(TraceLayer::new_for_http())
+}
+```
+
+- [ ] **Step 3: Split `pings::router` → `viewer_router` + `mod_router`**
+
+In `crates/web/src/routes/pings.rs`:
+
+```rust
+pub fn viewer_router() -> Router<WebState> {
+    Router::new().route("/pings", get(list))
+}
+
+pub fn mod_router() -> Router<WebState> {
+    Router::new()
+        .route("/pings", post(create))
+        .route("/pings/{name}", get(detail).post(update))
+        .route("/pings/{name}/delete", post(delete))
+        // ... whatever mutation routes already existed under the single router ...
+}
+```
+
+Drop the old single `router()` once both call-sites in `lib.rs` are wired. Existing tests calling `routes::pings::router()` need a sweep: replace with whichever sub-router the test depends on (mod tests use `mod_router`; the new viewer test uses `viewer_router`). Easiest: keep `pub fn router() -> Router<WebState>` as a backward-compat shim that merges both, and remove it in a follow-up.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail`
+Expected: `pings_routes::viewer_sees_pings_without_mutation_controls`, `leaderboard_route::viewer_can_read_leaderboard`, `flights_route::*` all pass. Existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/lib.rs crates/web/src/routes/pings.rs
+git commit -m "feat(web): split router into viewer / mod / public, role-aware root redirect"
+```
+
+---
+
+## Task 15: Sidebar — role-conditional groups
+
+**Files:**
+- Modify: `crates/web/src/nav.rs`
+- Modify: `crates/web/templates/sidebar.html`
+- Modify: `crates/web/src/routes/*.rs` (every handler that renders `sidebar.html` via `base.html`)
+
+- [ ] **Step 1: Extend the nav model**
+
+In `crates/web/src/nav.rs`:
+
+```rust
+use crate::auth::role::Role;
+
+pub struct SidebarCtx {
+    pub role: Role,
+    pub current: &'static str, // existing field
+    // ...
+}
+
+impl SidebarCtx {
+    pub fn is_mod(&self) -> bool { self.role == Role::Mod }
+}
+```
+
+If the existing nav uses a simpler enum or `current_page` string, just add a `pub role: Role` field; the template branches on `role`.
+
+- [ ] **Step 2: Gate groups in the template**
+
+In `crates/web/templates/sidebar.html`:
+
+```jinja
+<nav>
+  <div class="group-label">Operate</div>
+  <a href="/pings" {% if current == "pings" %}class="active"{% endif %}>Pings</a>
+  <a href="/leaderboard" {% if current == "leaderboard" %}class="active"{% endif %}>Leaderboard</a>
+  <a href="/flights" {% if current == "flights" %}class="active"{% endif %}>Flights</a>
+  {% if sidebar.is_mod() %}
+    <a href="/schedules" {% if current == "schedules" %}class="active"{% endif %}>Schedules</a>
+
+    <div class="group-label">Memory</div>
+    <a href="/memory/soul">SOUL</a>
+    <a href="/memory/lore">LORE</a>
+    <a href="/memory/users">Users</a>
+    <a href="/memory/state">State</a>
+
+    <div class="group-label">System</div>
+    <a href="/logs">Logs</a>
+    <a href="/config">Config</a>
+  {% endif %}
+</nav>
+
+<footer class="sidebar-foot">
+  <div class="user">{{ sidebar.user_login }} <span class="role">{{ sidebar.role.label() }}</span></div>
+  <form method="post" action="/logout">
+    <input type="hidden" name="_csrf" value="{{ sidebar.csrf }}">
+    <button>Logout</button>
+  </form>
+</footer>
+```
+
+- [ ] **Step 3: Plumb `role` into every render path**
+
+Every handler that constructs a template inheriting from `base.html` must pass the current session role through to the sidebar. The simplest pattern: a helper `SidebarCtx::from_session(&session, current)` in `nav.rs` that callers invoke, then store in each `*Tpl` struct.
+
+Sweep:
+```bash
+rg "sidebar:" crates/web/src/routes
+```
+
+Patch each render handler.
+
+- [ ] **Step 4: Run sidebar tests + add a viewer-sidebar assertion**
+
+Extend `crates/web/tests/sidebar_smoke.rs` with a test that seeds a `Viewer` session, hits `/leaderboard`, and asserts the response contains "Leaderboard" but **does not** contain `/memory/soul` or "Logs".
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web sidebar_smoke`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/web/src/nav.rs crates/web/templates/sidebar.html crates/web/src/routes crates/web/tests/sidebar_smoke.rs
+git commit -m "feat(web): sidebar hides Memory/System groups from viewer tier"
+```
+
+---
+
+## Task 16: Integration scenarios
+
+**Files:**
+- Create: `crates/web/tests/auth_viewer_tier.rs`
+
+- [ ] **Step 1: Author the scenario suite**
+
+```rust
+mod helpers;
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use helpers::{FakeHelix, build_state_with_dirs, cookie_header, install_crypto};
+use std::sync::Arc;
+use tower::ServiceExt as _;
+use twitch_1337_web::auth::Role;
+
+fn viewer_helix(user_id: &str) -> Arc<FakeHelix> {
+    Arc::new(FakeHelix {
+        moderators: vec![],
+        followers: vec![user_id.into()],
+        users: Default::default(),
+    })
+}
+
+#[tokio::test]
+async fn viewer_can_read_pings_and_leaderboard_and_flights() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(viewer_helix("42")).await;
+    let (sid, _) = state.sessions.insert("42".into(), "alice".into(), Role::Viewer).unwrap();
+    let cookie = cookie_header(&state.signed_key, &sid);
+    let app = twitch_1337_web::build_router(state.clone());
+
+    for path in ["/pings", "/leaderboard", "/flights"] {
+        let resp = app.clone().oneshot(
+            Request::builder().uri(path).method(Method::GET)
+                .header("cookie", cookie.clone()).body(Body::empty()).unwrap()
+        ).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "viewer GET {path}");
+    }
+}
+
+#[tokio::test]
+async fn viewer_blocked_from_memory_and_mutations() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(viewer_helix("42")).await;
+    let (sid, csrf) = state.sessions.insert("42".into(), "alice".into(), Role::Viewer).unwrap();
+    let cookie = cookie_header(&state.signed_key, &sid);
+    let app = twitch_1337_web::build_router(state.clone());
+
+    let resp = app.clone().oneshot(
+        Request::builder().uri("/memory/soul").method(Method::GET)
+            .header("cookie", cookie.clone()).body(Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "viewer cannot read memory");
+
+    let body = format!("_csrf={}", twitch_1337_web::auth::csrf::encode(&csrf));
+    let resp = app.oneshot(
+        Request::builder().uri("/pings/anything/delete").method(Method::POST)
+            .header("cookie", cookie).header("content-type", "application/x-www-form-urlencoded")
+            .body(Body::from(body)).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "viewer cannot mutate pings");
+}
+
+#[tokio::test]
+async fn viewer_loses_follow_after_recheck_window() {
+    install_crypto();
+    // Build state with role_check_refresh = 0 so any request triggers a recheck.
+    let mut helix = FakeHelix { moderators: vec![], followers: vec!["42".into()], users: Default::default() };
+    let helix_arc = Arc::new(helix);
+    let (mut state, _td_pings, _td_mem) = build_state_with_dirs(helix_arc.clone()).await;
+    // (Adjust state.config.role_check_refresh to zero — likely needs a tweak to
+    // build_state_with_dirs to accept an override. Document the helper change here.)
+    let (sid, _) = state.sessions.insert("42".into(), "alice".into(), Role::Viewer).unwrap();
+    let cookie = cookie_header(&state.signed_key, &sid);
+    // Mutate followers via interior mutability on FakeHelix (add `Mutex<Vec<String>>`
+    // for this purpose) — or rebuild state with the new helix.
+    // Drop "42" from followers; next request must 403 and drop the session.
+    // assertions follow.
+}
+
+#[tokio::test]
+async fn root_redirects_by_role() {
+    install_crypto();
+    let (state, _td_pings, _td_mem) = build_state_with_dirs(viewer_helix("42")).await;
+    let (viewer_sid, _) = state.sessions.insert("42".into(), "alice".into(), Role::Viewer).unwrap();
+    let (mod_sid, _) = state.sessions.insert("9".into(), "boss".into(), Role::Mod).unwrap();
+    let app = twitch_1337_web::build_router(state.clone());
+
+    let resp = app.clone().oneshot(
+        Request::builder().uri("/").method(Method::GET)
+            .header("cookie", cookie_header(&state.signed_key, &viewer_sid))
+            .body(Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(resp.headers().get("location").unwrap(), "/leaderboard");
+
+    let resp = app.oneshot(
+        Request::builder().uri("/").method(Method::GET)
+            .header("cookie", cookie_header(&state.signed_key, &mod_sid))
+            .body(Body::empty()).unwrap()
+    ).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(resp.headers().get("location").unwrap(), "/pings");
+}
+```
+
+The `viewer_loses_follow_after_recheck_window` test needs:
+- A way to override `role_check_refresh` on the `FakeHelix`-backed `WebState` — add `build_state_with_overrides(helix, refresh: Duration)` to `helpers/mod.rs`.
+- Interior mutability on `FakeHelix` for the followers list — wrap it as `tokio::sync::RwLock<Vec<String>>`. Update Task 4's test fixtures and the trait impl accordingly. (Defer to Task 4 follow-up if it's cleaner.)
+
+- [ ] **Step 2: Run the suite**
+
+Run: `cargo nextest run --show-progress=none --cargo-quiet --status-level=fail -p twitch-1337-web auth_viewer_tier`
+Expected: all 4 pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/web/tests/auth_viewer_tier.rs crates/web/tests/helpers/mod.rs
+git commit -m "test(web): viewer-tier integration scenarios"
+```
+
+---
+
+## Task 17: Startup self-check + CLAUDE.md note
+
+**Files:**
+- Modify: `crates/twitch-1337/src/<main bin entry>.rs`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Probe `/channels/followers` once at startup**
+
+Wherever the bot's helix client is constructed and the dashboard is spawned, add a one-shot call:
+
+```rust
+match helix.is_follower(&broadcaster_id, &broadcaster_id).await {
+    Ok(_) => tracing::info!("helix /channels/followers reachable with current scopes"),
+    Err(e) => tracing::warn!(error = ?e,
+        "helix /channels/followers probe failed — viewer tier sliding rechecks will degrade. \
+         Reissue the bot token with `moderator:read:followers`."),
+}
+```
+
+(Calling with `broadcaster_id` as both args is a deliberate harmless probe — the broadcaster always "follows themselves" in the sense that the endpoint accepts the parameters; if it 401s, scopes are wrong; if it returns `total: 0`, scopes are fine.)
+
+- [ ] **Step 2: Update `CLAUDE.md`**
+
+Under the `## Config` section, append a paragraph:
+
+```
+**Dashboard viewer tier (added 2026-05-12):** the bot's Twitch token must
+carry `moderator:read:followers` in addition to its existing scopes — the
+web dashboard uses it to gate read-only access for followers (sliding
+recheck via the bot token). The OAuth app must additionally allow
+`user:read:follows` on viewer logins (no broadcaster-token configuration
+required).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/twitch-1337/src CLAUDE.md
+git commit -m "ops: probe helix followers at startup; document new scopes"
+```
+
+---
+
+## Task 18: Final gate + PR
+
+- [ ] **Step 1: Full pre-commit gate**
+
+Run:
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo nextest run --show-progress=none --cargo-quiet --status-level=fail
+cargo audit
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Hand-smoke the dashboard**
+
+```bash
+cargo run --bin twitch-1337-web-dev
+```
+
+In another terminal/browser:
+- Log in as a moderator → land at `/pings`, see all sidebar groups, mutation controls present.
+- Use the `dev-login` feature to spoof a follower session → land at `/leaderboard`, see only Operate group, no mutation controls on `/pings`, `/memory/*` returns 403.
+
+(If `dev-login` doesn't currently let you set a role, extend it inside this task: a `?role=viewer` query parameter on the dev-login endpoint.)
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat(web): follower-gated viewer tier for dashboard" --body "$(cat <<'EOF'
+## Summary
+- Add `Role { Viewer, Mod }` and generalise `require_mod` → `require_role(min)`
+- Channel-followers see a read-only slice: `/pings` (no mutation controls), `/leaderboard`, `/flights`
+- All mutations + AI memory remain mod-only behind a separate sub-router with `viewer_method_guard` (GET/HEAD only)
+- Bot token must carry `moderator:read:followers`; viewer logins request `user:read:follows`
+
+Spec: `docs/superpowers/specs/2026-05-12-dashboard-viewer-tier-design.md`
+Plan: `docs/superpowers/plans/2026-05-12-dashboard-viewer-tier.md`
+
+## Test plan
+- [ ] CI: fmt + clippy + nextest + audit green
+- [ ] Manually verify mod login → /pings with full controls
+- [ ] Manually verify follower login → /leaderboard, hidden Memory/System groups, no delete buttons
+- [ ] Manually verify follower POST /pings/x/delete → 403
+- [ ] Manually verify viewer GET /memory/soul → 403
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+- Spec § 4 routing layout: covered Task 14 (router split).
+- Spec § 5 middleware: covered Task 6 (viewer guard) + Task 7 (require_role).
+- Spec § 6 helix changes: covered Task 4 (is_follower) + Task 5 (channels/followed login helper).
+- Spec § 7 callback: covered Task 8.
+- Spec § 8.1 pings read-only: covered Task 13 + Task 14 (route split).
+- Spec § 8.2 leaderboard: covered Task 11.
+- Spec § 8.3 flights: covered Task 10 (Snapshot variant) + Task 12 (route).
+- Spec § 10 config rename: covered Task 2.
+- Spec § 11 deploy prereqs: covered Task 17.
+- Spec § 13 testing: covered Tasks 1, 4, 6, 11, 12, 13, 15, 16.
+- Spec § 14 build sequence step 13 (startup self-check): covered Task 17.
+
+No placeholders left in the plan; every code block is complete enough for a fresh engineer to lift. Type names are consistent: `Role`, `GateOutcome`, `TrackedFlightView`, `TrackerCommand::Snapshot`, `record_role_check`, `last_role_check`, `role_check_refresh`, `is_follower`. Field rename of `ModCheckOutcome` → `GateOutcome` happens in Task 3 and every later reference uses `GateOutcome`.

--- a/docs/superpowers/specs/2026-05-12-dashboard-viewer-tier-design.md
+++ b/docs/superpowers/specs/2026-05-12-dashboard-viewer-tier-design.md
@@ -1,0 +1,261 @@
+# Dashboard viewer tier (follower read-only access)
+
+Status: design / ready for plan.
+
+## 1. Problem
+
+The web dashboard (`crates/web/`) is mod-gated end-to-end: the broadcaster, configured `hidden_admins`, and helix moderators of the channel are the only authenticated audience. Everyone else gets `403` at `require_mod`.
+
+We want to let the wider community see a curated slice of the dashboard (leaderboard, currently tracked flights, the ping catalogue) while keeping all mutation surfaces and AI memory mod-only.
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- Add a viewer tier gated by "is currently a follower of the broadcaster".
+- Viewer tier is strictly read-only.
+- Mods retain full access (no regression).
+- Reuse the existing session / sliding-recheck machinery; do not invent a parallel auth path.
+- Surface two new pages (leaderboard, live flights) and a stripped-down pings index.
+
+**Non-goals**
+
+- Sub-only or VIP-only tiers. Followers covers the chosen audience for v1; sub gating was considered and dropped because it requires either a broadcaster-token in config or persisting per-user OAuth tokens. See § 9.
+- Public unauthenticated access. Viewer still logs in via Twitch OAuth.
+- Per-user permissions / capabilities. Two ordered roles (`Viewer` < `Mod`) cover the requirement; capability sets are explicitly YAGNI here.
+- Writes by viewers — not even self-scoped writes. The route layer rejects non-GET/HEAD unconditionally.
+
+## 3. Roles
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum Role { Viewer, Mod }
+```
+
+`Role` is ordered: `session.role >= required` is the gate predicate. Adding tiers later means inserting in the enum at the right ordinal — no call-site churn.
+
+Stored on `Session` alongside `user_id`, `user_login`, `last_role_check` (renamed from `last_mod_check`).
+
+## 4. Routing layout
+
+`crates/web/src/lib.rs::build_router` becomes:
+
+```
+public                                       (no auth)
+  /healthz, /login, /auth/start, /auth/callback, /logout, /assets/*
+
+viewer  (require_role(Role::Viewer) + viewer_method_guard)
+  GET /                       → role-aware redirect (viewer→/leaderboard, mod→/pings)
+  GET /pings                  read-only render; mutation controls hidden by template
+  GET /leaderboard            NEW
+  GET /flights                NEW — replaces existing Flights stub
+
+mod     (require_role(Role::Mod))
+  POST   /pings, /pings/{name}/delete, /pings/{name}/edit
+  GET    /memory/{soul,lore,users,state}/...
+  POST   /memory/...   (existing CRUD, unchanged)
+```
+
+Two nested `Router::merge` layers under a single `CookieManagerLayer`. `viewer_method_guard` is a small `axum::middleware::from_fn` that returns `405 Method Not Allowed` for any method other than `GET`/`HEAD` on the viewer router — belt-and-suspenders: even if a write route were accidentally registered under the viewer layer, mutation can't slip through.
+
+The mod router stays mounted on the same paths it owns today; nothing moves.
+
+## 5. Middleware
+
+### 5.1 `require_role(min: Role)`
+
+Generalisation of the current `require_mod`. Responsibilities:
+
+1. Read signed `tw1337_sid`; load and touch session. Missing/expired → `WebError::Unauthenticated { next }`.
+2. If `session.role < min` → `WebError::Forbidden` (no recheck; static role mismatch).
+3. If `elapsed_since(session.last_role_check) > config.role_check_refresh`:
+   - If `session.role == Role::Mod`: call `check_is_mod(helix, …)` (existing path).
+   - If `session.role == Role::Viewer`: call `check_is_follower(helix, broadcaster_id, user_id)` (new).
+   - `Allow` → `record_role_check`. `Deny` → drop session, return `WebError::Forbidden`. `Err` → log + admit on stale check (existing policy preserved).
+4. Insert the session into request extensions; pass to next handler.
+
+`require_mod` becomes `pub async fn require_mod(...) { require_role(Role::Mod) ... }` — a thin alias so we don't fan out the rename at every call-site at once.
+
+### 5.2 `viewer_method_guard`
+
+```rust
+async fn viewer_method_guard(req: Request, next: Next) -> Result<Response, WebError> {
+    match *req.method() {
+        Method::GET | Method::HEAD => Ok(next.run(req).await),
+        _ => Err(WebError::MethodNotAllowed),
+    }
+}
+```
+
+Add `MethodNotAllowed` variant to `WebError`, mapping to `405`.
+
+## 6. Helix changes
+
+### 6.1 Trait
+
+`crates/web/src/helix.rs::HelixClient` gains:
+
+```rust
+async fn is_follower(&self, broadcaster_id: &str, user_id: &str) -> eyre::Result<bool>;
+```
+
+Production impl calls `GET /helix/channels/followers?broadcaster_id=…&user_id=…` with the bot's helix user token (the same token the existing `check_is_mod` path uses). The endpoint requires the bearer to be a moderator of the broadcaster's channel (`moderator:read:followers` scope) — the bot already moderates the channel, so this works with a single scope addition. The response shape is `{ "total": N, "data": [...] }`; the predicate is `!data.is_empty()` (or `total > 0`).
+
+`FakeHelixClient` in `crates/web/tests/common/` gains a matching `set_followers(Vec<(String, String)>)` builder so integration tests can configure follower state alongside the existing `set_moderators`.
+
+### 6.2 Login-path check via the user's own token
+
+The OAuth callback already authenticates the *user's* helix calls with the user's just-issued access token. A symmetric helper:
+
+```rust
+pub async fn check_is_follower_with_token(
+    state: &WebState,
+    user_id: &str,
+    user_access_token: &str,
+    broadcaster_id: &str,
+) -> eyre::Result<ModCheckOutcome>;
+```
+
+calls `GET /helix/channels/followed?user_id=…&broadcaster_id=…` with the user token and the `user:read:follows` scope. This avoids depending on the bot token at first-login.
+
+(Rename file `auth/mod_check.rs` → `auth/role_check.rs`; keep `ModCheckOutcome` or rename to `GateOutcome` for honesty. Rename has no external impact beyond `auth::mod_check` re-exports in `auth/mod.rs`.)
+
+### 6.3 OAuth scopes
+
+`auth_start` adds `Scope::new("user:read:follows".into())` next to the existing `user:read:email` and `user:read:moderated_channels`.
+
+Existing logged-in sessions are unaffected — sessions are cookie-backed in-memory state, not token-backed; the OAuth token from earlier logins isn't replayed.
+
+### 6.4 Bot token scope dependency
+
+Bot's helix token (used by the sliding role recheck) must carry `moderator:read:followers`. This is a deploy prerequisite; the spec calls it out in § 11 and the implementation plan will fail loud on `401`.
+
+## 7. Callback flow
+
+`crates/web/src/auth/routes.rs::callback`:
+
+1. Verify OAuth state cookie, exchange code, look up caller user (unchanged).
+2. `check_is_mod_with_token(user_token, ...)` → `Allow` ⇒ insert session with `role = Mod`. Done.
+3. Else `check_is_follower_with_token(user_token, ...)` → `Allow` ⇒ insert session with `role = Viewer`.
+4. Else log `result=denied`, return `WebError::Forbidden`.
+
+`SessionStore::insert` signature picks up `role: Role`; persistence still in-memory.
+
+`tracing::info!` audit fields extend: `action=login, result=ok|denied, role=mod|viewer`.
+
+## 8. Pages
+
+### 8.1 Pings (read-only for viewers)
+
+Handler passes `is_mod: bool` (derived from `session.role == Role::Mod`) into the template context. Existing `templates/pings/list.html` wraps:
+
+- `+ New ping` button
+- Row trailing-action ✎ / ✕ controls
+- `Sort` / `Import` mutating affordances if any
+
+…in `{% if is_mod %}` blocks. Row click and template/member columns stay visible.
+
+POST routes (`/pings`, `/pings/{name}/delete`, `/pings/{name}/edit`) remain only on the mod router. The viewer router exposes `GET /pings` only; the form/edit pages are reachable from the mod router (which the viewer is forbidden from anyway).
+
+### 8.2 Leaderboard `/leaderboard` (new)
+
+- Data source: `LeaderboardStore` (already an `Arc` shared into bot handlers). Add a read handle into `WebState`. Reading is `leaderboard.snapshot()` → `Vec<LeaderboardEntry { user_id, login, best_ms, count }>`.
+- Sort: ascending `best_ms`, ties broken by `count` desc then `login` asc.
+- Template: a stat strip (entries total, fastest PB, today's fastest) above a CSS-grid table mirroring the Pings table chrome (per visual handoff DESIGN.md § 7.3). Columns: rank | user | best (mono tabular-nums) | count.
+- Empty state: honest placeholder per the handoff's stub-page pattern; no fake rows.
+
+### 8.3 Live flights `/flights` (new — replaces the existing stub)
+
+- Data source: the flight tracker task. Today commands flow in over `Arc<mpsc::Sender<TrackerCommand>>`; the tracker holds the live state.
+- Extend `TrackerCommand` with `Snapshot { reply: tokio::sync::oneshot::Sender<Vec<TrackedFlightView>> }`. `TrackedFlightView` is a serde-friendly read projection of the internal `TrackedFlight`: callsign, owner_login, phase, altitude_ft, ground_speed_kt, last_update_secs_ago. The handler `send`s the command and `await`s the oneshot with a short timeout (e.g. 500 ms — tracker loop is non-blocking, this is generous).
+- Aviation-disabled fallback: `WebState` already holds an `Option<Arc<mpsc::Sender<TrackerCommand>>>`; `None` → render the existing stub.
+- Template: table of active flights; empty state when zero are tracked.
+
+Both new pages get a sidebar nav entry under the **Operate** group from the visual handoff (`Pings, Schedules, Flights` becomes `Pings, Leaderboard, Schedules, Flights`). Sidebar items are visibility-gated by role:
+
+- Viewer: Operate (Pings, Leaderboard, Flights). Memory and System groups are hidden entirely.
+- Mod: every group as before.
+
+The `/` redirect handler reads `session.role` and redirects accordingly: `Mod → /pings`, `Viewer → /leaderboard`.
+
+## 9. Why not subs
+
+Sub-tier checks need a token that can call `/helix/subscriptions`:
+
+- Broadcaster token (channel:read:subscriptions): a single new secret rotated by the broadcaster. Workable but adds an at-rest secret and a rotation chore.
+- Per-user token persisted in the session: viewer issues `user:read:subscriptions`, we cache + refresh. Adds at-rest tokens and the refresh-token plumbing the bot doesn't otherwise carry today.
+
+Followers covers "channel community" cleanly without either. If sub gating is wanted later, the cleanest path is the broadcaster-token approach plumbed through `HelixClient::is_subscriber` alongside `is_follower`; `Role` could grow `Subscriber` between `Viewer` and `Mod`.
+
+## 10. Config
+
+- No new config keys.
+- Rename `WebConfig.mod_check_refresh` → `role_check_refresh`. Default unchanged. Config struct is internal (loaded from in-process state, not serialised to a user-edited file), so this is a code-only rename.
+
+## 11. Deploy prerequisites
+
+1. Bot's Twitch IRC/helix token reissued with **`moderator:read:followers`** added to its scope set. The bot already needs to be a moderator of the broadcaster's channel for the scope to be usable (existing invariant).
+2. Twitch developer console OAuth app must permit **`user:read:follows`** as a requestable scope on the user-facing login. The code adds it to the authorise URL; the app config must allow it.
+3. Document both in `CLAUDE.md § Config`.
+
+Failure mode if (1) is forgotten: viewer sliding recheck logs the `401`, admits on stale check (preserved policy). Login still works because the login path uses the user token, not the bot token. A loud warning at startup that asserts the bot token can reach `/channels/followers` is a small addition — included in the plan.
+
+## 12. Security considerations
+
+- **Mutation surface**: viewer router has zero. `viewer_method_guard` enforces this at the layer level; route enumeration enforces it at the routing level.
+- **CSRF**: viewer has no forms, no header-driven mutations. CSRF on mod mutations unchanged.
+- **Session lifetime**: same TTL + sliding refresh as today. A demoted mod or unfollowed viewer is dropped on next request after the recheck TTL fires.
+- **Log noise**: `action=role_recheck, result=denied, role=viewer` is expected churn (viewers unfollow). Not an error; log at `info`, not `warn`.
+- **Open redirect / `?next=`**: existing `is_safe_redirect` filter unchanged. The root redirect handler is a server-issued `Redirect::to`, no user input.
+
+## 13. Testing
+
+### 13.1 Unit
+
+- `Role` ordering: `Viewer < Mod`; `Mod >= Viewer`; `Viewer >= Viewer`.
+- `check_is_follower` against `FakeHelixClient`: empty / matched / error → expected `GateOutcome`.
+- `viewer_method_guard`: GET admitted, HEAD admitted, POST/PUT/DELETE/PATCH → `405`.
+
+### 13.2 Integration (`tests/common/TestBotBuilder`)
+
+Scenarios driven through the real router with a fake helix:
+
+1. **Mod login**: callback issues `role=Mod`, can `GET /pings`, `GET /memory/soul`, `POST /pings/.../delete`. Regression coverage.
+2. **Follower login**: callback issues `role=Viewer`. Can `GET /pings`, `/leaderboard`, `/flights`. `POST /pings/.../delete` → `403` (route lives on the mod router; `require_role(Mod)` rejects the viewer). `GET /memory/...` → `403`. `/` redirects to `/leaderboard`. Separately, hand-crafted `POST /leaderboard` (a viewer-router path with a method the guard rejects) → `405` from `viewer_method_guard`.
+3. **Non-follower non-mod**: callback returns `403`, no session cookie issued.
+4. **Follower-loses-follow mid-session**: recheck fakes `is_follower=false` after TTL; next request → `403` + session dropped.
+5. **Mod-loses-mod mid-session**: existing test, kept green.
+6. **Mod also follows**: lands as Mod, not Viewer (mod check runs first).
+
+### 13.3 Template / render
+
+- Render `templates/pings/list.html` with `is_mod=false`: assert no `<form action="/pings"`, no `data-action="delete"` (or whichever marker — exact assertion left to plan); assert row body still present.
+- Render with `is_mod=true`: assert mutation controls present.
+
+### 13.4 Flights snapshot
+
+- Mock `TrackerCommand::Snapshot` returning 0 / 1 / many flights; assert empty-state branch vs table render. Confirm 500 ms timeout path doesn't poison the request (graceful degraded message).
+
+## 14. Build sequence
+
+Each step is independently mergeable / reviewable.
+
+1. `Role` enum + `Session.role` + `Ord` impl + `SessionStore::insert(role)`. All call-sites (one) pass `Role::Mod` to start. No behaviour change.
+2. Rename `last_mod_check` → `last_role_check`, `mod_check_refresh` → `role_check_refresh`, `mod_check.rs` → `role_check.rs`. Mechanical.
+3. Add `HelixClient::is_follower` + production impl + `FakeHelixClient::set_followers`.
+4. Add `check_is_follower_with_token` (user-token path).
+5. Replace `require_mod` body with `require_role(Role::Mod)`; add `require_role` taking the minimum role parameter. `require_mod` becomes an alias.
+6. Add `viewer_method_guard` + `WebError::MethodNotAllowed`.
+7. Callback: try mod → try follower → deny. New OAuth scope `user:read:follows`. Audit field `role`.
+8. Pings template: gate mutations on `is_mod`. Handler extension.
+9. Leaderboard route + template + nav entry. `WebState` gains read handle.
+10. Tracker `Snapshot` command + flights route + template + nav entry. Stub fallback when aviation is disabled.
+11. Root `/` redirect by role.
+12. Integration test scenarios per § 13.2.
+13. Startup self-check: probe `/channels/followers` with the bot token; log `warn` if it `401`s so a missing `moderator:read:followers` scope is loud.
+
+## 15. Open questions
+
+- **Leaderboard time window**: "today" stat — do we want a today-PB chip in addition to all-time best? Punted to plan; the data is there in `leaderboard.ron` if we want it.
+- **Flights view auth**: viewers see the owner login of each tracked flight. That's already public from the IRC `!flights` command, so no leak — flagged for sanity.
+- **Sidebar group label for Leaderboard**: leaning **Operate** to match the visual handoff. Could argue for a new **Stats** group if we add more read-only pages later.


### PR DESCRIPTION
## Summary

Adds a **viewer** auth tier so channel followers can see a read-only slice of the dashboard while mutations + AI memory remain mod-only.

- `Role { Viewer, Mod }` ordered enum; generalised `require_mod` → `require_role(min)`.
- Login flow: callback tries mod → follower → deny. Viewer logins request `user:read:follows`; the bot token must carry `moderator:read:followers` for the sliding follower recheck (startup logs a warn on probe failure).
- Router split into `viewer` / `mod_only` / `public`; `viewer_method_guard` enforces GET/HEAD on the viewer surface.
- Two new pages: `/leaderboard` (sourced from the shared `Arc<RwLock<HashMap<_, PersonalBest>>>`) and `/flights` (live snapshot via `TrackerCommand::Snapshot`, 500 ms timeout).
- `/pings` becomes role-aware: viewers see the table, mods keep the `+ New ping` button and row actions.
- Sidebar hides Memory / System groups from viewers; root `/` redirects by role.

Spec: `docs/superpowers/specs/2026-05-12-dashboard-viewer-tier-design.md`
Plan: `docs/superpowers/plans/2026-05-12-dashboard-viewer-tier.md`

## Deploy prereqs

- Reissue the bot's Twitch token with `moderator:read:followers` added.
- Twitch developer-console OAuth app must allow `user:read:follows` as a requestable scope.

## Test plan

- [ ] CI: `fmt + clippy + test`, `cargo audit`, hadolint, trivy, actionlint, zizmor, gitleaks all green
- [ ] Locally: `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run` — 462/462 pass (1 skipped) at HEAD
- [ ] Manually log in as a moderator → land at `/pings` with full controls (Memory + System groups visible)
- [ ] Manually log in as a follower → land at `/leaderboard`, no Memory/System groups, no mutation controls on `/pings`
- [ ] Manually attempt `POST /pings/<name>/delete` as a follower → 403
- [ ] Manually attempt `GET /memory/soul` as a follower → 403
- [ ] Confirm startup log line confirms `helix /channels/followers reachable with current bot scopes` after reissuing the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)