### PR TITLE
ci: split clippy and test into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
-  check:
-    name: clippy + test
+  clippy:
+    name: clippy
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -60,6 +60,28 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Read Rust toolchain channel
+        id: rust-toolchain
+        run: |
+          channel=$(grep '^channel' crates/twitch-1337/rust-toolchain.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@master # zizmor: ignore[unpinned-uses]
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest # zizmor: ignore[unpinned-uses]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,13 @@ Linear history required, force-push + delete blocked, conversations must resolve
 
 **Branch naming:** `feature/` features, `spec/` specs, `fix/` bug fixes, `refactor/` refactors, `build/` CI / dependencies / Docker. Slug after slash, kebab-case.
 
-**Required status checks (7, must all pass to merge):**
+**Required status checks (9, must all pass to merge):**
 
 | Check | Workflow | Purpose |
 |---|---|---|
-| `fmt + clippy + test` | ci.yml | cargo fmt --check, clippy -D warnings, cargo test |
+| `fmt` | ci.yml | cargo fmt --check |
+| `clippy` | ci.yml | cargo clippy --workspace --all-targets -- -D warnings |
+| `test` | ci.yml | cargo nextest run --workspace |
 | `cargo audit` | ci.yml | RustSec CVE scan of Cargo.lock via rustsec/audit-check |
 | `hadolint (Dockerfile)` | sast.yml | Dockerfile lint, SARIF → Security tab |
 | `trivy config (IaC)` | sast.yml | IaC misconfig scan, HIGH/CRITICAL only |
@@ -64,7 +66,7 @@ Others pinned to major tags; Dependabot keeps them current.
 
 **Typical PR flow:**
 1. branch → commit → push → `gh pr create`
-2. wait for 7 checks green; rebase on main if `strict` blocks merge
+2. wait for 9 checks green; rebase on main if `strict` blocks merge
 3. `gh pr merge --squash`
 
 **When `cargo audit` fails:**
@@ -74,7 +76,7 @@ Others pinned to major tags; Dependabot keeps them current.
   both must be resolved — usually by bumping the dep pulling in the old major.
 - Last resort: ignore in `.cargo/audit.toml` with a written-down reason.
 
-**When Dependabot cargo PRs break `fmt + clippy + test`:**
+**When Dependabot cargo PRs break `clippy` or `test`:**
 - Breaking-API bump; adapt code on the dependabot branch and force-push
   (`git push origin dependabot/cargo/<name>-<ver>`). CI reruns, then merge.
 - Example: rand 0.10 moved `.random::<T>()` from `Rng` to `RngExt` — generic bounds


### PR DESCRIPTION
## Summary
- Split combined `clippy + test` job into parallel `clippy` and `test` jobs to cut CI wall-clock time.
- Each job keeps its own Swatinem rust-cache slot (auto-keyed by job name).
- Update CLAUDE.md required-checks table + count (9) to match new job names.

## Test plan
- [ ] All four ci.yml jobs (`fmt`, `clippy`, `test`, `cargo audit`) run and pass on this PR.
- [ ] Branch-protection rules updated on repo settings to require new `clippy` + `test` checks instead of legacy `clippy + test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)