### PR TITLE
fix(web): settings dirty tracking + polished text/range rows

### DIFF
--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -1206,6 +1206,30 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   flex-shrink: 0;
 }
 
+.model-input,
+.bytesize-input {
+  background: var(--bg-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  outline: 0;
+  font-family: var(--mono);
+  font-size: 13.5px;
+  color: var(--fg);
+  padding: 7px 12px;
+  width: 260px;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.bytesize-input { width: 160px; }
+.model-input:hover,
+.bytesize-input:hover { border-color: var(--line-2); }
+.model-input:focus,
+.bytesize-input:focus {
+  border-color: var(--line-strong);
+  background: var(--bg-2);
+}
+.settings-row.is-dirty .model-input,
+.settings-row.is-dirty .bytesize-input { border-color: var(--accent-soft); }
+
 /* `:has(input:checked)` drives on-state so dirty tracking is the only
    piece that needs JS. */
 .toggle {

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -1206,8 +1206,7 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   flex-shrink: 0;
 }
 
-.model-input,
-.bytesize-input {
+.text-input {
   background: var(--bg-3);
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
@@ -1217,18 +1216,44 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   color: var(--fg);
   padding: 7px 12px;
   width: 260px;
-  transition: border-color 0.12s ease, background 0.12s ease;
+  transition: border-color 0.12s ease, background 0.12s ease, opacity 0.12s ease;
 }
-.bytesize-input { width: 160px; }
-.model-input:hover,
-.bytesize-input:hover { border-color: var(--line-2); }
-.model-input:focus,
-.bytesize-input:focus {
+.text-input.is-narrow { width: 160px; }
+.text-input.is-wide { width: 360px; }
+.text-input:focus {
   border-color: var(--line-strong);
   background: var(--bg-2);
 }
-.settings-row.is-dirty .model-input,
-.settings-row.is-dirty .bytesize-input { border-color: var(--accent-soft); }
+.settings-row.is-dirty .text-input { border-color: var(--accent-soft); }
+
+.row-control-cell .text-input { opacity: 0; }
+.settings-row:hover .row-control-cell .text-input,
+.settings-row:focus-within .row-control-cell .text-input,
+.settings-row.is-dirty .row-control-cell .text-input { opacity: 1; }
+
+.range-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: 260px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.settings-row:hover .range-wrap,
+.settings-row:focus-within .range-wrap,
+.settings-row.is-dirty .range-wrap { opacity: 1; }
+.range-wrap input[type=range] {
+  flex: 1;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+.range-wrap .range-value {
+  font-family: var(--mono);
+  font-size: 13.5px;
+  color: var(--fg-2);
+  min-width: 3ch;
+  text-align: right;
+}
 
 /* `:has(input:checked)` drives on-state so dirty tracking is the only
    piece that needs JS. */

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -126,8 +126,12 @@ document.addEventListener(
   function formatPretty(input, prettyEl) {
     const unit = prettyEl?.dataset.prettyUnit ?? '';
     if (unit === 'bool') return input.checked ? 'On' : 'Off';
+    if (input.type === 'text' || input.type === 'time' || input.type === 'email' || input.type === 'url') {
+      return input.value || (input.placeholder ? `(${input.placeholder})` : '');
+    }
     const n = Number(input.value);
     if (!Number.isFinite(n)) return input.value;
+    if (unit === 'pct') return `${Math.round(n * 100)}%`;
     if (unit === 's') return n === 1 ? '1 second' : `${n} seconds`;
     if (unit === 'B') {
       if (n % 1024 === 0 && n >= 1024) return `${n / 1024} KiB`;
@@ -169,7 +173,20 @@ document.addEventListener(
       const offDefault = cur !== (r.input.dataset.default ?? '');
       r.el.classList.toggle('is-dirty', dirty);
       if (r.reset) r.reset.hidden = !offDefault;
-      if (r.pretty) r.pretty.textContent = formatPretty(r.input, r.pretty);
+      if (r.pretty) {
+        const isText = ['text', 'time', 'email', 'url'].includes(r.input.type);
+        // Server already renders nuanced markup (placeholder/empty muted span)
+        // for text-type rows; only overwrite the pretty when the user has
+        // edited the value, otherwise leave the SSR markup intact.
+        if (!isText || dirty) r.pretty.textContent = formatPretty(r.input, r.pretty);
+      }
+      if (r.input.type === 'range') {
+        const valEl = r.el.querySelector('[data-range-value]');
+        if (valEl) {
+          const n = Number(r.input.value);
+          valEl.textContent = Number.isFinite(n) ? `${Math.round(n * 100)}%` : r.input.value;
+        }
+      }
       if (!dirty) continue;
       dirtyKeys.push(r.input.dataset.key ?? r.input.name);
       if (r.section) perSection.set(r.section, (perSection.get(r.section) ?? 0) + 1);

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -101,14 +101,19 @@ document.addEventListener(
   const discardBtn = saveBar.querySelector('[data-discard]');
 
   const rows = Array.from(form.querySelectorAll('.settings-row'))
-    .map((row) => ({
-      el: row,
-      input: row.querySelector('input[name]'),
-      reset: row.querySelector('.row-reset'),
-      pretty: row.querySelector('.row-pretty'),
-      section: row.dataset.section,
-    }))
+    .map((row) => {
+      const input = row.querySelector('input[name]');
+      return {
+        el: row,
+        input,
+        reset: row.querySelector('.row-reset'),
+        pretty: row.querySelector('.row-pretty'),
+        section: row.dataset.section,
+        baseline: input ? (input.type === 'checkbox' ? (input.checked ? 'true' : 'false') : input.value) : '',
+      };
+    })
     .filter((r) => r.input);
+
 
   function formatPretty(input, prettyEl) {
     const unit = prettyEl?.dataset.prettyUnit ?? '';
@@ -142,9 +147,11 @@ document.addEventListener(
     const dirtyKeys = [];
     const perSection = new Map();
     for (const r of rows) {
-      const dirty = currentValue(r.input) !== (r.input.dataset.default ?? '');
+      const cur = currentValue(r.input);
+      const dirty = cur !== r.baseline;
+      const offDefault = cur !== (r.input.dataset.default ?? '');
       r.el.classList.toggle('is-dirty', dirty);
-      if (r.reset) r.reset.hidden = !dirty;
+      if (r.reset) r.reset.hidden = !offDefault;
       if (r.pretty) r.pretty.textContent = formatPretty(r.input, r.pretty);
       if (!dirty) continue;
       dirtyKeys.push(r.input.dataset.key ?? r.input.name);

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -102,17 +102,25 @@ document.addEventListener(
 
   const rows = Array.from(form.querySelectorAll('.settings-row'))
     .map((row) => {
-      const input = row.querySelector('input[name]');
+      const inputs = Array.from(row.querySelectorAll('input[name]'));
+      const isRadio = inputs.length > 1 && inputs.every((i) => i.type === 'radio');
+      const primary = inputs[0];
+      if (!primary) return null;
+      const baseline = isRadio
+        ? (inputs.find((i) => i.checked)?.value ?? '')
+        : primary.type === 'checkbox' ? (primary.checked ? 'true' : 'false') : primary.value;
       return {
         el: row,
-        input,
+        input: primary,
+        inputs,
+        isRadio,
         reset: row.querySelector('.row-reset'),
         pretty: row.querySelector('.row-pretty'),
         section: row.dataset.section,
-        baseline: input ? (input.type === 'checkbox' ? (input.checked ? 'true' : 'false') : input.value) : '',
+        baseline,
       };
     })
-    .filter((r) => r.input);
+    .filter((r) => r);
 
 
   function formatPretty(input, prettyEl) {
@@ -134,12 +142,21 @@ document.addEventListener(
     return input.type === 'checkbox' ? (input.checked ? 'true' : 'false') : input.value;
   }
 
-  function applyDefault(input) {
-    const def = input.dataset.default ?? '';
-    if (input.type === 'checkbox') {
-      input.checked = def === 'true' || def === '1';
+  function rowCurrent(r) {
+    if (r.isRadio) return r.inputs.find((i) => i.checked)?.value ?? '';
+    return currentValue(r.input);
+  }
+
+  function applyDefault(r) {
+    const def = r.input.dataset.default ?? '';
+    if (r.isRadio) {
+      for (const i of r.inputs) i.checked = i.value === def;
+      return;
+    }
+    if (r.input.type === 'checkbox') {
+      r.input.checked = def === 'true' || def === '1';
     } else {
-      input.value = def;
+      r.input.value = def;
     }
   }
 
@@ -147,7 +164,7 @@ document.addEventListener(
     const dirtyKeys = [];
     const perSection = new Map();
     for (const r of rows) {
-      const cur = currentValue(r.input);
+      const cur = rowCurrent(r);
       const dirty = cur !== r.baseline;
       const offDefault = cur !== (r.input.dataset.default ?? '');
       r.el.classList.toggle('is-dirty', dirty);
@@ -185,14 +202,23 @@ document.addEventListener(
   }
 
   form.addEventListener('input', refreshAll);
-  form.addEventListener('change', refreshAll);
+  form.addEventListener('change', (e) => {
+    const t = e.target;
+    if (t instanceof HTMLInputElement && t.type === 'radio') {
+      const group = form.querySelectorAll(`input[type=radio][name="${t.name}"]`);
+      for (const i of group) {
+        i.closest('.segment')?.classList.toggle('is-active', i.checked);
+      }
+    }
+    refreshAll();
+  });
 
   form.addEventListener('click', (e) => {
     const btn = e.target.closest('.row-reset');
     if (!btn) return;
     const r = rows.find((row) => row.reset === btn);
     if (!r) return;
-    applyDefault(r.input);
+    applyDefault(r);
     refreshAll();
     r.input.focus();
   });

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -107,8 +107,9 @@
 <div class="settings-row" data-section="{{ section }}">
   {% call row_head(key, hint) %}{% endcall %}
   <div class="row-control-cell">
+    <span class="row-pretty" aria-hidden="true">{{ value }}</span>
     <input type="text"
-           class="model-input"
+           class="text-input"
            name="{{ field }}"
            list="ai-models-{{ scope }}"
            value="{{ value }}"
@@ -153,6 +154,72 @@
 </div>
 {% endmacro %}
 
+{# Generic free-text row (URLs, paths). `value` is the current string;
+   `placeholder` shows when value is empty. Pretty span echoes the value
+   (or placeholder hint when empty) and hides on hover/focus/dirty. #}
+{% macro text_row(section, field, key, hint, value, default, placeholder) %}
+<div class="settings-row" data-section="{{ section }}">
+  {% call row_head(key, hint) %}{% endcall %}
+  <div class="row-control-cell">
+    <span class="row-pretty" aria-hidden="true">{% if value.is_empty() %}<span class="muted">{{ placeholder }}</span>{% else %}{{ value }}{% endif %}</span>
+    <input type="text"
+           class="text-input is-wide"
+           name="{{ field }}"
+           value="{{ value }}"
+           placeholder="{{ placeholder }}"
+           data-default="{{ default }}"
+           data-key="{{ key }}">
+  </div>
+  <div class="row-right">
+    {% call row_reset(key) %}{% endcall %}
+    <span class="row-default">default <span class="mono">{% if default.is_empty() %}(empty){% else %}{{ default }}{% endif %}</span></span>
+  </div>
+</div>
+{% endmacro %}
+
+{# Time-of-day row for `HH:MM` strings (Berlin wallclock). #}
+{% macro time_row(section, field, key, hint, value, default) %}
+<div class="settings-row" data-section="{{ section }}">
+  {% call row_head(key, hint) %}{% endcall %}
+  <div class="row-control-cell">
+    <span class="row-pretty" aria-hidden="true">{{ value }}</span>
+    <input type="time"
+           class="text-input is-narrow"
+           name="{{ field }}"
+           value="{{ value }}"
+           data-default="{{ default }}"
+           data-key="{{ key }}">
+  </div>
+  <div class="row-right">
+    {% call row_reset(key) %}{% endcall %}
+    <span class="row-default">default <span class="mono">{{ default }}</span></span>
+  </div>
+</div>
+{% endmacro %}
+
+{# Slider row for 0..=1 floats (rendered as percentage). #}
+{% macro range_row(section, field, key, hint, value, default) %}
+<div class="settings-row" data-section="{{ section }}">
+  {% call row_head(key, hint) %}{% endcall %}
+  <div class="row-control-cell">
+    <span class="row-pretty" aria-hidden="true" data-pretty-unit="pct">{{ value }}</span>
+    <div class="range-wrap">
+      <input type="range"
+             min="0" max="1" step="0.05"
+             name="{{ field }}"
+             value="{{ value }}"
+             data-default="{{ default }}"
+             data-key="{{ key }}">
+      <span class="range-value" data-range-value>{{ value }}</span>
+    </div>
+  </div>
+  <div class="row-right">
+    {% call row_reset(key) %}{% endcall %}
+    <span class="row-default">default <span class="mono">{{ default }}</span></span>
+  </div>
+</div>
+{% endmacro %}
+
 {# One segmented radio for the reasoning_effort selector. Lifted into a macro
    because askama 0.16 can't iterate `[&str; N]` and compare against a `&str`
    `selected` arg in the same expression without type-mismatch errors. #}
@@ -169,8 +236,9 @@
 <div class="settings-row" data-section="{{ section }}">
   {% call row_head(key, hint) %}{% endcall %}
   <div class="row-control-cell">
+    <span class="row-pretty" aria-hidden="true">{{ value }}</span>
     <input type="text"
-           class="bytesize-input"
+           class="text-input is-narrow"
            name="{{ field }}"
            value="{{ value }}"
            data-default="{{ default }}"

--- a/crates/web/templates/settings/cards/ai_connection.html
+++ b/crates/web/templates/settings/cards/ai_connection.html
@@ -37,21 +37,10 @@
       </div>
     </div>
 
-    <div class="settings-row" data-section="ai_connection">
-      {% call m::row_head("base_url", "Override the provider's API base URL. Empty = provider default.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text"
-               name="ai_connection_base_url"
-               value="{% match current.ai.connection.base_url %}{% when Some with (v) %}{{ v }}{% when None %}{% endmatch %}"
-               placeholder="https://api.openai.com/v1"
-               data-default=""
-               data-key="ai.connection.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.connection.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">(provider default)</span></span>
-      </div>
-    </div>
+    {% let conn_base_url = current.ai.connection.base_url.as_deref().unwrap_or("") %}
+    {% call m::text_row("ai_connection", "ai_connection_base_url", "base_url",
+       "Override the provider's API base URL. Empty = provider default.",
+       conn_base_url, "", "https://api.openai.com/v1") %}{% endcall %}
 
     {% call m::model_row("ai_connection", "ai_connection_model", "model",
        "Model used for !ai chat turns.",

--- a/crates/web/templates/settings/cards/ai_dreamer.html
+++ b/crates/web/templates/settings/cards/ai_dreamer.html
@@ -20,14 +20,16 @@
      the same hidden input is kept for symmetry with the optional cards. #}
   <input type="hidden" name="ai_dreamer_card_visible" value="1">
   <div class="settings-rows">
+    {% let dreamer_model = current.ai.dreamer.model.as_deref().unwrap_or("") %}
     <div class="settings-row" data-section="ai_dreamer" data-card-enabled-by="ai_dreamer_enabled">
       {% call m::row_head("model", "Override the model used for the dreamer pass. Empty = use connection.model.") %}{% endcall %}
       <div class="row-control-cell">
+        <span class="row-pretty" aria-hidden="true">{% if dreamer_model.is_empty() %}<span class="muted">(connection)</span>{% else %}{{ dreamer_model }}{% endif %}</span>
         <input type="text"
-               class="model-input"
+               class="text-input"
                name="ai_dreamer_model"
                list="ai-models-dreamer"
-               value="{% match current.ai.dreamer.model %}{% when Some with (v) %}{{ v }}{% when None %}{% endmatch %}"
+               value="{{ dreamer_model }}"
                placeholder="(use connection model)"
                data-default=""
                data-key="ai.dreamer.model"
@@ -59,22 +61,9 @@
       </div>
     </div>
 
-    <div class="settings-row" data-section="ai_dreamer" data-card-enabled-by="ai_dreamer_enabled">
-      {% call m::row_head("run_at", "Berlin-local wallclock for the nightly run (HH:MM).") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text"
-               name="ai_dreamer_run_at"
-               value="{{ current.ai.dreamer.run_at }}"
-               pattern="^\d{2}:\d{2}$"
-               placeholder="04:00"
-               data-default="{{ defaults.ai.dreamer.run_at }}"
-               data-key="ai.dreamer.run_at">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.dreamer.run_at") %}{% endcall %}
-        <span class="row-default">default <span class="mono">{{ defaults.ai.dreamer.run_at }}</span></span>
-      </div>
-    </div>
+    {% call m::time_row("ai_dreamer", "ai_dreamer_run_at", "run_at",
+       "Berlin-local wallclock for the nightly run (HH:MM).",
+       current.ai.dreamer.run_at, defaults.ai.dreamer.run_at) %}{% endcall %}
 
     {% call m::num_row_bounded("ai_dreamer", "ai_dreamer_timeout_secs", "timeout_secs",
        "Per-pass timeout.",

--- a/crates/web/templates/settings/cards/ai_emotes.html
+++ b/crates/web/templates/settings/cards/ai_emotes.html
@@ -45,19 +45,10 @@
     {% call m::num_row_bounded("ai_emotes", "ai_emotes_min_baseline_emotes", "min_baseline_emotes",
        "Minimum baseline emotes retained even when filtering by recency.",
        e.min_baseline_emotes, 4, "", 0, 200) %}{% endcall %}
-    <div class="settings-row" data-section="ai_emotes" data-card-enabled-by="ai_emotes_enabled">
-      {% call m::row_head("base_url", "Override emote-source base URL. Empty = built-in default.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text" name="ai_emotes_base_url"
-               value="{% match e.base_url %}{% when Some with (v) %}{{ v }}{% when None %}{% endmatch %}"
-               placeholder="(built-in default)"
-               data-default="" data-key="ai.emotes.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.emotes.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">(built-in)</span></span>
-      </div>
-    </div>
+    {% let emotes_base_url = e.base_url.as_deref().unwrap_or("") %}
+    {% call m::text_row("ai_emotes", "ai_emotes_base_url", "base_url",
+       "Override emote-source base URL. Empty = built-in default.",
+       emotes_base_url, "", "(built-in default)") %}{% endcall %}
     {% when None %}
     <div class="settings-row" data-section="ai_emotes" data-card-enabled-by="ai_emotes_enabled">
       {% call m::row_head("include_global", "Include Twitch/3rd-party global emotes (not just channel-specific).") %}{% endcall %}
@@ -84,18 +75,9 @@
     {% call m::num_row_bounded("ai_emotes", "ai_emotes_min_baseline_emotes", "min_baseline_emotes",
        "Minimum baseline emotes retained even when filtering by recency.",
        4, 4, "", 0, 200) %}{% endcall %}
-    <div class="settings-row" data-section="ai_emotes" data-card-enabled-by="ai_emotes_enabled">
-      {% call m::row_head("base_url", "Override emote-source base URL. Empty = built-in default.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text" name="ai_emotes_base_url" value=""
-               placeholder="(built-in default)"
-               data-default="" data-key="ai.emotes.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.emotes.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">(built-in)</span></span>
-      </div>
-    </div>
+    {% call m::text_row("ai_emotes", "ai_emotes_base_url", "base_url",
+       "Override emote-source base URL. Empty = built-in default.",
+       "", "", "(built-in default)") %}{% endcall %}
     {% endmatch %}
   </div>
 </section>

--- a/crates/web/templates/settings/cards/ai_prefill.html
+++ b/crates/web/templates/settings/cards/ai_prefill.html
@@ -19,58 +19,22 @@
   <div class="settings-rows">
     {% match current.ai.prefill %}
     {% when Some with (p) %}
-    <div class="settings-row" data-section="ai_prefill" data-card-enabled-by="ai_prefill_enabled">
-      {% call m::row_head("base_url", "Rustlog endpoint. Restart needed when changed.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text" name="ai_prefill_base_url" value="{{ p.base_url }}"
-               placeholder="https://logs.zonian.dev"
-               data-default="https://logs.zonian.dev" data-key="ai.prefill.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.prefill.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">https://logs.zonian.dev</span></span>
-      </div>
-    </div>
-    <div class="settings-row" data-section="ai_prefill" data-card-enabled-by="ai_prefill_enabled">
-      {% call m::row_head("threshold", "If today's history is below this fraction, also pull yesterday.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="number" step="0.05" min="0" max="1" name="ai_prefill_threshold"
-               value="{{ p.threshold }}"
-               data-default="0.5" data-key="ai.prefill.threshold">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.prefill.threshold") %}{% endcall %}
-        <span class="row-default">default <span class="mono">0.5</span></span>
-      </div>
-    </div>
+    {% call m::text_row("ai_prefill", "ai_prefill_base_url", "base_url",
+       "Rustlog endpoint. Restart needed when changed.",
+       p.base_url, "https://logs.zonian.dev", "https://logs.zonian.dev") %}{% endcall %}
+    {% call m::range_row("ai_prefill", "ai_prefill_threshold", "threshold",
+       "If today's history is below this fraction, also pull yesterday.",
+       p.threshold, 0.5) %}{% endcall %}
     {% when None %}
     {# Card is off: render the same fields with the compiled defaults so that
        enabling the toggle gives admins something sensible to edit. JS (Task
        20) disables them visually via data-card-enabled-by. #}
-    <div class="settings-row" data-section="ai_prefill" data-card-enabled-by="ai_prefill_enabled">
-      {% call m::row_head("base_url", "Rustlog endpoint. Restart needed when changed.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text" name="ai_prefill_base_url" value="https://logs.zonian.dev"
-               placeholder="https://logs.zonian.dev"
-               data-default="https://logs.zonian.dev" data-key="ai.prefill.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.prefill.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">https://logs.zonian.dev</span></span>
-      </div>
-    </div>
-    <div class="settings-row" data-section="ai_prefill" data-card-enabled-by="ai_prefill_enabled">
-      {% call m::row_head("threshold", "If today's history is below this fraction, also pull yesterday.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="number" step="0.05" min="0" max="1" name="ai_prefill_threshold"
-               value="0.5"
-               data-default="0.5" data-key="ai.prefill.threshold">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.prefill.threshold") %}{% endcall %}
-        <span class="row-default">default <span class="mono">0.5</span></span>
-      </div>
-    </div>
+    {% call m::text_row("ai_prefill", "ai_prefill_base_url", "base_url",
+       "Rustlog endpoint. Restart needed when changed.",
+       "https://logs.zonian.dev", "https://logs.zonian.dev", "https://logs.zonian.dev") %}{% endcall %}
+    {% call m::range_row("ai_prefill", "ai_prefill_threshold", "threshold",
+       "If today's history is below this fraction, also pull yesterday.",
+       0.5, 0.5) %}{% endcall %}
     {% endmatch %}
   </div>
 </section>

--- a/crates/web/templates/settings/cards/ai_web.html
+++ b/crates/web/templates/settings/cards/ai_web.html
@@ -19,18 +19,9 @@
   <div class="settings-rows">
     {% match current.ai.web %}
     {% when Some with (w) %}
-    <div class="settings-row" data-section="ai_web" data-card-enabled-by="ai_web_enabled">
-      {% call m::row_head("base_url", "SearXNG /search endpoint.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text" name="ai_web_base_url" value="{{ w.base_url }}"
-               placeholder="http://localhost:8080/search"
-               data-default="http://localhost:8080/search" data-key="ai.web.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.web.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">http://localhost:8080/search</span></span>
-      </div>
-    </div>
+    {% call m::text_row("ai_web", "ai_web_base_url", "base_url",
+       "SearXNG /search endpoint.",
+       w.base_url, "http://localhost:8080/search", "http://localhost:8080/search") %}{% endcall %}
     {% call m::num_row_bounded("ai_web", "ai_web_timeout", "timeout",
        "Per-request timeout.",
        w.timeout, 15, "s", 1, 120) %}{% endcall %}
@@ -47,18 +38,9 @@
        "Max entries in the LRU search cache.",
        w.cache_capacity, 100, "", 1, 10000) %}{% endcall %}
     {% when None %}
-    <div class="settings-row" data-section="ai_web" data-card-enabled-by="ai_web_enabled">
-      {% call m::row_head("base_url", "SearXNG /search endpoint.") %}{% endcall %}
-      <div class="row-control-cell">
-        <input type="text" name="ai_web_base_url" value="http://localhost:8080/search"
-               placeholder="http://localhost:8080/search"
-               data-default="http://localhost:8080/search" data-key="ai.web.base_url">
-      </div>
-      <div class="row-right">
-        {% call m::row_reset("ai.web.base_url") %}{% endcall %}
-        <span class="row-default">default <span class="mono">http://localhost:8080/search</span></span>
-      </div>
-    </div>
+    {% call m::text_row("ai_web", "ai_web_base_url", "base_url",
+       "SearXNG /search endpoint.",
+       "http://localhost:8080/search", "http://localhost:8080/search", "http://localhost:8080/search") %}{% endcall %}
     {% call m::num_row_bounded("ai_web", "ai_web_timeout", "timeout",
        "Per-request timeout.",
        15, 15, "s", 1, 120) %}{% endcall %}


### PR DESCRIPTION
## Summary
- Settings save POST succeeded but UI kept showing "X changes pending" forever — JS compared each row to its compile-time `data-default` instead of the saved value. Snapshot the loaded value as a per-row baseline; reset-to-default still uses `data-default`.
- Backend and reasoning_effort segmented radio groups never triggered the save bar because row tracking only saw the first radio in the group. Track all radios per row and toggle `.segment.is-active` on change.
- Free-text rows (base_url, dreamer.model, dreamer.run_at, media size caps) had no CSS class and no row-pretty summary, so they rendered as bare browser inputs in permanent "edit" state. Introduce `.text-input` with the same hover/focus/dirty reveal as numeric rows, plus `text_row`/`time_row`/`range_row` macros; convert every affected card.
- `ai.prefill.threshold` is now a 0..1 range slider with a live percentage readout.
- `ai.dreamer.run_at` uses `<input type=\"time\">`.

## Test plan
- [ ] Load `/settings`: no "pending changes" bar on first paint, every section's nav badge reads 0.
- [ ] Edit a cooldown → save bar appears with count, save → page reloads with flash and bar gone.
- [ ] Switch backend (ollama ↔ openai) → save bar appears, pill follows pick.
- [ ] Change reasoning_effort segment → save bar appears, save succeeds.
- [ ] Hover a model/url/run_at row → pretty summary fades, styled text input appears; idle returns to pretty.
- [ ] Drag prefill threshold slider → percentage readout updates live, save persists value.
- [ ] Reset-to-default button shows whenever current ≠ compile default (independent of baseline).