### PR TITLE
feat(web): grouped settings sidebar + bytes-input control

### DIFF
--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -1333,27 +1333,28 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
 .bytes-units {
   display: inline-flex;
   align-items: stretch;
-  padding: 3px;
-  gap: 2px;
+  padding: 4px;
+  gap: 3px;
 }
 .bytes-units .bytes-unit {
   background: transparent;
   border: 0;
   font: inherit;
   font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--fg-4);
-  padding: 0 9px;
-  border-radius: 3px;
+  font-size: 12px;
+  color: var(--fg-3);
+  padding: 0 10px;
+  border-radius: 4px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   transition: background 0.15s, color 0.15s;
 }
-.bytes-units .bytes-unit:hover { color: var(--fg-2); }
+.bytes-units .bytes-unit:hover { color: var(--fg); }
 .bytes-units .bytes-unit.is-active {
   background: var(--accent-soft);
   color: var(--accent);
+  font-weight: 600;
 }
 
 .text-input {

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -1333,8 +1333,10 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   background: transparent;
   border: 0;
   font: inherit;
-  color: var(--fg-muted);
-  padding: 4px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-4);
+  padding: 5px 10px;
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
@@ -1344,44 +1346,6 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   background: var(--bg-elev);
   color: var(--accent);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
-}
-.bytes-aux {
-  display: block;
-  margin-top: 6px;
-  font-family: var(--mono);
-  font-size: 11.5px;
-  color: var(--fg-3);
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-.bytes-aux .muted { color: var(--fg-4); }
-.settings-row:hover .bytes-aux,
-.settings-row:focus-within .bytes-aux,
-.settings-row.is-dirty .bytes-aux { opacity: 1; }
-.bytes-presets {
-  display: flex;
-  gap: 6px;
-  margin-top: 6px;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-.settings-row:hover .bytes-presets,
-.settings-row:focus-within .bytes-presets { opacity: 1; }
-.bytes-preset {
-  background: transparent;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--fg-3);
-  padding: 2px 8px;
-  cursor: pointer;
-  transition: border-color 0.12s, color 0.12s, background 0.12s;
-}
-.bytes-preset:hover {
-  border-color: var(--accent-soft);
-  color: var(--accent);
-  background: var(--bg-2);
 }
 
 .text-input {

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -1308,44 +1308,52 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   flex-shrink: 0;
 }
 
-/* ─── Bytes row (numeric + unit segmented + aux) ─────────────────────────── */
+/* ─── Bytes row (numeric + inline unit segments) ─────────────────────────── */
 .bytes-wrap {
   display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-.bytes-input-wrap {
-  display: inline-flex;
-  align-items: center;
+  align-items: stretch;
   background: var(--bg-3);
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   transition: border-color 0.12s ease, background 0.12s ease;
-  width: 96px;
+  width: 220px;
+  overflow: hidden;
 }
-.bytes-input-wrap:focus-within {
+.bytes-wrap:focus-within {
   border-color: var(--line-strong);
   background: var(--bg-2);
 }
-.settings-row.is-dirty .bytes-input-wrap { border-color: var(--accent-soft); }
-.bytes-input-wrap .bytes-display { padding: 7px 10px; text-align: right; }
-.segmented.bytes-units .bytes-unit {
+.settings-row.is-dirty .bytes-wrap { border-color: var(--accent-soft); }
+.bytes-wrap .bytes-display {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  text-align: right;
+}
+.bytes-units {
+  display: inline-flex;
+  align-items: stretch;
+  padding: 3px;
+  gap: 2px;
+}
+.bytes-units .bytes-unit {
   background: transparent;
   border: 0;
   font: inherit;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--fg-4);
-  padding: 5px 10px;
-  border-radius: 4px;
+  padding: 0 9px;
+  border-radius: 3px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
   transition: background 0.15s, color 0.15s;
 }
-.segmented.bytes-units .bytes-unit:hover { color: var(--fg-2); }
-.segmented.bytes-units .bytes-unit.is-active {
-  background: var(--bg-elev);
+.bytes-units .bytes-unit:hover { color: var(--fg-2); }
+.bytes-units .bytes-unit.is-active {
+  background: var(--accent-soft);
   color: var(--accent);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
 }
 
 .text-input {

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -954,32 +954,108 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   top: 12px;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 18px;
 }
-.settings-nav-label {
+
+/* Group header (Chat / AI / Runtime) */
+.settings-nav-group { display: flex; flex-direction: column; }
+.settings-nav-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 0;
+  padding: 4px 6px 6px;
   font-family: var(--mono);
   font-size: 10.5px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--fg-4);
-  padding: 0 8px 8px;
+  cursor: pointer;
+  transition: color 0.12s ease;
 }
+.settings-nav-group-head:hover { color: var(--fg-3); }
+.settings-nav-group.has-active .settings-nav-group-head { color: var(--fg-2); }
+.settings-nav-group-head .chev {
+  display: inline-block;
+  font-size: 9px;
+  color: var(--fg-4);
+  transition: transform 0.18s ease;
+  width: 8px;
+  text-align: center;
+}
+.settings-nav-group-head[aria-expanded="true"] .chev { transform: rotate(90deg); }
+.settings-nav-group-head .lbl { font-weight: 600; }
+.settings-nav-group-head .meta {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.settings-nav-group-head .count {
+  font-size: 10.5px;
+  color: var(--fg-4);
+  font-variant-numeric: tabular-nums;
+}
+.settings-nav-group-head .gdirty {
+  font-size: 10.5px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Collapsible body using grid trick */
+.settings-nav-group-body {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.2s ease;
+}
+.settings-nav-group-body > * { overflow: hidden; min-height: 0; }
+.settings-nav-group[data-open="false"] .settings-nav-group-body { grid-template-rows: 0fr; }
+
+.settings-nav-group-items {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0 0 0 18px;
+  border-left: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  transition: border-color 0.18s ease;
+}
+.settings-nav-group.has-active .settings-nav-group-items { border-left-color: var(--accent-soft); }
+
 .settings-nav-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 10px;
+  padding: 6px 10px;
   border-radius: var(--r-sm);
   font-family: var(--mono);
   font-size: 13px;
   color: var(--fg-3);
   text-decoration: none;
   cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 .settings-nav-item:hover { background: var(--bg-1); color: var(--fg-2); }
 .settings-nav-item.active {
   background: var(--accent-fade);
   color: var(--fg);
+}
+.settings-nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -19px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 2px;
+  box-shadow: 0 0 6px var(--accent);
 }
 .settings-nav-item .dot {
   width: 5px;
@@ -987,6 +1063,7 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   border-radius: 50%;
   background: var(--bg-3);
   flex-shrink: 0;
+  transition: background 0.12s ease, box-shadow 0.12s ease;
 }
 .settings-nav-item.active .dot {
   background: var(--accent);
@@ -1001,6 +1078,27 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   border-radius: 999px;
   font-variant-numeric: tabular-nums;
 }
+
+/* Main-column group dividers */
+.settings-group-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0 14px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--fg-4);
+}
+.settings-group-divider:not(:first-child) { margin-top: 18px; }
+.settings-group-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+.settings-group-divider > span { white-space: nowrap; }
 
 .settings-main { min-width: 0; }
 

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -957,7 +957,6 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   gap: 18px;
 }
 
-/* Group header (Chat / AI / Runtime) */
 .settings-nav-group { display: flex; flex-direction: column; }
 .settings-nav-group-head {
   display: flex;
@@ -1006,7 +1005,6 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   font-variant-numeric: tabular-nums;
 }
 
-/* Collapsible body using grid trick */
 .settings-nav-group-body {
   display: grid;
   grid-template-rows: 1fr;
@@ -1079,7 +1077,6 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   font-variant-numeric: tabular-nums;
 }
 
-/* Main-column group dividers */
 .settings-group-divider {
   display: flex;
   align-items: center;
@@ -1308,7 +1305,6 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   flex-shrink: 0;
 }
 
-/* ─── Bytes row (numeric + inline unit segments) ─────────────────────────── */
 .bytes-wrap {
   display: inline-flex;
   align-items: stretch;

--- a/crates/web/assets/app.css
+++ b/crates/web/assets/app.css
@@ -1123,16 +1123,20 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   transition: opacity 0.12s ease;
 }
 .row-control-cell .num-wrap,
-.row-control-cell .toggle {
+.row-control-cell .toggle,
+.row-control-cell .bytes-wrap {
   transition: opacity 0.12s ease;
   opacity: 0;
 }
 .settings-row:hover .row-control-cell .num-wrap,
 .settings-row:hover .row-control-cell .toggle,
+.settings-row:hover .row-control-cell .bytes-wrap,
 .settings-row:focus-within .row-control-cell .num-wrap,
 .settings-row:focus-within .row-control-cell .toggle,
+.settings-row:focus-within .row-control-cell .bytes-wrap,
 .settings-row.is-dirty .row-control-cell .num-wrap,
-.settings-row.is-dirty .row-control-cell .toggle { opacity: 1; }
+.settings-row.is-dirty .row-control-cell .toggle,
+.settings-row.is-dirty .row-control-cell .bytes-wrap { opacity: 1; }
 .settings-row:hover .row-pretty,
 .settings-row:focus-within .row-pretty,
 .settings-row.is-dirty .row-pretty { opacity: 0; }
@@ -1204,6 +1208,82 @@ textarea.input { resize: vertical; min-height: 140px; line-height: 1.6; }
   font-size: 12px;
   color: var(--fg-4);
   flex-shrink: 0;
+}
+
+/* ─── Bytes row (numeric + unit segmented + aux) ─────────────────────────── */
+.bytes-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.bytes-input-wrap {
+  display: inline-flex;
+  align-items: center;
+  background: var(--bg-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  transition: border-color 0.12s ease, background 0.12s ease;
+  width: 96px;
+}
+.bytes-input-wrap:focus-within {
+  border-color: var(--line-strong);
+  background: var(--bg-2);
+}
+.settings-row.is-dirty .bytes-input-wrap { border-color: var(--accent-soft); }
+.bytes-input-wrap .bytes-display { padding: 7px 10px; text-align: right; }
+.segmented.bytes-units .bytes-unit {
+  background: transparent;
+  border: 0;
+  font: inherit;
+  color: var(--fg-muted);
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.segmented.bytes-units .bytes-unit:hover { color: var(--fg-2); }
+.segmented.bytes-units .bytes-unit.is-active {
+  background: var(--bg-elev);
+  color: var(--accent);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+.bytes-aux {
+  display: block;
+  margin-top: 6px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--fg-3);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.bytes-aux .muted { color: var(--fg-4); }
+.settings-row:hover .bytes-aux,
+.settings-row:focus-within .bytes-aux,
+.settings-row.is-dirty .bytes-aux { opacity: 1; }
+.bytes-presets {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.settings-row:hover .bytes-presets,
+.settings-row:focus-within .bytes-presets { opacity: 1; }
+.bytes-preset {
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.bytes-preset:hover {
+  border-color: var(--accent-soft);
+  color: var(--accent);
+  background: var(--bg-2);
 }
 
 .text-input {

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -289,8 +289,6 @@ document.addEventListener(
     const hidden = row.querySelector('.bytes-canonical');
     const display = row.querySelector('.bytes-display');
     const buttons = Array.from(row.querySelectorAll('.bytes-unit'));
-    const auxBytes = row.querySelector('[data-bytes-aux-bytes]');
-    const auxPretty = row.querySelector('[data-bytes-aux-pretty]');
     if (!hidden || !display) return;
     const bytes = Number(hidden.value) || 0;
     const unit = display.dataset.unit || pickBestUnit(bytes);
@@ -303,8 +301,6 @@ document.addEventListener(
       b.classList.toggle('is-active', active);
       b.setAttribute('aria-pressed', active ? 'true' : 'false');
     }
-    if (auxBytes) auxBytes.textContent = String(bytes);
-    if (auxPretty) auxPretty.textContent = formatBytesIec(bytes);
   }
 
   function syncAllBytesRows() {
@@ -323,7 +319,6 @@ document.addEventListener(
   for (const row of bytesRows) {
     const display = row.querySelector('.bytes-display');
     const buttons = Array.from(row.querySelectorAll('.bytes-unit'));
-    const presets = Array.from(row.querySelectorAll('.bytes-preset'));
 
     display?.addEventListener('input', () => {
       const v = Number(display.value);
@@ -349,13 +344,6 @@ document.addEventListener(
         if (!newUnit || !display) return;
         display.dataset.unit = newUnit;
         syncBytesRow(row);
-      });
-    }
-    for (const p of presets) {
-      p.addEventListener('click', () => {
-        const bytes = Number(p.dataset.bytes) || 0;
-        if (display) display.dataset.unit = pickBestUnit(bytes);
-        commitBytes(row, bytes);
       });
     }
   }

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -330,7 +330,11 @@ document.addEventListener(
     }
   }
 
-  for (const b of bytesRows) syncBytesRow(b);
+  for (const b of bytesRows) {
+    const def = b.el.querySelector('[data-bytes-default]');
+    if (def) def.textContent = formatBytesIec(def.dataset.bytesDefault);
+    syncBytesRow(b);
+  }
 
   form.addEventListener('input', refreshAll);
   form.addEventListener('change', (e) => {

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -123,8 +123,21 @@ document.addEventListener(
     .filter((r) => r);
 
 
+  const BYTES_UNIT_FACTOR = { B: 1, KiB: 1024, MiB: 1024 * 1024 };
+
+  function formatBytesIec(bytes) {
+    const n = Number(bytes);
+    if (!Number.isFinite(n) || n < 0) return `${bytes} B`;
+    if (n >= 1048576 && n % 1048576 === 0) return `${n / 1048576} MiB`;
+    if (n >= 1024 && n % 1024 === 0) return `${n / 1024} KiB`;
+    if (n >= 1048576) return `${(n / 1048576).toFixed(2)} MiB`;
+    if (n >= 1024) return `${(n / 1024).toFixed(2)} KiB`;
+    return `${n} B`;
+  }
+
   function formatPretty(input, prettyEl) {
     const unit = prettyEl?.dataset.prettyUnit ?? '';
+    if (unit === 'bytes') return formatBytesIec(input.value);
     if (unit === 'bool') return input.checked ? 'On' : 'Off';
     if (input.type === 'text' || input.type === 'time' || input.type === 'email' || input.type === 'url') {
       return input.value || (input.placeholder ? `(${input.placeholder})` : '');
@@ -209,6 +222,8 @@ document.addEventListener(
       }
     }
 
+    syncAllBytesRows();
+
     const total = dirtyKeys.length;
     countEl.textContent = String(total);
     nounEl.textContent = total === 1 ? 'change' : 'changes';
@@ -217,6 +232,97 @@ document.addEventListener(
       total > 3 ? `${preview} +${total - 3}` : preview;
     saveBar.classList.toggle('visible', total > 0);
   }
+
+  const bytesRows = Array.from(form.querySelectorAll('[data-bytes-row]'));
+
+  function pickBestUnit(bytes) {
+    if (bytes >= 1048576 && bytes % 1048576 === 0) return 'MiB';
+    if (bytes >= 1024 && bytes % 1024 === 0) return 'KiB';
+    return 'B';
+  }
+
+  function displayInUnit(bytes, unit) {
+    const f = BYTES_UNIT_FACTOR[unit] ?? 1;
+    const v = bytes / f;
+    return Number(v.toFixed(6)).toString();
+  }
+
+  function syncBytesRow(row) {
+    const hidden = row.querySelector('.bytes-canonical');
+    const display = row.querySelector('.bytes-display');
+    const buttons = Array.from(row.querySelectorAll('.bytes-unit'));
+    const auxBytes = row.querySelector('[data-bytes-aux-bytes]');
+    const auxPretty = row.querySelector('[data-bytes-aux-pretty]');
+    if (!hidden || !display) return;
+    const bytes = Number(hidden.value) || 0;
+    const unit = display.dataset.unit || pickBestUnit(bytes);
+    display.dataset.unit = unit;
+    if (document.activeElement !== display) {
+      display.value = displayInUnit(bytes, unit);
+    }
+    for (const b of buttons) {
+      const active = b.dataset.unit === unit;
+      b.classList.toggle('is-active', active);
+      b.setAttribute('aria-pressed', active ? 'true' : 'false');
+    }
+    if (auxBytes) auxBytes.textContent = String(bytes);
+    if (auxPretty) auxPretty.textContent = formatBytesIec(bytes);
+  }
+
+  function syncAllBytesRows() {
+    for (const r of bytesRows) syncBytesRow(r);
+  }
+
+  function commitBytes(row, bytes) {
+    const hidden = row.querySelector('.bytes-canonical');
+    if (!hidden) return;
+    const clamped = Math.max(0, Math.round(bytes));
+    if (Number(hidden.value) === clamped) return;
+    hidden.value = String(clamped);
+    hidden.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  for (const row of bytesRows) {
+    const display = row.querySelector('.bytes-display');
+    const buttons = Array.from(row.querySelectorAll('.bytes-unit'));
+    const presets = Array.from(row.querySelectorAll('.bytes-preset'));
+
+    display?.addEventListener('input', () => {
+      const v = Number(display.value);
+      if (!Number.isFinite(v) || v < 0) return;
+      const f = BYTES_UNIT_FACTOR[display.dataset.unit || 'B'] ?? 1;
+      commitBytes(row, v * f);
+    });
+    display?.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        syncBytesRow(row);
+        display.blur();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        display.blur();
+      }
+    });
+    display?.addEventListener('blur', () => syncBytesRow(row));
+
+    for (const b of buttons) {
+      b.addEventListener('click', () => {
+        const newUnit = b.dataset.unit;
+        if (!newUnit || !display) return;
+        display.dataset.unit = newUnit;
+        syncBytesRow(row);
+      });
+    }
+    for (const p of presets) {
+      p.addEventListener('click', () => {
+        const bytes = Number(p.dataset.bytes) || 0;
+        if (display) display.dataset.unit = pickBestUnit(bytes);
+        commitBytes(row, bytes);
+      });
+    }
+  }
+
+  syncAllBytesRows();
 
   form.addEventListener('input', refreshAll);
   form.addEventListener('change', (e) => {

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -125,19 +125,24 @@ document.addEventListener(
 
   const BYTES_UNIT_FACTOR = { B: 1, KiB: 1024, MiB: 1024 * 1024 };
 
+  function pickBestBytesUnit(n) {
+    if (n >= BYTES_UNIT_FACTOR.MiB) return 'MiB';
+    if (n >= BYTES_UNIT_FACTOR.KiB) return 'KiB';
+    return 'B';
+  }
+
   function formatBytesIec(bytes) {
     const n = Number(bytes);
-    if (!Number.isFinite(n) || n < 0) return `${bytes} B`;
-    if (n >= 1048576 && n % 1048576 === 0) return `${n / 1048576} MiB`;
-    if (n >= 1024 && n % 1024 === 0) return `${n / 1024} KiB`;
-    if (n >= 1048576) return `${(n / 1048576).toFixed(2)} MiB`;
-    if (n >= 1024) return `${(n / 1024).toFixed(2)} KiB`;
-    return `${n} B`;
+    if (!Number.isFinite(n)) return String(bytes);
+    const unit = pickBestBytesUnit(n);
+    const f = BYTES_UNIT_FACTOR[unit];
+    const v = n / f;
+    return `${n % f === 0 ? v : v.toFixed(2)} ${unit}`;
   }
 
   function formatPretty(input, prettyEl) {
     const unit = prettyEl?.dataset.prettyUnit ?? '';
-    if (unit === 'bytes') return formatBytesIec(input.value);
+    if (unit === 'bytes' || unit === 'B') return formatBytesIec(input.value);
     if (unit === 'bool') return input.checked ? 'On' : 'Off';
     if (input.type === 'text' || input.type === 'time' || input.type === 'email' || input.type === 'url') {
       return input.value || (input.placeholder ? `(${input.placeholder})` : '');
@@ -146,38 +151,34 @@ document.addEventListener(
     if (!Number.isFinite(n)) return input.value;
     if (unit === 'pct') return `${Math.round(n * 100)}%`;
     if (unit === 's') return n === 1 ? '1 second' : `${n} seconds`;
-    if (unit === 'B') {
-      if (n % 1024 === 0 && n >= 1024) return `${n / 1024} KiB`;
-      return `${n} B`;
-    }
     return unit ? `${n} ${unit}` : String(n);
   }
   const cards = Array.from(form.querySelectorAll('.settings-card'));
   const navItems = Array.from(document.querySelectorAll('.settings-nav-item'));
-  const navGroups = Array.from(document.querySelectorAll('.settings-nav-group'));
+  const navGroups = Array.from(document.querySelectorAll('.settings-nav-group')).map((el) => ({
+    el,
+    items: Array.from(el.querySelectorAll('.settings-nav-item')),
+    badge: el.querySelector('.gdirty'),
+  }));
 
-  // Collapsible groups (persisted per-group in localStorage).
   const STORAGE_KEY = 'settings-nav-groups-collapsed';
   let collapsed = new Set();
-  try { collapsed = new Set(JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')); } catch { /* ignore */ }
-  for (const g of navGroups) {
-    const id = g.dataset.group;
-    const open = !collapsed.has(id);
-    g.dataset.open = open ? 'true' : 'false';
-    const head = g.querySelector('.settings-nav-group-head');
-    head?.setAttribute('aria-expanded', open ? 'true' : 'false');
+  try { collapsed = new Set(JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')); } catch { /* ignore corrupt JSON, start fresh */ }
+  for (const { el } of navGroups) {
+    const open = !collapsed.has(el.dataset.group);
+    el.dataset.open = open ? 'true' : 'false';
+    el.querySelector('.settings-nav-group-head')?.setAttribute('aria-expanded', open ? 'true' : 'false');
   }
   for (const head of document.querySelectorAll('[data-group-toggle]')) {
     head.addEventListener('click', () => {
       const group = head.closest('.settings-nav-group');
       if (!group) return;
       const id = group.dataset.group;
-      const wasOpen = group.dataset.open !== 'false';
-      const open = !wasOpen;
+      const open = group.dataset.open === 'false';
       group.dataset.open = open ? 'true' : 'false';
       head.setAttribute('aria-expanded', open ? 'true' : 'false');
       if (open) collapsed.delete(id); else collapsed.add(id);
-      try { localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed])); } catch { /* ignore */ }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed]));
     });
   }
 
@@ -248,19 +249,14 @@ document.addEventListener(
       }
     }
 
-    for (const group of navGroups) {
+    for (const g of navGroups) {
       let n = 0;
-      for (const item of group.querySelectorAll('.settings-nav-item')) {
-        n += perSection.get(item.dataset.target) ?? 0;
-      }
-      const badge = group.querySelector('.gdirty');
-      if (badge) {
-        badge.hidden = n === 0;
-        badge.textContent = String(n);
+      for (const item of g.items) n += perSection.get(item.dataset.target) ?? 0;
+      if (g.badge) {
+        g.badge.hidden = n === 0;
+        g.badge.textContent = String(n);
       }
     }
-
-    syncAllBytesRows();
 
     const total = dirtyKeys.length;
     countEl.textContent = String(total);
@@ -271,84 +267,70 @@ document.addEventListener(
     saveBar.classList.toggle('visible', total > 0);
   }
 
-  const bytesRows = Array.from(form.querySelectorAll('[data-bytes-row]'));
-
-  function pickBestUnit(bytes) {
-    if (bytes >= 1048576 && bytes % 1048576 === 0) return 'MiB';
-    if (bytes >= 1024 && bytes % 1024 === 0) return 'KiB';
-    return 'B';
-  }
+  const bytesRows = Array.from(form.querySelectorAll('[data-bytes-row]'))
+    .map((el) => ({
+      el,
+      hidden: el.querySelector('.bytes-canonical'),
+      display: el.querySelector('.bytes-display'),
+      buttons: Array.from(el.querySelectorAll('.bytes-unit')),
+    }))
+    .filter((b) => b.hidden && b.display);
+  const bytesRowByHidden = new Map(bytesRows.map((b) => [b.hidden, b]));
 
   function displayInUnit(bytes, unit) {
-    const f = BYTES_UNIT_FACTOR[unit] ?? 1;
-    const v = bytes / f;
-    return Number(v.toFixed(6)).toString();
+    return parseFloat((bytes / BYTES_UNIT_FACTOR[unit]).toFixed(6)).toString();
   }
 
-  function syncBytesRow(row) {
-    const hidden = row.querySelector('.bytes-canonical');
-    const display = row.querySelector('.bytes-display');
-    const buttons = Array.from(row.querySelectorAll('.bytes-unit'));
-    if (!hidden || !display) return;
-    const bytes = Number(hidden.value) || 0;
-    const unit = display.dataset.unit || pickBestUnit(bytes);
-    display.dataset.unit = unit;
-    if (document.activeElement !== display) {
-      display.value = displayInUnit(bytes, unit);
-    }
-    for (const b of buttons) {
-      const active = b.dataset.unit === unit;
-      b.classList.toggle('is-active', active);
-      b.setAttribute('aria-pressed', active ? 'true' : 'false');
+  function activeUnit(b) {
+    return b.buttons.find((btn) => btn.classList.contains('is-active'))?.dataset.unit
+      ?? pickBestBytesUnit(Number(b.hidden.value) || 0);
+  }
+
+  function syncBytesRow(b) {
+    const bytes = Number(b.hidden.value) || 0;
+    const unit = activeUnit(b);
+    if (document.activeElement !== b.display) b.display.value = displayInUnit(bytes, unit);
+    for (const btn of b.buttons) {
+      const active = btn.dataset.unit === unit;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
     }
   }
 
-  function syncAllBytesRows() {
-    for (const r of bytesRows) syncBytesRow(r);
-  }
-
-  function commitBytes(row, bytes) {
-    const hidden = row.querySelector('.bytes-canonical');
-    if (!hidden) return;
+  function commitBytes(b, bytes) {
     const clamped = Math.max(0, Math.round(bytes));
-    if (Number(hidden.value) === clamped) return;
-    hidden.value = String(clamped);
-    hidden.dispatchEvent(new Event('input', { bubbles: true }));
+    if (Number(b.hidden.value) === clamped) return;
+    b.hidden.value = String(clamped);
+    b.hidden.dispatchEvent(new Event('input', { bubbles: true }));
   }
 
-  for (const row of bytesRows) {
-    const display = row.querySelector('.bytes-display');
-    const buttons = Array.from(row.querySelectorAll('.bytes-unit'));
-
-    display?.addEventListener('input', () => {
-      const v = Number(display.value);
+  for (const b of bytesRows) {
+    b.display.addEventListener('input', () => {
+      const v = Number(b.display.value);
       if (!Number.isFinite(v) || v < 0) return;
-      const f = BYTES_UNIT_FACTOR[display.dataset.unit || 'B'] ?? 1;
-      commitBytes(row, v * f);
+      commitBytes(b, v * BYTES_UNIT_FACTOR[activeUnit(b)]);
     });
-    display?.addEventListener('keydown', (e) => {
+    b.display.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        syncBytesRow(row);
-        display.blur();
+        syncBytesRow(b);
+        b.display.blur();
       } else if (e.key === 'Enter') {
         e.preventDefault();
-        display.blur();
+        b.display.blur();
       }
     });
-    display?.addEventListener('blur', () => syncBytesRow(row));
+    b.display.addEventListener('blur', () => syncBytesRow(b));
 
-    for (const b of buttons) {
-      b.addEventListener('click', () => {
-        const newUnit = b.dataset.unit;
-        if (!newUnit || !display) return;
-        display.dataset.unit = newUnit;
-        syncBytesRow(row);
+    for (const btn of b.buttons) {
+      btn.addEventListener('click', () => {
+        for (const other of b.buttons) other.classList.toggle('is-active', other === btn);
+        syncBytesRow(b);
       });
     }
   }
 
-  syncAllBytesRows();
+  for (const b of bytesRows) syncBytesRow(b);
 
   form.addEventListener('input', refreshAll);
   form.addEventListener('change', (e) => {
@@ -368,6 +350,8 @@ document.addEventListener(
     const r = rows.find((row) => row.reset === btn);
     if (!r) return;
     applyDefault(r);
+    const b = bytesRowByHidden.get(r.input);
+    if (b) syncBytesRow(b);
     refreshAll();
     r.input.focus();
   });
@@ -384,7 +368,7 @@ document.addEventListener(
       byId.get(section)?.classList.add('active');
       const activeItem = byId.get(section);
       const activeGroup = activeItem?.closest('.settings-nav-group');
-      for (const g of navGroups) g.classList.toggle('has-active', g === activeGroup);
+      for (const g of navGroups) g.el.classList.toggle('has-active', g.el === activeGroup);
     };
     setActive(cards[0].dataset.section);
     const io = new IntersectionObserver(

--- a/crates/web/assets/app.js
+++ b/crates/web/assets/app.js
@@ -154,6 +154,32 @@ document.addEventListener(
   }
   const cards = Array.from(form.querySelectorAll('.settings-card'));
   const navItems = Array.from(document.querySelectorAll('.settings-nav-item'));
+  const navGroups = Array.from(document.querySelectorAll('.settings-nav-group'));
+
+  // Collapsible groups (persisted per-group in localStorage).
+  const STORAGE_KEY = 'settings-nav-groups-collapsed';
+  let collapsed = new Set();
+  try { collapsed = new Set(JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')); } catch { /* ignore */ }
+  for (const g of navGroups) {
+    const id = g.dataset.group;
+    const open = !collapsed.has(id);
+    g.dataset.open = open ? 'true' : 'false';
+    const head = g.querySelector('.settings-nav-group-head');
+    head?.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  for (const head of document.querySelectorAll('[data-group-toggle]')) {
+    head.addEventListener('click', () => {
+      const group = head.closest('.settings-nav-group');
+      if (!group) return;
+      const id = group.dataset.group;
+      const wasOpen = group.dataset.open !== 'false';
+      const open = !wasOpen;
+      group.dataset.open = open ? 'true' : 'false';
+      head.setAttribute('aria-expanded', open ? 'true' : 'false');
+      if (open) collapsed.delete(id); else collapsed.add(id);
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed])); } catch { /* ignore */ }
+    });
+  }
 
   function currentValue(input) {
     return input.type === 'checkbox' ? (input.checked ? 'true' : 'false') : input.value;
@@ -216,6 +242,18 @@ document.addEventListener(
     for (const item of navItems) {
       const n = perSection.get(item.dataset.target) ?? 0;
       const badge = item.querySelector('.ndirty');
+      if (badge) {
+        badge.hidden = n === 0;
+        badge.textContent = String(n);
+      }
+    }
+
+    for (const group of navGroups) {
+      let n = 0;
+      for (const item of group.querySelectorAll('.settings-nav-item')) {
+        n += perSection.get(item.dataset.target) ?? 0;
+      }
+      const badge = group.querySelector('.gdirty');
       if (badge) {
         badge.hidden = n === 0;
         badge.textContent = String(n);
@@ -356,6 +394,9 @@ document.addEventListener(
       if (active) byId.get(active)?.classList.remove('active');
       active = section;
       byId.get(section)?.classList.add('active');
+      const activeItem = byId.get(section);
+      const activeGroup = activeItem?.closest('.settings-nav-group');
+      for (const g of navGroups) g.classList.toggle('has-active', g === activeGroup);
     };
     setActive(cards[0].dataset.section);
     const io = new IntersectionObserver(

--- a/crates/web/src/bin/web_dev.rs
+++ b/crates/web/src/bin/web_dev.rs
@@ -63,7 +63,9 @@ async fn main() -> Result<()> {
 
     let pings = PingManager::load(&data_dir).wrap_err("load ping manager")?;
 
-    let audit_log = Arc::new(twitch_1337_core::settings::MemoryAuditLog::new());
+    let audit_log: Arc<dyn twitch_1337_core::settings::AuditLog> = Arc::new(
+        twitch_1337_core::settings::FileAuditLog::new(data_dir.join("settings_audit.log")),
+    );
     let (settings_store, settings_handle) =
         twitch_1337_core::settings::SettingsStore::open(&data_dir, audit_log)
             .wrap_err("open settings store")?;

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -286,15 +286,6 @@
              data-default="{{ default_bytes }}"
              data-key="{{ key }}">
     </div>
-    <div class="bytes-aux" aria-live="polite">
-      <span class="mono" data-bytes-aux-bytes>{{ bytes }}</span> bytes
-      <span class="muted">· <span data-bytes-aux-pretty>{{ value }}</span></span>
-    </div>
-    <div class="bytes-presets" aria-label="Common caps">
-      <button type="button" class="bytes-preset" data-bytes="1024">1 KiB</button>
-      <button type="button" class="bytes-preset" data-bytes="65536">64 KiB</button>
-      <button type="button" class="bytes-preset" data-bytes="1048576">1 MiB</button>
-    </div>
   </div>
   <div class="row-right">
     {% call row_reset(key) %}{% endcall %}

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -232,19 +232,48 @@
 </label>
 {% endmacro %}
 
+{# Bytes row: one numeric input + B / KiB / MiB segmented unit picker.
+   Canonical stored value is bytes (hidden input is the form-posted field).
+   Unit governs display only. Server accepts `"6144"` via ByteSize::from_str. #}
 {% macro bytesize_row(section, field, key, hint, value, default) %}
-<div class="settings-row" data-section="{{ section }}">
+{% let bytes = value.as_u64() %}
+{% let default_bytes = default.as_u64() %}
+<div class="settings-row" data-section="{{ section }}" data-bytes-row>
   {% call row_head(key, hint) %}{% endcall %}
   <div class="row-control-cell">
-    <span class="row-pretty" aria-hidden="true">{{ value }}</span>
-    <input type="text"
-           class="text-input is-narrow"
-           name="{{ field }}"
-           value="{{ value }}"
-           data-default="{{ default }}"
-           data-key="{{ key }}"
-           pattern="^\d+(\.\d+)?\s?(B|KB|KiB|MB|MiB|GB|GiB)$"
-           title="e.g. 10 MiB">
+    <span class="row-pretty" aria-hidden="true" data-pretty-unit="bytes">{{ value }}</span>
+    <div class="bytes-wrap">
+      <div class="bytes-input-wrap">
+        <input
+          type="number"
+          class="num-input bytes-display"
+          min="0"
+          step="any"
+          value=""
+          data-unit=""
+          aria-label="{{ key }} amount">
+      </div>
+      <div class="segmented bytes-units" role="group" aria-label="{{ key }} unit">
+        <button type="button" class="segment bytes-unit" data-unit="B" aria-pressed="false"><span>B</span></button>
+        <button type="button" class="segment bytes-unit" data-unit="KiB" aria-pressed="false"><span>KiB</span></button>
+        <button type="button" class="segment bytes-unit" data-unit="MiB" aria-pressed="false"><span>MiB</span></button>
+      </div>
+      <input type="hidden"
+             class="bytes-canonical"
+             name="{{ field }}"
+             value="{{ bytes }}"
+             data-default="{{ default_bytes }}"
+             data-key="{{ key }}">
+    </div>
+    <div class="bytes-aux" aria-live="polite">
+      <span class="mono" data-bytes-aux-bytes>{{ bytes }}</span> bytes
+      <span class="muted">· <span data-bytes-aux-pretty>{{ value }}</span></span>
+    </div>
+    <div class="bytes-presets" aria-label="Common caps">
+      <button type="button" class="bytes-preset" data-bytes="1024">1 KiB</button>
+      <button type="button" class="bytes-preset" data-bytes="65536">64 KiB</button>
+      <button type="button" class="bytes-preset" data-bytes="1048576">1 MiB</button>
+    </div>
   </div>
   <div class="row-right">
     {% call row_reset(key) %}{% endcall %}

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -253,9 +253,8 @@
 </label>
 {% endmacro %}
 
-{# Bytes row: one numeric input + B / KiB / MiB segmented unit picker.
-   Canonical stored value is bytes (hidden input is the form-posted field).
-   Unit governs display only. Server accepts `"6144"` via ByteSize::from_str. #}
+{# Server accepts raw byte counts via ByteSize::from_str, so the hidden
+   input posts the canonical integer; the unit selector is display-only. #}
 {% macro bytesize_row(section, field, key, hint, value, default) %}
 {% let bytes = value.as_u64() %}
 {% let default_bytes = default.as_u64() %}
@@ -270,7 +269,6 @@
         min="0"
         step="any"
         value=""
-        data-unit=""
         aria-label="{{ key }} amount">
       <div class="bytes-units" role="group" aria-label="{{ key }} unit">
         <button type="button" class="bytes-unit" data-unit="B" aria-pressed="false">B</button>

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -4,6 +4,27 @@
    then call e.g. {% call m::num_row(...) %}{% endcall %}.
 #}
 
+{% macro nav_group_head(group_id, label, count) %}
+<button type="button" class="settings-nav-group-head" data-group-toggle="{{ group_id }}" aria-expanded="true" aria-controls="nav-group-body-{{ group_id }}">
+  <span class="chev" aria-hidden="true">▸</span>
+  <span class="lbl">{{ label }}</span>
+  <span class="meta">
+    <span class="count" aria-label="{{ count }} sections">{{ count }}</span>
+    <span class="gdirty" hidden aria-label="Group has unsaved changes">0</span>
+  </span>
+</button>
+{% endmacro %}
+
+{% macro nav_section_item(slug, target, label) %}
+<li>
+  <a href="#sec-{{ slug }}" class="settings-nav-item" data-target="{{ target }}">
+    <span class="dot" aria-hidden="true"></span>
+    <span class="lbl">{{ label }}</span>
+    <span class="ndirty" hidden>0</span>
+  </a>
+</li>
+{% endmacro %}
+
 {% macro row_head(key, hint) %}
 <div class="row-left">
   <div class="row-label">

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -253,15 +253,16 @@
 </label>
 {% endmacro %}
 
-{# Server accepts raw byte counts via ByteSize::from_str, so the hidden
-   input posts the canonical integer; the unit selector is display-only. #}
-{% macro bytesize_row(section, field, key, hint, value, default) %}
-{% let bytes = value.as_u64() %}
-{% let default_bytes = default.as_u64() %}
+{# `bytes` and `default_bytes` are raw u64. The hidden input posts the
+   canonical integer — `ByteSize::from_str` (server side) accepts it, and
+   `Deserialize<Option<usize>>` does too — so this macro covers both
+   ByteSize-typed (ai.media) and usize-typed (ai.memory) fields. Pretty
+   text + default label are rendered from JS on init via formatBytesIec. #}
+{% macro bytesize_row(section, field, key, hint, bytes, default_bytes) %}
 <div class="settings-row" data-section="{{ section }}" data-bytes-row>
   {% call row_head(key, hint) %}{% endcall %}
   <div class="row-control-cell">
-    <span class="row-pretty" aria-hidden="true" data-pretty-unit="bytes">{{ value }}</span>
+    <span class="row-pretty" aria-hidden="true" data-pretty-unit="bytes">{{ bytes }}</span>
     <div class="bytes-wrap">
       <input
         type="number"
@@ -285,7 +286,7 @@
   </div>
   <div class="row-right">
     {% call row_reset(key) %}{% endcall %}
-    <span class="row-default">default <span class="mono">{{ default }}</span></span>
+    <span class="row-default">default <span class="mono" data-bytes-default="{{ default_bytes }}">{{ default_bytes }}</span></span>
   </div>
 </div>
 {% endmacro %}

--- a/crates/web/templates/settings/_macros.html
+++ b/crates/web/templates/settings/_macros.html
@@ -264,20 +264,18 @@
   <div class="row-control-cell">
     <span class="row-pretty" aria-hidden="true" data-pretty-unit="bytes">{{ value }}</span>
     <div class="bytes-wrap">
-      <div class="bytes-input-wrap">
-        <input
-          type="number"
-          class="num-input bytes-display"
-          min="0"
-          step="any"
-          value=""
-          data-unit=""
-          aria-label="{{ key }} amount">
-      </div>
-      <div class="segmented bytes-units" role="group" aria-label="{{ key }} unit">
-        <button type="button" class="segment bytes-unit" data-unit="B" aria-pressed="false"><span>B</span></button>
-        <button type="button" class="segment bytes-unit" data-unit="KiB" aria-pressed="false"><span>KiB</span></button>
-        <button type="button" class="segment bytes-unit" data-unit="MiB" aria-pressed="false"><span>MiB</span></button>
+      <input
+        type="number"
+        class="num-input bytes-display"
+        min="0"
+        step="any"
+        value=""
+        data-unit=""
+        aria-label="{{ key }} amount">
+      <div class="bytes-units" role="group" aria-label="{{ key }} unit">
+        <button type="button" class="bytes-unit" data-unit="B" aria-pressed="false">B</button>
+        <button type="button" class="bytes-unit" data-unit="KiB" aria-pressed="false">KiB</button>
+        <button type="button" class="bytes-unit" data-unit="MiB" aria-pressed="false">MiB</button>
       </div>
       <input type="hidden"
              class="bytes-canonical"

--- a/crates/web/templates/settings/cards/ai_media.html
+++ b/crates/web/templates/settings/cards/ai_media.html
@@ -18,18 +18,18 @@
        current.ai.media.timeout, defaults.ai.media.timeout, "s", 5, 600) %}{% endcall %}
     {% call m::bytesize_row("ai_media", "ai_media_max_image_size", "max_image_size",
        "Maximum image size accepted.",
-       current.ai.media.max_image_size, defaults.ai.media.max_image_size) %}{% endcall %}
+       current.ai.media.max_image_size.as_u64(), defaults.ai.media.max_image_size.as_u64()) %}{% endcall %}
     {% call m::bytesize_row("ai_media", "ai_media_max_pdf_size", "max_pdf_size",
        "Maximum PDF size accepted.",
-       current.ai.media.max_pdf_size, defaults.ai.media.max_pdf_size) %}{% endcall %}
+       current.ai.media.max_pdf_size.as_u64(), defaults.ai.media.max_pdf_size.as_u64()) %}{% endcall %}
     {% call m::bytesize_row("ai_media", "ai_media_max_audio_size", "max_audio_size",
        "Maximum audio size accepted.",
-       current.ai.media.max_audio_size, defaults.ai.media.max_audio_size) %}{% endcall %}
+       current.ai.media.max_audio_size.as_u64(), defaults.ai.media.max_audio_size.as_u64()) %}{% endcall %}
     {% call m::bytesize_row("ai_media", "ai_media_max_video_size", "max_video_size",
        "Maximum video size accepted.",
-       current.ai.media.max_video_size, defaults.ai.media.max_video_size) %}{% endcall %}
+       current.ai.media.max_video_size.as_u64(), defaults.ai.media.max_video_size.as_u64()) %}{% endcall %}
     {% call m::bytesize_row("ai_media", "ai_media_max_text_size", "max_text_size",
        "Maximum raw-text size accepted (per attachment).",
-       current.ai.media.max_text_size, defaults.ai.media.max_text_size) %}{% endcall %}
+       current.ai.media.max_text_size.as_u64(), defaults.ai.media.max_text_size.as_u64()) %}{% endcall %}
   </div>
 </section>

--- a/crates/web/templates/settings/cards/ai_memory.html
+++ b/crates/web/templates/settings/cards/ai_memory.html
@@ -10,21 +10,21 @@
     <div class="settings-card-tag"><span class="card-dirty" hidden>0 modified</span></div>
   </header>
   <div class="settings-rows">
-    {% call m::num_row_bounded("ai_memory", "ai_memory_soul_bytes", "soul_bytes",
+    {% call m::bytesize_row("ai_memory", "ai_memory_soul_bytes", "soul_bytes",
        "Hard cap on SOUL.md size.",
-       current.ai.memory.soul_bytes, defaults.ai.memory.soul_bytes, "B", 256, 65536) %}{% endcall %}
-    {% call m::num_row_bounded("ai_memory", "ai_memory_lore_bytes", "lore_bytes",
+       current.ai.memory.soul_bytes, defaults.ai.memory.soul_bytes) %}{% endcall %}
+    {% call m::bytesize_row("ai_memory", "ai_memory_lore_bytes", "lore_bytes",
        "Hard cap on LORE.md size.",
-       current.ai.memory.lore_bytes, defaults.ai.memory.lore_bytes, "B", 256, 131072) %}{% endcall %}
-    {% call m::num_row_bounded("ai_memory", "ai_memory_user_bytes", "user_bytes",
+       current.ai.memory.lore_bytes, defaults.ai.memory.lore_bytes) %}{% endcall %}
+    {% call m::bytesize_row("ai_memory", "ai_memory_user_bytes", "user_bytes",
        "Hard cap on each per-user character sheet.",
-       current.ai.memory.user_bytes, defaults.ai.memory.user_bytes, "B", 256, 65536) %}{% endcall %}
-    {% call m::num_row_bounded("ai_memory", "ai_memory_state_bytes", "state_bytes",
+       current.ai.memory.user_bytes, defaults.ai.memory.user_bytes) %}{% endcall %}
+    {% call m::bytesize_row("ai_memory", "ai_memory_state_bytes", "state_bytes",
        "Hard cap on each per-state file.",
-       current.ai.memory.state_bytes, defaults.ai.memory.state_bytes, "B", 128, 32768) %}{% endcall %}
-    {% call m::num_row_bounded("ai_memory", "ai_memory_inject_byte_budget", "inject_byte_budget",
+       current.ai.memory.state_bytes, defaults.ai.memory.state_bytes) %}{% endcall %}
+    {% call m::bytesize_row("ai_memory", "ai_memory_inject_byte_budget", "inject_byte_budget",
        "Total memory bytes injected into a single !ai prompt.",
-       current.ai.memory.inject_byte_budget, defaults.ai.memory.inject_byte_budget, "B", 1024, 262144) %}{% endcall %}
+       current.ai.memory.inject_byte_budget, defaults.ai.memory.inject_byte_budget) %}{% endcall %}
     {% call m::num_row_bounded("ai_memory", "ai_memory_max_state_files", "max_state_files",
        "Max per-state files kept on disk.",
        current.ai.memory.max_state_files, defaults.ai.memory.max_state_files, "", 1, 256) %}{% endcall %}

--- a/crates/web/templates/settings/index.html
+++ b/crates/web/templates/settings/index.html
@@ -1,5 +1,6 @@
 {# crates/web/templates/settings/index.html #}
 {% extends "base.html" %}
+{% import "settings/_macros.html" as m %}
 {% block title %}Settings — twitch-1337{% endblock %}
 
 {% block content %}
@@ -25,70 +26,41 @@
 
 <div class="settings-grid">
   <aside class="settings-nav" aria-label="Settings sections">
-    <div class="settings-nav-label">Sections</div>
-    <a href="#sec-cooldowns" class="settings-nav-item" data-target="cooldowns">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Cooldowns</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-pings" class="settings-nav-item" data-target="pings">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Pings</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <div class="settings-nav-label settings-nav-group">AI</div>
-    <a href="#sec-ai-connection" class="settings-nav-item" data-target="ai_connection">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Connection</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-behavior" class="settings-nav-item" data-target="ai_behavior">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Behavior</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-history" class="settings-nav-item" data-target="ai_history">
-      <span class="dot" aria-hidden="true"></span>
-      <span>History</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-memory" class="settings-nav-item" data-target="ai_memory">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Memory</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-dreamer" class="settings-nav-item" data-target="ai_dreamer">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Dreamer</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-prefill" class="settings-nav-item" data-target="ai_prefill">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Prefill</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-web" class="settings-nav-item" data-target="ai_web">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Web tools</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-emotes" class="settings-nav-item" data-target="ai_emotes">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Emotes</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
-    <a href="#sec-ai-media" class="settings-nav-item" data-target="ai_media">
-      <span class="dot" aria-hidden="true"></span>
-      <span>Media</span>
-      <span class="ndirty" hidden>0</span>
-    </a>
+    <div class="settings-nav-group" data-group="chat">
+      {% call m::nav_group_head("chat", "Chat", 2) %}{% endcall %}
+      <div class="settings-nav-group-body" id="nav-group-body-chat">
+        <ul class="settings-nav-group-items">
+          {% call m::nav_section_item("cooldowns", "cooldowns", "Cooldowns") %}{% endcall %}
+          {% call m::nav_section_item("pings", "pings", "Pings") %}{% endcall %}
+        </ul>
+      </div>
+    </div>
+
+    <div class="settings-nav-group" data-group="ai">
+      {% call m::nav_group_head("ai", "AI", 9) %}{% endcall %}
+      <div class="settings-nav-group-body" id="nav-group-body-ai">
+        <ul class="settings-nav-group-items">
+          {% call m::nav_section_item("ai-connection", "ai_connection", "Connection") %}{% endcall %}
+          {% call m::nav_section_item("ai-behavior", "ai_behavior", "Behavior") %}{% endcall %}
+          {% call m::nav_section_item("ai-history", "ai_history", "History") %}{% endcall %}
+          {% call m::nav_section_item("ai-memory", "ai_memory", "Memory") %}{% endcall %}
+          {% call m::nav_section_item("ai-dreamer", "ai_dreamer", "Dreamer") %}{% endcall %}
+          {% call m::nav_section_item("ai-prefill", "ai_prefill", "Prefill") %}{% endcall %}
+          {% call m::nav_section_item("ai-web", "ai_web", "Web tools") %}{% endcall %}
+          {% call m::nav_section_item("ai-emotes", "ai_emotes", "Emotes") %}{% endcall %}
+          {% call m::nav_section_item("ai-media", "ai_media", "Media") %}{% endcall %}
+        </ul>
+      </div>
+    </div>
   </aside>
 
   <div class="settings-main">
     <form id="settings-form" method="post" action="/settings">
       <input type="hidden" name="_csrf" value="{{ csrf }}">
+      <div class="settings-group-divider" data-group="chat"><span>CHAT</span></div>
       {% include "settings/cards/cooldowns.html" %}
       {% include "settings/cards/pings.html" %}
+      <div class="settings-group-divider" data-group="ai"><span>AI</span></div>
       {% include "settings/cards/ai_connection.html" %}
       {% include "settings/cards/ai_behavior.html" %}
       {% include "settings/cards/ai_history.html" %}


### PR DESCRIPTION
## Summary
- **Bug fix.** `just dev-web` failed to compile because `web-dev` referenced `MemoryAuditLog`, which is gated behind `cfg(any(test, feature = \"testing\"))`. Swapped it for `FileAuditLog` writing to `\$DATA_DIR/settings_audit.log` (matches `crates/twitch-1337/src/main.rs`).
- **Sidebar rework.** Flat \"Sections\" list → two collapsible groups (**Chat** = Cooldowns, Pings · **AI** = Connection / Behavior / History / Memory / Dreamer / Prefill / Web tools / Emotes / Media). Group headers carry chevron + section count + rolled-up dirty badge; children indent under a hairline that tints accent-soft when the active section sits inside; the active row picks up a 2px accent bar + glowing dot. Matching CHAT / AI dividers above the main column. Collapse state persists per-group in localStorage. (Runtime group deferred — no Twitch/Aviation settings exist in `Settings` yet.)
- **Bytes input.** Replaced the freeform \"10 MiB\" text field with a numeric input + inline B / KiB / MiB segment picker sharing one rounded container. Canonical value is bytes (hidden input → POST), the unit is display-only. Unit switch re-renders the same canonical value, Enter commits, Escape reverts. Macro generalised to raw `u64`, so it serves both `ByteSize`-typed `ai.media` and `usize`-typed `ai.memory` fields — AI · Memory size caps now use it too. Pretty + default labels formatted client-side via `formatBytesIec`.

## Test plan
- [ ] \`cargo fmt --all\` clean
- [ ] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] \`cargo nextest run --workspace\` — 545/545 green locally
- [ ] \`just dev-web\` boots, \`/_dev/login\` mints a session
- [ ] \`/settings\` renders the two-group sidebar; collapsing/expanding persists across reload
- [ ] Editing a bytes row, switching units, hitting Escape/Enter, and clicking reset all behave correctly
- [ ] Saving an AI · Memory or AI · Media bytes change round-trips through the server (\`settings.ron\` updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)